### PR TITLE
gh-1346 move c11y meta into modules property

### DIFF
--- a/adapters/handlers/rest/embedded_spec.go
+++ b/adapters/handlers/rest/embedded_spec.go
@@ -2058,19 +2058,14 @@ func init() {
       "description": "Contains meta information of the current Weaviate instance.",
       "type": "object",
       "properties": {
-        "contextionaryVersion": {
-          "description": "Version of the contextionary service connected to weaviate",
-          "type": "string"
-        },
-        "contextionaryWordCount": {
-          "description": "Number of total words in the contextionary",
-          "type": "number",
-          "format": "int"
-        },
         "hostname": {
           "description": "The url of the host.",
           "type": "string",
           "format": "url"
+        },
+        "modules": {
+          "description": "Module-specific meta information",
+          "type": "object"
         },
         "version": {
           "description": "Version of weaviate you are currently running",
@@ -4918,19 +4913,14 @@ func init() {
       "description": "Contains meta information of the current Weaviate instance.",
       "type": "object",
       "properties": {
-        "contextionaryVersion": {
-          "description": "Version of the contextionary service connected to weaviate",
-          "type": "string"
-        },
-        "contextionaryWordCount": {
-          "description": "Number of total words in the contextionary",
-          "type": "number",
-          "format": "int"
-        },
         "hostname": {
           "description": "The url of the host.",
           "type": "string",
           "format": "url"
+        },
+        "modules": {
+          "description": "Module-specific meta information",
+          "type": "object"
         },
         "version": {
           "description": "Version of weaviate you are currently running",

--- a/adapters/handlers/rest/handlers_misc.go
+++ b/adapters/handlers/rest/handlers_misc.go
@@ -62,10 +62,18 @@ func setupMiscHandlers(api *operations.WeaviateAPI, serverConfig *config.Weaviat
 		}
 
 		res := &models.Meta{
-			Hostname:               serverConfig.GetHostAddress(),
-			Version:                swj.Info.Version,
-			ContextionaryVersion:   c11yVersion,
-			ContextionaryWordCount: c11yWordCount,
+			Hostname: serverConfig.GetHostAddress(),
+			Version:  swj.Info.Version,
+
+			// TODO: When doing actual modularization, don't hard-code the module
+			// value, but ask each module for the meta info they want to provide
+			// dynamically
+			Modules: map[string]interface{}{
+				"text2vec-contextionary": map[string]interface{}{
+					"version":   c11yVersion,
+					"wordCount": c11yWordCount,
+				},
+			},
 		}
 
 		return meta.NewMetaGetOK().WithPayload(res)

--- a/entities/models/meta.go
+++ b/entities/models/meta.go
@@ -26,14 +26,11 @@ import (
 // swagger:model Meta
 type Meta struct {
 
-	// Version of the contextionary service connected to weaviate
-	ContextionaryVersion string `json:"contextionaryVersion,omitempty"`
-
-	// Number of total words in the contextionary
-	ContextionaryWordCount int64 `json:"contextionaryWordCount,omitempty"`
-
 	// The url of the host.
 	Hostname string `json:"hostname,omitempty"`
+
+	// Module-specific meta information
+	Modules interface{} `json:"modules,omitempty"`
 
 	// Version of weaviate you are currently running
 	Version string `json:"version,omitempty"`

--- a/openapi-specs/schema.json
+++ b/openapi-specs/schema.json
@@ -346,14 +346,9 @@
           "description": "Version of weaviate you are currently running",
           "type": "string"
         },
-        "contextionaryWordCount": {
-          "description": "Number of total words in the contextionary",
-          "type": "number",
-          "format": "int"
-        },
-        "contextionaryVersion": {
-          "description": "Version of the contextionary service connected to weaviate",
-          "type": "string"
+        "modules": {
+          "description": "Module-specific meta information",
+          "type": "object"
         }
       },
       "type": "object"


### PR DESCRIPTION
No actual modularization is happening at the moment, the c11y module is
hard-coded.

closes #1346