### PR TITLE
gh-1344 add per-property module config

### DIFF
--- a/adapters/handlers/rest/embedded_spec.go
+++ b/adapters/handlers/rest/embedded_spec.go
@@ -2232,18 +2232,18 @@ func init() {
           "description": "Description of the property.",
           "type": "string"
         },
-        "index": {
-          "description": "Optional. By default each property is fully indexed both for full-text, as well as vector-search. You can ignore properties in searches by explicitly setting index to false. Not set is the same as true",
+        "indexInverted": {
+          "description": "Optional. Should this property be indexed in the inverted index. Defaults to true. If you choose false, you will not be able to use this property in where filters. This property has no affect on vectorization decisions done by modules",
           "type": "boolean",
           "x-nullable": true
+        },
+        "moduleConfig": {
+          "description": "Configuratino specific to modules this Weaviate instance has installed",
+          "type": "object"
         },
         "name": {
           "description": "Name of the property as URI relative to the schema URL.",
           "type": "string"
-        },
-        "vectorizePropertyName": {
-          "description": "Set this to true if the object vector should include this property's name in calculating the overall vector position. If set to false (default), only the property value will be used.",
-          "type": "boolean"
         }
       }
     },
@@ -4962,18 +4962,18 @@ func init() {
           "description": "Description of the property.",
           "type": "string"
         },
-        "index": {
-          "description": "Optional. By default each property is fully indexed both for full-text, as well as vector-search. You can ignore properties in searches by explicitly setting index to false. Not set is the same as true",
+        "indexInverted": {
+          "description": "Optional. Should this property be indexed in the inverted index. Defaults to true. If you choose false, you will not be able to use this property in where filters. This property has no affect on vectorization decisions done by modules",
           "type": "boolean",
           "x-nullable": true
+        },
+        "moduleConfig": {
+          "description": "Configuratino specific to modules this Weaviate instance has installed",
+          "type": "object"
         },
         "name": {
           "description": "Name of the property as URI relative to the schema URL.",
           "type": "string"
-        },
-        "vectorizePropertyName": {
-          "description": "Set this to true if the object vector should include this property's name in calculating the overall vector position. If set to false (default), only the property value will be used.",
-          "type": "boolean"
         }
       }
     },

--- a/adapters/repos/db/crud_noindex_property_integration_test.go
+++ b/adapters/repos/db/crud_noindex_property_integration_test.go
@@ -48,9 +48,9 @@ func TestCRUD_NoIndexProp(t *testing.T) {
 			Name:     "stringProp",
 			DataType: []string{string(schema.DataTypeString)},
 		}, {
-			Name:     "hiddenStringProp",
-			DataType: []string{string(schema.DataTypeString)},
-			Index:    ptBool(false),
+			Name:          "hiddenStringProp",
+			DataType:      []string{string(schema.DataTypeString)},
+			IndexInverted: ptBool(false),
 		}},
 	}
 	schemaGetter := &fakeSchemaGetter{}

--- a/adapters/repos/db/inverted/objects.go
+++ b/adapters/repos/db/inverted/objects.go
@@ -52,7 +52,7 @@ func (a *Analyzer) analyzeProps(propsMap map[string]*models.Property,
 			return nil, fmt.Errorf("prop %q has no datatype", prop.Name)
 		}
 
