### PR TITLE
gh-1035 don't cache refs considered a supernode

### DIFF
--- a/adapters/handlers/rest/configure_api.go
+++ b/adapters/handlers/rest/configure_api.go
@@ -94,7 +94,7 @@ func configureAPI(api *operations.WeaviateAPI) http.Handler {
 	var explorer explorer
 
 	repo := esvector.NewRepo(esClient, appState.Logger, nil,
-		appState.ServerConfig.Config.VectorIndex.DenormalizationDepth)
+		appState.ServerConfig.Config.VectorIndex.DenormalizationDepth, appState.ServerConfig.Config.VectorIndex.SupernodeThreshold)
 	vectorMigrator = esvector.NewMigrator(repo)
 	vectorRepo = repo
 	migrator = vectorMigrator

--- a/adapters/repos/esvector/add_reference_integration_test.go
+++ b/adapters/repos/esvector/add_reference_integration_test.go
@@ -71,7 +71,7 @@ func Test_AddingReferenceOneByOne(t *testing.T) {
 	}
 	schemaGetter := &fakeSchemaGetter{schema: schema}
 	logger := logrus.New()
-	repo := NewRepo(client, logger, schemaGetter, 2)
+	repo := NewRepo(client, logger, schemaGetter, 2, 100)
 	waitForEsToBeReady(t, repo)
 	migrator := NewMigrator(repo)
 

--- a/adapters/repos/esvector/aggregations_integration_test.go
+++ b/adapters/repos/esvector/aggregations_integration_test.go
@@ -48,7 +48,7 @@ func Test_Aggregations(t *testing.T) {
 			},
 		},
 	}
-	repo := NewRepo(client, logger, schemaGetter, 3)
+	repo := NewRepo(client, logger, schemaGetter, 3, 100)
 	waitForEsToBeReady(t, repo)
 	migrator := NewMigrator(repo)
 

--- a/adapters/repos/esvector/batch_add_reference_integration_test.go
+++ b/adapters/repos/esvector/batch_add_reference_integration_test.go
@@ -74,7 +74,7 @@ func Test_AddingReferencesInBatches(t *testing.T) {
 	}
 	schemaGetter := &fakeSchemaGetter{schema: schema}
 	logger := logrus.New()
-	repo := NewRepo(client, logger, schemaGetter, 2)
+	repo := NewRepo(client, logger, schemaGetter, 2, 100)
 	waitForEsToBeReady(t, repo)
 	migrator := NewMigrator(repo)
 

