### PR TITLE
gh-xxx: remove the playground from docker compose

### DIFF
--- a/docker-compose/runtime/docker-compose.yml
+++ b/docker-compose/runtime/docker-compose.yml
@@ -1,11 +1,5 @@
 version: '3.4'
 services:
-  weaviate-playground:
-    image: semitechnologies/weaviate-playground:latest
-    depends_on:
-      - weaviate
-    ports:
-     - "80:80"
   weaviate:
     image: semitechnologies/weaviate:0.20.0
     command: 


### PR DESCRIPTION
In the new docs, we refer to the playground on the website or as a separate container. People seem to use the compose file to create semi-production solutions. This seems cleaner to me.