### PR TITLE
gh-1078 support numbers in c11y endpoint

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -37,7 +37,7 @@ require (
 	github.com/ugorji/go/codec v0.0.0-20190309163734-c4a1c341dc93
 	go.mongodb.org/mongo-driver v1.3.0 // indirect
 	golang.org/x/net v0.0.0-20191002035440-2ec189313ef0
-	golang.org/x/tools v0.0.0-20200228135638-5c7c66ced534 // indirect
+	golang.org/x/tools v0.0.0-20200301222351-066e0c02454c // indirect
 	google.golang.org/grpc v1.24.0
 	gopkg.in/yaml.v2 v2.2.8
 	sigs.k8s.io/yaml v1.1.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -470,6 +470,8 @@ golang.org/x/tools v0.0.0-20200227222343-706bc42d1f0d h1:7M9AXzLrJWWGdDYtBblPHBT
 golang.org/x/tools v0.0.0-20200227222343-706bc42d1f0d/go.mod h1:TB2adYChydJhpapKDTa4BR/hXlZSLoq2Wpct/0txZ28=
 golang.org/x/tools v0.0.0-20200228135638-5c7c66ced534 h1:XVzrScQUlfS6ssloilmEJdJhlMDtnculCx+0zmVHSA8=
 golang.org/x/tools v0.0.0-20200228135638-5c7c66ced534/go.mod h1:TB2adYChydJhpapKDTa4BR/hXlZSLoq2Wpct/0txZ28=
+golang.org/x/tools v0.0.0-20200301222351-066e0c02454c h1:FD7jysxM+EJqg5UYYy3XYDsAiUickFsn4UiaanJkf8c=
+golang.org/x/tools v0.0.0-20200301222351-066e0c02454c/go.mod h1:TB2adYChydJhpapKDTa4BR/hXlZSLoq2Wpct/0txZ28=
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898 h1:/atklqdjdhuosWIl6AIbOeHJjicWYPqR9bpxqxYG2pA=
 golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=

--- a/usecases/vectorizer/fakes_for_test.go
+++ b/usecases/vectorizer/fakes_for_test.go
@@ -1,3 +1,16 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2019 SeMI Holding B.V. (registered @ Dutch Chamber of Commerce no 75221632). All rights reserved.
+//  LICENSE WEAVIATE OPEN SOURCE: https://www.semi.technology/playbook/playbook/contract-weaviate-OSS.html
+//  LICENSE WEAVIATE ENTERPRISE: https://www.semi.technology/playbook/contract-weaviate-enterprise.html
+//  CONCEPT: Bob van Luijt (@bobvanluijt)
+//  CONTACT: hello@semi.technology
+//
+
 package vectorizer
 
 import "context"

--- a/usecases/vectorizer/fakes_for_test.go
+++ b/usecases/vectorizer/fakes_for_test.go
@@ -1,0 +1,26 @@
+package vectorizer
+
+import "context"
+
+type fakeClient struct {
+	lastInput []string
+}
+
+func (c *fakeClient) VectorForCorpi(ctx context.Context, corpi []string, overrides map[string]string) ([]float32, error) {
+	c.lastInput = corpi
+	return []float32{0, 1, 2, 3}, nil
+}
+
+func (c *fakeClient) VectorForWord(ctx context.Context, word string) ([]float32, error) {
+	c.lastInput = []string{word}
+	return []float32{3, 2, 1, 0}, nil
+
+}
+func (c *fakeClient) NearestWordsByVector(ctx context.Context,
+	vector []float32, n int, k int) ([]string, []float32, error) {
+	return []string{"word1", "word2"}, []float32{0.1, 0.2}, nil
+}
+
+func (c *fakeClient) IsWordPresent(ctx context.Context, word string) (bool, error) {
+	return true, nil
+}

--- a/usecases/vectorizer/inspector.go
+++ b/usecases/vectorizer/inspector.go
@@ -16,7 +16,6 @@ package vectorizer
 import (
 	"context"
 	"fmt"
-	"regexp"
 	"strings"
 	"unicode"
 	"unicode/utf8"
@@ -64,12 +63,14 @@ func (i *Inspector) GetWords(ctx context.Context, words string) (*models.C11yWor
 
 func (i *Inspector) validateAndSplit(words string) ([]string, error) {
 	// set first character to lowercase
-	firstChar := []rune(words)
-	firstChar[0] = unicode.ToLower(firstChar[0])
-	words = string(firstChar)
+	wordChars := []rune(words)
+	wordChars[0] = unicode.ToLower(wordChars[0])
+	words = string(wordChars)
 
-	if ok, _ := regexp.MatchString("^[a-zA-Z]+$", words); !ok {
-		return nil, fmt.Errorf("invalid word input: words must match ^[a-zA-Z]+$")
+	for _, r := range words {
+		if !unicode.IsLetter(r) && !unicode.IsNumber(r) {
+			return nil, fmt.Errorf("invalid word input: words must only contain unicode letters and digits")
+		}
 	}
 
 	return split(words), nil
@@ -218,7 +219,7 @@ func split(src string) (entries []string) {
 		case unicode.IsUpper(r):
 			class = 2
 		case unicode.IsDigit(r):
-			class = 3
+			class = 1
 		default:
 			class = 4
 		}

--- a/usecases/vectorizer/inspector_test.go
+++ b/usecases/vectorizer/inspector_test.go
@@ -1,0 +1,179 @@
+package vectorizer
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/semi-technologies/weaviate/entities/models"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestInspector(t *testing.T) {
+
+	type test struct {
+		name           string
+		input          string
+		expectedErr    error
+		expectedOutput *models.C11yWordsResponse
+	}
+
+	tests := []test{
+		test{
+			name:        "invalid input",
+			input:       "i don't like pizza",
+			expectedErr: fmt.Errorf("invalid word input: words must only contain unicode letters and digits"),
+		},
+		test{
+			name:  "single valid word",
+			input: "pizza",
+			expectedOutput: &models.C11yWordsResponse{
+				IndividualWords: []*models.C11yWordsResponseIndividualWordsItems0{
+					&models.C11yWordsResponseIndividualWordsItems0{
+						InC11y: true,
+						Word:   "pizza",
+						Info: &models.C11yWordsResponseIndividualWordsItems0Info{
+							Vector: []float32{3, 2, 1, 0},
+							NearestNeighbors: []*models.C11yNearestNeighborsItems0{
+								&models.C11yNearestNeighborsItems0{
+									Distance: 0.1,
+									Word:     "word1",
+								},
+								&models.C11yNearestNeighborsItems0{
+									Distance: 0.2,
+									Word:     "word2",
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		test{
+			name:  "single valid word containing numbers",
+			input: "pi55a",
+			expectedOutput: &models.C11yWordsResponse{
+				IndividualWords: []*models.C11yWordsResponseIndividualWordsItems0{
+					&models.C11yWordsResponseIndividualWordsItems0{
+						InC11y: true,
+						Word:   "pi55a",
+						Info: &models.C11yWordsResponseIndividualWordsItems0Info{
+							Vector: []float32{3, 2, 1, 0},
+							NearestNeighbors: []*models.C11yNearestNeighborsItems0{
+								&models.C11yNearestNeighborsItems0{
+									Distance: 0.1,
+									Word:     "word1",
+								},
+								&models.C11yNearestNeighborsItems0{
+									Distance: 0.2,
+									Word:     "word2",
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		test{
+			name:  "concatenated words",
+			input: "pizzaBakerMakerShaker",
+			expectedOutput: &models.C11yWordsResponse{
+				ConcatenatedWord: &models.C11yWordsResponseConcatenatedWord{
+					ConcatenatedWord:   "pizzaBakerMakerShaker",
+					SingleWords:        []string{"pizza", "baker", "maker", "shaker"},
+					ConcatenatedVector: []float32{0, 1, 2, 3},
+					ConcatenatedNearestNeighbors: []*models.C11yNearestNeighborsItems0{
+						&models.C11yNearestNeighborsItems0{
+							Distance: 0.1,
+							Word:     "word1",
+						},
+						&models.C11yNearestNeighborsItems0{
+							Distance: 0.2,
+							Word:     "word2",
+						},
+					},
+				},
+				IndividualWords: []*models.C11yWordsResponseIndividualWordsItems0{
+					&models.C11yWordsResponseIndividualWordsItems0{
+						InC11y: true,
+						Word:   "pizza",
+						Info: &models.C11yWordsResponseIndividualWordsItems0Info{
+							Vector: []float32{3, 2, 1, 0},
+							NearestNeighbors: []*models.C11yNearestNeighborsItems0{
+								&models.C11yNearestNeighborsItems0{
+									Distance: 0.1,
+									Word:     "word1",
+								},
+								&models.C11yNearestNeighborsItems0{
+									Distance: 0.2,
+									Word:     "word2",
+								},
+							},
+						},
+					},
+					&models.C11yWordsResponseIndividualWordsItems0{
+						InC11y: true,
+						Word:   "baker",
+						Info: &models.C11yWordsResponseIndividualWordsItems0Info{
+							Vector: []float32{3, 2, 1, 0},
+							NearestNeighbors: []*models.C11yNearestNeighborsItems0{
+								&models.C11yNearestNeighborsItems0{
+									Distance: 0.1,
+									Word:     "word1",
+								},
+								&models.C11yNearestNeighborsItems0{
+									Distance: 0.2,
+									Word:     "word2",
+								},
+							},
+						},
+					},
+					&models.C11yWordsResponseIndividualWordsItems0{
+						InC11y: true,
+						Word:   "maker",
+						Info: &models.C11yWordsResponseIndividualWordsItems0Info{
+							Vector: []float32{3, 2, 1, 0},
+							NearestNeighbors: []*models.C11yNearestNeighborsItems0{
+								&models.C11yNearestNeighborsItems0{
+									Distance: 0.1,
+									Word:     "word1",
+								},
+								&models.C11yNearestNeighborsItems0{
+									Distance: 0.2,
+									Word:     "word2",
+								},
+							},
+						},
+					},
+					&models.C11yWordsResponseIndividualWordsItems0{
+						InC11y: true,
+						Word:   "shaker",
+						Info: &models.C11yWordsResponseIndividualWordsItems0Info{
+							Vector: []float32{3, 2, 1, 0},
+							NearestNeighbors: []*models.C11yNearestNeighborsItems0{
+								&models.C11yNearestNeighborsItems0{
+									Distance: 0.1,
+									Word:     "word1",
+								},
+								&models.C11yNearestNeighborsItems0{
+									Distance: 0.2,
+									Word:     "word2",
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	for _, test := range tests {
+		client := &fakeClient{}
+		i := NewInspector(client)
+		res, err := i.GetWords(context.Background(), test.input)
+		require.Equal(t, err, test.expectedErr)
+		assert.Equal(t, res, test.expectedOutput)
+	}
+
+}

--- a/usecases/vectorizer/inspector_test.go
+++ b/usecases/vectorizer/inspector_test.go
@@ -1,3 +1,16 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2019 SeMI Holding B.V. (registered @ Dutch Chamber of Commerce no 75221632). All rights reserved.
+//  LICENSE WEAVIATE OPEN SOURCE: https://www.semi.technology/playbook/playbook/contract-weaviate-OSS.html
+//  LICENSE WEAVIATE ENTERPRISE: https://www.semi.technology/playbook/contract-weaviate-enterprise.html
+//  CONCEPT: Bob van Luijt (@bobvanluijt)
+//  CONTACT: hello@semi.technology
+//
+
 package vectorizer
 
 import (

--- a/usecases/vectorizer/vectorizer_test.go
+++ b/usecases/vectorizer/vectorizer_test.go
@@ -303,12 +303,3 @@ func TestVectorizingSearchTerms(t *testing.T) {
 		})
 	}
 }
-
-type fakeClient struct {
-	lastInput []string
-}
-
-func (c *fakeClient) VectorForCorpi(ctx context.Context, corpi []string, overrides map[string]string) ([]float32, error) {
-	c.lastInput = corpi
-	return []float32{0, 1, 2, 3}, nil
-}


### PR DESCRIPTION
closes #1078

Prior to this we used a very simple regex to validate. Now instead we're
accepting any letter/digit utf-8 value.

There were also no tests on this feature, so I've added a few simple
test cases to cover the most common cases and make this a bit more
robust.