--- a/adapters/repos/esvector/batch_integration_test.go
+++ b/adapters/repos/esvector/batch_integration_test.go
@@ -40,7 +40,7 @@ func TestEsVectorRepoBatch(t *testing.T) {
 
 	logger, _ := test.NewNullLogger()
 	schemaGetter := &fakeSchemaGetter{}
-	repo := NewRepo(client, logger, schemaGetter, 3)
+	repo := NewRepo(client, logger, schemaGetter, 3, 100)
 	waitForEsToBeReady(t, repo)
 	migrator := NewMigrator(repo)
 

--- a/adapters/repos/esvector/cache.go
+++ b/adapters/repos/esvector/cache.go
@@ -93,6 +93,11 @@ func (c *cacheManager) populate(ctx context.Context, kind kind.Kind, id strfmt.U
 				continue
 			}
 
+			if len(refs) > c.repo.superNodeThreshold {
+				resolvedSchema[prop] = value
+				continue
+			}
+
 			resolvedRefs, err := c.resolveRefs(ctx, refs, depth+1)
 			if err != nil {
 				return nil, err

--- a/adapters/repos/esvector/cache_integration_test.go
+++ b/adapters/repos/esvector/cache_integration_test.go
@@ -109,7 +109,7 @@ func testEsVectorCache(t *testing.T) {
 	require.Nil(t, err)
 	logger := logrus.New()
 	schemaGetter := &fakeSchemaGetter{schema: refSchema}
-	repo := NewRepo(client, logger, schemaGetter, 2)
+	repo := NewRepo(client, logger, schemaGetter, 2, 100)
 	waitForEsToBeReady(t, repo)
 	requestCounter := &testCounter{}
 	repo.requestCounter = requestCounter

--- a/adapters/repos/esvector/filters_integration_test.go
+++ b/adapters/repos/esvector/filters_integration_test.go
@@ -60,7 +60,7 @@ func Test_Filters(t *testing.T) {
 
 	logger := logrus.New()
 	schemaGetter := &fakeSchemaGetter{}
-	repo := NewRepo(client, logger, schemaGetter, 3)
+	repo := NewRepo(client, logger, schemaGetter, 3, 100)
 	waitForEsToBeReady(t, repo)
 	migrator := NewMigrator(repo)
 

--- a/adapters/repos/esvector/merge_integration_test.go
+++ b/adapters/repos/esvector/merge_integration_test.go
@@ -94,7 +94,7 @@ func Test_MergingObjects(t *testing.T) {
 	}
 	schemaGetter := &fakeSchemaGetter{schema: schema}
 	logger := logrus.New()
-	repo := NewRepo(client, logger, schemaGetter, 2)
+	repo := NewRepo(client, logger, schemaGetter, 2, 100)
 	waitForEsToBeReady(t, repo)
 	migrator := NewMigrator(repo)
 

--- a/adapters/repos/esvector/migrator_integration_test.go
+++ b/adapters/repos/esvector/migrator_integration_test.go
@@ -83,7 +83,7 @@ func TestEsVectorMigrator(t *testing.T) {
 	require.Nil(t, err)
 	logger, _ := test.NewNullLogger()
 	schemaGetter := &fakeSchemaGetter{schema: refSchema}
-	repo := NewRepo(client, logger, schemaGetter, 3)
+	repo := NewRepo(client, logger, schemaGetter, 3, 100)
 	waitForEsToBeReady(t, repo)
 	migrator := NewMigrator(repo)
 
@@ -277,7 +277,7 @@ func TestEsVectorMigrator_ImportingConcepts(t *testing.T) {
 	require.Nil(t, err)
 	logger, _ := test.NewNullLogger()
 	schemaGetter := &fakeSchemaGetter{}
-	repo := NewRepo(client, logger, schemaGetter, 3)
+	repo := NewRepo(client, logger, schemaGetter, 3, 100)
 	waitForEsToBeReady(t, repo)
 	migrator := NewMigrator(repo)
 

--- a/adapters/repos/esvector/orchestrate_caching_integration_test.go
+++ b/adapters/repos/esvector/orchestrate_caching_integration_test.go
@@ -41,7 +41,7 @@ func Test_OrchestrateCaching(t *testing.T) {
 	require.Nil(t, err)
 	schemaGetter := &fakeSchemaGetter{schema: parkingGaragesSchema()}
 	logger := logrus.New()
-	repo := NewRepo(client, logger, schemaGetter, 2)
+	repo := NewRepo(client, logger, schemaGetter, 2, 100)
 	waitForEsToBeReady(t, repo)
 	requestCounter := &testCounter{}
 	repo.requestCounter = requestCounter

--- a/adapters/repos/esvector/parse_schema.go
+++ b/adapters/repos/esvector/parse_schema.go
@@ -171,7 +171,7 @@ func parseGeoProp(lat interface{}, lon interface{}) (*models.GeoCoordinates, err
 func (r *Repo) parseRefs(input []interface{}, prop string, cache cache, depth int,
 	selectProp traverser.SelectProperty) ([]interface{}, error) {
 
-	if cache.hot {
+	if cache.hot && len(input) <= r.superNodeThreshold {
 		// start with depth=1, parseRefs was called on the outermost class
 		// (depth=0), so the first ref is depth=1
 		refs, err := r.parseCacheSchemaToRefs(cache.schema, prop, 1, selectProp)

--- a/adapters/repos/esvector/repo.go
+++ b/adapters/repos/esvector/repo.go
@@ -67,6 +67,7 @@ type Repo struct {
 	logger                    logrus.FieldLogger
 	schemaGetter              schemaUC.SchemaGetter
 	denormalizationDepthLimit int
+	superNodeThreshold        int
 	requestCounter            counter
 	cacheIndexer              *cacheIndexer
 	schemaRefFinder           schemaRefFinder
@@ -92,12 +93,13 @@ func (c *noopCounter) Inc() {}
 
 // NewRepo from existing es client
 func NewRepo(client *elasticsearch.Client, logger logrus.FieldLogger,
-	schemaGetter schemaUC.SchemaGetter, denormalizationLimit int) *Repo {
+	schemaGetter schemaUC.SchemaGetter, denormalizationLimit int, superNodeThreshold int) *Repo {
 	return &Repo{
 		client:                    client,
 		logger:                    logger,
 		schemaGetter:              schemaGetter,
 		denormalizationDepthLimit: denormalizationLimit,
+		superNodeThreshold:        superNodeThreshold,
 		requestCounter:            &noopCounter{},
 		cacheIndexer:              nil,
 		schemaRefFinder:           &noopSchemaRefFinder{},

--- a/adapters/repos/esvector/repo_integration_test.go
+++ b/adapters/repos/esvector/repo_integration_test.go
@@ -42,7 +42,7 @@ func TestEsVectorRepo(t *testing.T) {
 
 	logger, _ := test.NewNullLogger()
 	schemaGetter := &fakeSchemaGetter{}
-	repo := NewRepo(client, logger, schemaGetter, 3)
+	repo := NewRepo(client, logger, schemaGetter, 3, 100)
 	waitForEsToBeReady(t, repo)
 	migrator := NewMigrator(repo)
 

--- a/usecases/config/config_handler.go
+++ b/usecases/config/config_handler.go
@@ -70,6 +70,7 @@ type VectorIndex struct {
 	Enabled                bool   `json:"enabled" yaml:"enabled"`
 	URL                    string `json:"url" yaml:"url"`
 	DenormalizationDepth   int    `json:"denormalizationDepth" yaml:"denormalizationDepth"`
+	SupernodeThreshold     int    `json:"supernodeThreshold" yaml:"supernodeThreshold"`
 	CacheCycleIdleWaitTime int    `json:"cacheCycleIdleWaitTime" yaml:"cacheCycleIdleWaitTime"`
 	CacheCycleBusyWaitTime int    `json:"cacheCycleBusyWaitTime" yaml:"cacheCycleBusyWaitTime"`
 	CacheCycleBulkSize     int    `json:"cacheCycleBulkSize" yaml:"cacheCycleBulkSize"`
@@ -78,6 +79,10 @@ type VectorIndex struct {
 func (v *VectorIndex) SetDefaults() {
 	if v.DenormalizationDepth == 0 {
 		v.DenormalizationDepth = 2
+	}
+
+	if v.SupernodeThreshold == 0 {
+		v.SupernodeThreshold = 100
 	}
 
 	if v.CacheCycleIdleWaitTime == 0 {


### PR DESCRIPTION
*waiting to merge this for more feedback from @fefi42's test cluster*

This is done merely by the amount of outgoing refs at the moment

closes #1035