-		if prop.Index != nil && !*prop.Index {
+		if prop.IndexInverted != nil && !*prop.IndexInverted {
 			continue
 		}
 

--- a/adapters/repos/db/migrator.go
+++ b/adapters/repos/db/migrator.go
@@ -42,7 +42,7 @@ func (m *Migrator) AddClass(ctx context.Context, kind kind.Kind, class *models.C
 	}
 
 	for _, prop := range class.Properties {
-		if prop.Index != nil && !*prop.Index {
+		if prop.IndexInverted != nil && !*prop.IndexInverted {
 			continue
 		}
 

--- a/entities/models/property.go
+++ b/entities/models/property.go
@@ -32,14 +32,14 @@ type Property struct {
 	// Description of the property.
 	Description string `json:"description,omitempty"`
 
-	// Optional. By default each property is fully indexed both for full-text, as well as vector-search. You can ignore properties in searches by explicitly setting index to false. Not set is the same as true
-	Index *bool `json:"index,omitempty"`
+	// Optional. Should this property be indexed in the inverted index. Defaults to true. If you choose false, you will not be able to use this property in where filters. This property has no affect on vectorization decisions done by modules
+	IndexInverted *bool `json:"indexInverted,omitempty"`
+
+	// Configuratino specific to modules this Weaviate instance has installed
+	ModuleConfig interface{} `json:"moduleConfig,omitempty"`
 
 	// Name of the property as URI relative to the schema URL.
 	Name string `json:"name,omitempty"`
-
-	// Set this to true if the object vector should include this property's name in calculating the overall vector position. If set to false (default), only the property value will be used.
-	VectorizePropertyName bool `json:"vectorizePropertyName,omitempty"`
 }
 
 // Validate validates this property

--- a/openapi-specs/schema.json
+++ b/openapi-specs/schema.json
@@ -530,16 +530,16 @@
           "description": "Description of the property.",
           "type": "string"
         },
-        "vectorizePropertyName": {
-          "description": "Set this to true if the object vector should include this property's name in calculating the overall vector position. If set to false (default), only the property value will be used.",
-          "type": "boolean"
+        "moduleConfig": {
+          "description": "Configuratino specific to modules this Weaviate instance has installed",
+          "type": "object"
         },
         "name": {
           "description": "Name of the property as URI relative to the schema URL.",
           "type": "string"
         },
-        "index": {
-          "description": "Optional. By default each property is fully indexed both for full-text, as well as vector-search. You can ignore properties in searches by explicitly setting index to false. Not set is the same as true",
+        "indexInverted": {
+          "description": "Optional. Should this property be indexed in the inverted index. Defaults to true. If you choose false, you will not be able to use this property in where filters. This property has no affect on vectorization decisions done by modules",
           "type": "boolean",
           "x-nullable": true
         }

--- a/test/acceptance/graphql_resolvers/setup_test.go
+++ b/test/acceptance/graphql_resolvers/setup_test.go
@@ -138,14 +138,22 @@ func addTestSchema(t *testing.T) {
 		},
 		Properties: []*models.Property{
 			&models.Property{
-				Name:                  "name",
-				DataType:              []string{"string"},
-				VectorizePropertyName: false,
+				Name:     "name",
+				DataType: []string{"string"},
+				ModuleConfig: map[string]interface{}{
+					"text2vec-contextionary": map[string]interface{}{
+						"vectorizePropertyName": false,
+					},
+				},
 			},
 			&models.Property{
-				Name:                  "inCity",
-				DataType:              []string{"City"},
-				VectorizePropertyName: false,
+				Name:     "inCity",
+				DataType: []string{"City"},
+				ModuleConfig: map[string]interface{}{
+					"text2vec-contextionary": map[string]interface{}{
+						"vectorizePropertyName": false,
+					},
+				},
 			},
 		},
 	})
@@ -159,14 +167,22 @@ func addTestSchema(t *testing.T) {
 		},
 		Properties: []*models.Property{
 			&models.Property{
-				Name:                  "name",
-				DataType:              []string{"string"},
-				VectorizePropertyName: false,
+				Name:     "name",
+				DataType: []string{"string"},
+				ModuleConfig: map[string]interface{}{
+					"text2vec-contextionary": map[string]interface{}{
+						"vectorizePropertyName": false,
+					},
+				},
 			},
 			&models.Property{
-				Name:                  "livesIn",
-				DataType:              []string{"City"},
-				VectorizePropertyName: false,
+				Name:     "livesIn",
+				DataType: []string{"City"},
+				ModuleConfig: map[string]interface{}{
+					"text2vec-contextionary": map[string]interface{}{
+						"vectorizePropertyName": false,
+					},
+				},
 			},
 		},
 	})

--- a/test/acceptance/graphql_resolvers/unindexed_property_test.go
+++ b/test/acceptance/graphql_resolvers/unindexed_property_test.go
@@ -47,9 +47,9 @@ func Test_UnindexedProperty(t *testing.T) {
 					DataType: []string{"string"},
 				},
 				&models.Property{
-					Name:     "hiddenName",
-					DataType: []string{"string"},
-					Index:    referenceToFalse(),
+					Name:          "hiddenName",
+					DataType:      []string{"string"},
+					IndexInverted: referenceToFalse(),
 				},
 			},
 		}

--- a/usecases/schema/add.go
+++ b/usecases/schema/add.go
@@ -85,7 +85,7 @@ func (m *Manager) validateCanAddClass(ctx context.Context, principal *models.Pri
 	foundNames := map[string]bool{}
 	for _, property := range class.Properties {
 		err = m.validatePropertyName(ctx, class.Class, property.Name,
-			property.VectorizePropertyName)
+			property.ModuleConfig)
 		if err != nil {
 			return err
 		}

--- a/usecases/schema/add_property.go
+++ b/usecases/schema/add_property.go
@@ -77,7 +77,7 @@ func (m *Manager) validateCanAddProperty(ctx context.Context, principal *models.
 	}
 
 	err = m.validatePropertyName(ctx, class.Class, property.Name,
-		property.VectorizePropertyName)
+		property.ModuleConfig)
 	if err != nil {
 		return err
 	}

--- a/usecases/schema/authorization_test.go
+++ b/usecases/schema/authorization_test.go
@@ -97,7 +97,7 @@ func Test_Schema_Authorization(t *testing.T) {
 		for _, method := range allExportedMethods(&Manager{}) {
 			switch method {
 			case "TriggerSchemaUpdateCallbacks", "RegisterSchemaUpdateCallback", "UpdateMeta", "GetSchemaSkipAuth",
-				"Indexed", "VectorizeClassName", "VectorizePropertyName":
+				"IndexedInverted", "IndexedContextionary", "VectorizeClassName", "VectorizePropertyName":
 				// don't require auth on methods which are exported because other
 				// packages need to call them for maintenance and other regular jobs,
 				// but aren't user facing

--- a/usecases/schema/get.go
+++ b/usecases/schema/get.go
@@ -37,7 +37,7 @@ func (m *Manager) GetSchemaSkipAuth() schema.Schema {
 	}
 }
 
-func (m *Manager) Indexed(className, propertyName string) bool {
+func (m *Manager) IndexedInverted(className, propertyName string) bool {
 	s := schema.Schema{
 		Objects: m.state.ObjectSchema,
 	}
@@ -48,11 +48,30 @@ func (m *Manager) Indexed(className, propertyName string) bool {
 
 	for _, prop := range class.Properties {
 		if prop.Name == propertyName {
-			if prop.Index == nil {
+			if prop.IndexInverted == nil {
 				return true
 			}
 
-			return *prop.Index
+			return *prop.IndexInverted
+		}
+	}
+
+	return false
+}
+
+// TODO: This is text2vec-contextionary specific logic and should be moved there
+func (m *Manager) IndexedContextionary(className, propertyName string) bool {
+	s := schema.Schema{
+		Objects: m.state.ObjectSchema,
+	}
+	class := s.FindClassByName(schema.ClassName(className))
+	if class == nil {
+		return false
+	}
+
+	for _, prop := range class.Properties {
+		if prop.Name == propertyName {
+			return m.indexPropertyInVectorIndex(prop.ModuleConfig)
 		}
 	}
 
@@ -84,7 +103,7 @@ func (m *Manager) VectorizePropertyName(className, propertyName string) bool {
 
 	for _, prop := range class.Properties {
 		if prop.Name == propertyName {
-			return prop.VectorizePropertyName
+			return m.vectorizePropertyName(prop.ModuleConfig)
 		}
 	}
 

--- a/usecases/schema/update_property.go
+++ b/usecases/schema/update_property.go
@@ -71,7 +71,7 @@ func (m *Manager) updateClassProperty(ctx context.Context, className string, nam
 
 	// Validate name / keywords in contextionary
 	err = m.validatePropertyName(ctx, className, propNameAfterUpdate,
-		prop.VectorizePropertyName)
+		prop.ModuleConfig)
 	if err != nil {
 		return err
 	}

--- a/usecases/schema/validation_test.go
+++ b/usecases/schema/validation_test.go
@@ -481,35 +481,13 @@ func Test_Validation_PropertyNames(t *testing.T) {
 						Vectorizer: "text2vec-contextionary",
 						Class:      "ValidName",
 						Properties: []*models.Property{{
-							DataType:              []string{"string"},
-							Name:                  test.input,
-							VectorizePropertyName: test.vectorize,
-						}},
-					}
-
-					m := newSchemaManager()
-					err := m.AddObject(context.Background(), nil, class)
-					t.Log(err)
-					assert.Equal(t, test.valid, err == nil)
-
-					// only proceed if input was supposed to be valid
-					if test.valid == false {
-						return
-					}
-
-					schema, _ := m.GetSchema(nil)
-					propName := schema.Objects.Classes[0].Properties[0].Name
-					assert.Equal(t, propName, test.storedAs, "class should be stored correctly")
-				})
-
-				t.Run(test.name+" as action class", func(t *testing.T) {
-					class := &models.Class{
-						Vectorizer: "text2vec-contextionary",
-						Class:      "ValidName",
-						Properties: []*models.Property{{
-							DataType:              []string{"string"},
-							Name:                  test.input,
-							VectorizePropertyName: test.vectorize,
+							DataType: []string{"string"},
+							Name:     test.input,
+							ModuleConfig: map[string]interface{}{
+								"text2vec-contextionary": map[string]interface{}{
+									"vectorizePropertyName": test.vectorize,
+								},
+							},
 						}},
 					}
 
@@ -537,35 +515,13 @@ func Test_Validation_PropertyNames(t *testing.T) {
 						Vectorizer: "text2vec-contextionary",
 						Class:      "ValidName",
 						Properties: []*models.Property{{
-							DataType:              []string{"string"},
-							Name:                  test.input,
-							VectorizePropertyName: test.vectorize,
-						}},
-					}
-
-					m := newSchemaManager()
-					err := m.AddObject(context.Background(), nil, class)
-					t.Log(err)
-					assert.Equal(t, test.valid, err == nil)
-
-					// only proceed if input was supposed to be valid
-					if test.valid == false {
-						return
-					}
-
-					schema, _ := m.GetSchema(nil)
-					propName := schema.Objects.Classes[0].Properties[0].Name
-					assert.Equal(t, propName, test.storedAs, "class should be stored correctly")
-				})
-
-				t.Run(test.name+" as action class", func(t *testing.T) {
-					class := &models.Class{
-						Vectorizer: "text2vec-contextionary",
-						Class:      "ValidName",
-						Properties: []*models.Property{{
-							DataType:              []string{"string"},
-							Name:                  test.input,
-							VectorizePropertyName: test.vectorize,
+							DataType: []string{"string"},
+							Name:     test.input,
+							ModuleConfig: map[string]interface{}{
+								"text2vec-contextionary": map[string]interface{}{
+									"vectorizePropertyName": test.vectorize,
+								},
+							},
 						}},
 					}
 
@@ -607,44 +563,13 @@ func Test_Validation_PropertyNames(t *testing.T) {
 					require.Nil(t, err)
 
 					property := &models.Property{
-						DataType:              []string{"string"},
-						Name:                  test.input,
-						VectorizePropertyName: test.vectorize,
-					}
-					err = m.AddObjectProperty(context.Background(), nil, "ValidName", property)
-					t.Log(err)
-					require.Equal(t, test.valid, err == nil)
-
-					// only proceed if input was supposed to be valid
-					if test.valid == false {
-						return
-					}
-
-					schema, _ := m.GetSchema(nil)
-					propName := schema.Objects.Classes[0].Properties[1].Name
-					assert.Equal(t, propName, test.storedAs, "class should be stored correctly")
-				})
-
-				t.Run(test.name+" as action class", func(t *testing.T) {
-					class := &models.Class{
-						Vectorizer: "text2vec-contextionary",
-						Class:      "ValidName",
-						Properties: []*models.Property{
-							&models.Property{
-								Name:     "dummyPropSoWeDontRunIntoAllNoindexedError",
-								DataType: []string{"string"},
+						DataType: []string{"string"},
+						Name:     test.input,
+						ModuleConfig: map[string]interface{}{
+							"text2vec-contextionary": map[string]interface{}{
+								"vectorizePropertyName": test.vectorize,
 							},
 						},
-					}
-
-					m := newSchemaManager()
-					err := m.AddObject(context.Background(), nil, class)
-					require.Nil(t, err)
-
-					property := &models.Property{
-						DataType:              []string{"string"},
-						Name:                  test.input,
-						VectorizePropertyName: test.vectorize,
 					}
 					err = m.AddObjectProperty(context.Background(), nil, "ValidName", property)
 					t.Log(err)
@@ -669,35 +594,13 @@ func Test_Validation_PropertyNames(t *testing.T) {
 						Vectorizer: "text2vec-contextionary",
 						Class:      "ValidName",
 						Properties: []*models.Property{{
-							DataType:              []string{"string"},
-							Name:                  test.input,
-							VectorizePropertyName: test.vectorize,
-						}},
-					}
-
-					m := newSchemaManager()
-					err := m.AddObject(context.Background(), nil, class)
-					t.Log(err)
-					assert.Equal(t, test.valid, err == nil)
-
-					// only proceed if input was supposed to be valid
-					if test.valid == false {
-						return
-					}
-
-					schema, _ := m.GetSchema(nil)
-					propName := schema.Objects.Classes[0].Properties[0].Name
-					assert.Equal(t, propName, test.storedAs, "class should be stored correctly")
-				})
-
-				t.Run(test.name+" as action class", func(t *testing.T) {
-					class := &models.Class{
-						Vectorizer: "text2vec-contextionary",
-						Class:      "ValidName",
-						Properties: []*models.Property{{
-							DataType:              []string{"string"},
-							Name:                  test.input,
-							VectorizePropertyName: test.vectorize,
+							DataType: []string{"string"},
+							Name:     test.input,
+							ModuleConfig: map[string]interface{}{
+								"text2vec-contextionary": map[string]interface{}{
+									"vectorizePropertyName": test.vectorize,
+								},
+							},
 						}},
 					}
 
@@ -730,44 +633,13 @@ func Test_Validation_PropertyNames(t *testing.T) {
 						Class:      "ValidName",
 						Properties: []*models.Property{
 							&models.Property{
-								DataType:              []string{"string"},
-								VectorizePropertyName: test.vectorize,
-								Name:                  originalName,
-							},
-						},
-					}
-
-					m := newSchemaManager()
-					err := m.AddObject(context.Background(), nil, class)
-					require.Nil(t, err)
-
-					updatedProperty := &models.Property{
-						DataType: []string{"string"},
-						Name:     test.input,
-					}
-					err = m.UpdateObjectProperty(context.Background(), nil, "ValidName", originalName, updatedProperty)
-					t.Log(err)
-					require.Equal(t, test.valid, err == nil)
-
-					// only proceed if input was supposed to be valid
-					if test.valid == false {
-						return
-					}
-
-					schema, _ := m.GetSchema(nil)
-					propName := schema.Objects.Classes[0].Properties[0].Name
-					assert.Equal(t, propName, test.storedAs, "class should be stored correctly")
-				})
-
-				t.Run(test.name+" as action class", func(t *testing.T) {
-					class := &models.Class{
-						Vectorizer: "text2vec-contextionary",
-						Class:      "ValidName",
-						Properties: []*models.Property{
-							&models.Property{
-								DataType:              []string{"string"},
-								Name:                  originalName,
-								VectorizePropertyName: test.vectorize,
+								DataType: []string{"string"},
+								ModuleConfig: map[string]interface{}{
+									"text2vec-contextionary": map[string]interface{}{
+										"vectorizePropertyName": test.vectorize,
+									},
+								},
+								Name: originalName,
 							},
 						},
 					}
@@ -803,35 +675,13 @@ func Test_Validation_PropertyNames(t *testing.T) {
 						Vectorizer: "text2vec-contextionary",
 						Class:      "ValidName",
 						Properties: []*models.Property{{
-							DataType:              []string{"string"},
-							Name:                  test.input,
-							VectorizePropertyName: test.vectorize,
-						}},
-					}
-
-					m := newSchemaManager()
-					err := m.AddObject(context.Background(), nil, class)
-					t.Log(err)
-					assert.Equal(t, test.valid, err == nil)
-
-					// only proceed if input was supposed to be valid
-					if test.valid == false {
-						return
-					}
-
-					schema, _ := m.GetSchema(nil)
-					propName := schema.Objects.Classes[0].Properties[0].Name
-					assert.Equal(t, propName, test.storedAs, "class should be stored correctly")
-				})
-
-				t.Run(test.name+" as action class", func(t *testing.T) {
-					class := &models.Class{
-						Vectorizer: "text2vec-contextionary",
-						Class:      "ValidName",
-						Properties: []*models.Property{{
-							DataType:              []string{"string"},
-							Name:                  test.input,
-							VectorizePropertyName: test.vectorize,
+							DataType: []string{"string"},
+							Name:     test.input,
+							ModuleConfig: map[string]interface{}{
+								"text2vec-contextionary": map[string]interface{}{
+									"vectorizePropertyName": test.vectorize,
+								},
+							},
 						}},
 					}
 
@@ -866,21 +716,34 @@ func Test_AllUsablePropsNoindexed(t *testing.T) {
 			},
 			Properties: []*models.Property{
 				{
-					DataType:              []string{"text"},
-					Name:                  "decsription",
-					Index:                 ptFalse(),
-					VectorizePropertyName: false,
+					DataType: []string{"text"},
+					Name:     "decsription",
+					ModuleConfig: map[string]interface{}{
+						"text2vec-contextionary": map[string]interface{}{
+							"vectorizeClassName": false,
+							"skip":               true,
+						},
+					},
 				},
 				{
-					DataType:              []string{"string"},
-					Name:                  "name",
-					Index:                 ptFalse(),
-					VectorizePropertyName: false,
+					DataType: []string{"string"},
+					Name:     "name",
+					ModuleConfig: map[string]interface{}{
+						"text2vec-contextionary": map[string]interface{}{
+							"vectorizeClassName": false,
+							"skip":               true,
+						},
+					},
 				},
 				{
-					DataType:              []string{"int"},
-					Name:                  "amount",
-					VectorizePropertyName: false,
+					DataType: []string{"int"},
+					Name:     "amount",
+					ModuleConfig: map[string]interface{}{
+						"text2vec-contextionary": map[string]interface{}{
+							"vectorizeClassName": false,
+							"skip":               true,
+						},
+					},
 				},
 			},
 		}
@@ -889,9 +752,4 @@ func Test_AllUsablePropsNoindexed(t *testing.T) {
 		err := m.AddObject(context.Background(), nil, class)
 		assert.NotNil(t, err)
 	})
-}
-
-func ptFalse() *bool {
-	f := false
-	return &f
 }

--- a/usecases/vectorizer/vectorizer.go
+++ b/usecases/vectorizer/vectorizer.go
@@ -11,6 +11,10 @@
 
 package vectorizer
 
+// TODO: This entire package should be part of the text2vec-contextionary
+// module, if methods/objects in here are used from non-modular code, they
+// probably shouldn't be in here
+
 import (
 	"context"
 	"fmt"
@@ -45,7 +49,7 @@ type client interface {
 
 // IndexCheck returns whether a property of a class should be indexed
 type IndexCheck interface {
-	Indexed(className, property string) bool
+	IndexedContextionary(className, property string) bool
 	VectorizeClassName(className string) bool
 	VectorizePropertyName(className, propertyName string) bool
 }
@@ -79,7 +83,7 @@ func (v *Vectorizer) object(ctx context.Context, className string,
 
 	if schema != nil {
 		for prop, value := range schema.(map[string]interface{}) {
-			if !v.indexCheck.Indexed(className, prop) {
+			if !v.indexCheck.IndexedContextionary(className, prop) {
 				continue
 			}
 

--- a/usecases/vectorizer/vectorizer_test.go
+++ b/usecases/vectorizer/vectorizer_test.go
@@ -166,7 +166,11 @@ type propertyIndexer struct {
 	excludedProperty string
 }
 
-func (p *propertyIndexer) Indexed(className, property string) bool {
+func (p *propertyIndexer) IndexedInverted(className, property string) bool {
+	panic("IndexedInverted should not matter to the vectorizer")
+}
+
+func (p *propertyIndexer) IndexedContextionary(className, property string) bool {
 	return property != p.noIndex
 }
 


### PR DESCRIPTION
- change `index` to `indexInverted`, make sure it only affects inverted
  index
- add `moduleConfig.text2vec-contextionary.skip` which defaults to `false`
- add `moduleConfig.text2vec-contextionary.vectorizeProptyName` which
  defaults to `false`
- closes #1344