### PR TITLE
Gh 1487 config in vector fn

### DIFF
--- a/entities/modulecapabilities/searcher.go
+++ b/entities/modulecapabilities/searcher.go
@@ -15,14 +15,20 @@ import (
 	"context"
 
 	"github.com/go-openapi/strfmt"
+	"github.com/semi-technologies/weaviate/entities/moduletools"
 )
 
 // FindVectorFn method for getting a vector of given object by it's ID
 type FindVectorFn = func(ctx context.Context, id strfmt.UUID) ([]float32, error)
 
 // VectorForParams defines method for passing a raw searcher content to the module
-// and exchanging it for a vector
-type VectorForParams = func(ctx context.Context, params interface{}, findVectorFn FindVectorFn) ([]float32, error)
+// and exchanging it for a vector. Warning: Argument "cfg"
+// (moduletools.ClassConfig) is not guaranteed to be non-nil. Implementations
+// have to provide a nil check before using it. It is generally present on
+// class-based action, but is not present on Cross-Class requests, such as
+// Explore {}
+type VectorForParams = func(ctx context.Context, params interface{}, findVectorFn FindVectorFn,
+	cfg moduletools.ClassConfig) ([]float32, error)
 
 // Searcher defines all methods for all searchers
 // for getting a vector from a given raw searcher content

--- a/modules/text2vec-contextionary/neartext/text2vec_searcher.go
+++ b/modules/text2vec-contextionary/neartext/text2vec_searcher.go
@@ -17,6 +17,7 @@ import (
 	"github.com/go-openapi/strfmt"
 	"github.com/pkg/errors"
 	"github.com/semi-technologies/weaviate/entities/modulecapabilities"
+	"github.com/semi-technologies/weaviate/entities/moduletools"
 	"github.com/semi-technologies/weaviate/entities/schema/crossref"
 	libvectorizer "github.com/semi-technologies/weaviate/usecases/vectorizer"
 )
@@ -42,7 +43,7 @@ func (s *Searcher) VectorSearches() map[string]modulecapabilities.VectorForParam
 }
 
 func (s *Searcher) vectorForNearTextParam(ctx context.Context, params interface{},
-	findVectorFn modulecapabilities.FindVectorFn) ([]float32, error) {
+	findVectorFn modulecapabilities.FindVectorFn, cfg moduletools.ClassConfig) ([]float32, error) {
 	return s.vectorFromNearTextParam(ctx,
 		params.(*NearTextParams),
 		findVectorFn,

--- a/modules/text2vec-transformers/module.go
+++ b/modules/text2vec-transformers/module.go
@@ -36,9 +36,10 @@ type TransformersModule struct {
 
 type textVectorizer interface {
 	Object(ctx context.Context, obj *models.Object,
-		icheck vectorizer.ClassSettings) error
+		settings vectorizer.ClassSettings) error
 
-	Texts(ctx context.Context, input []string) ([]float32, error)
+	Texts(ctx context.Context, input []string,
+		settings vectorizer.ClassSettings) ([]float32, error)
 	// TODO all of these should be moved out of here, gh-1470
 
 	MoveTo(source, target []float32, weight float32) ([]float32, error)

--- a/modules/text2vec-transformers/module.go
+++ b/modules/text2vec-transformers/module.go
@@ -86,7 +86,7 @@ func (m *TransformersModule) RootHandler() http.Handler {
 
 func (m *TransformersModule) VectorizeObject(ctx context.Context,
 	obj *models.Object, cfg moduletools.ClassConfig) error {
-	icheck := vectorizer.NewIndexChecker(cfg)
+	icheck := vectorizer.NewClassSettings(cfg)
 	return m.vectorizer.Object(ctx, obj, icheck)
 }
 

--- a/modules/text2vec-transformers/neartext/searcher.go
+++ b/modules/text2vec-transformers/neartext/searcher.go
@@ -17,7 +17,9 @@ import (
 	"github.com/go-openapi/strfmt"
 	"github.com/pkg/errors"
 	"github.com/semi-technologies/weaviate/entities/modulecapabilities"
+	"github.com/semi-technologies/weaviate/entities/moduletools"
 	"github.com/semi-technologies/weaviate/entities/schema/crossref"
+	localvectorizer "github.com/semi-technologies/weaviate/modules/text2vec-transformers/vectorizer"
 )
 
 type Searcher struct {
@@ -29,7 +31,8 @@ func NewSearcher(vectorizer vectorizer) *Searcher {
 }
 
 type vectorizer interface {
-	Texts(ctx context.Context, input []string) ([]float32, error)
+	Texts(ctx context.Context, input []string,
+		settings localvectorizer.ClassSettings) ([]float32, error)
 	MoveTo(source, target []float32, weight float32) ([]float32, error)
 	MoveAwayFrom(source, target []float32, weight float32) ([]float32, error)
 	CombineVectors(vectors [][]float32) []float32
@@ -42,16 +45,14 @@ func (s *Searcher) VectorSearches() map[string]modulecapabilities.VectorForParam
 }
 
 func (s *Searcher) vectorForNearTextParam(ctx context.Context, params interface{},
-	findVectorFn modulecapabilities.FindVectorFn) ([]float32, error) {
-	return s.vectorFromNearTextParam(ctx,
-		params.(*NearTextParams),
-		findVectorFn,
-	)
+	findVectorFn modulecapabilities.FindVectorFn,
+	cfg moduletools.ClassConfig) ([]float32, error) {
+	return s.vectorFromNearTextParam(ctx, params.(*NearTextParams), findVectorFn)
 }
 
 func (s *Searcher) vectorFromNearTextParam(ctx context.Context,
 	params *NearTextParams, findVectorFn modulecapabilities.FindVectorFn) ([]float32, error) {
-	vector, err := s.vectorizer.Texts(ctx, params.Values)
+	vector, err := s.vectorizer.Texts(ctx, params.Values, nil)
 	if err != nil {
 		return nil, errors.Errorf("vectorize keywords: %v", err)
 	}
@@ -93,7 +94,7 @@ func (s *Searcher) vectorFromValuesAndObjects(ctx context.Context,
 	var objectVectors [][]float32
 
 	if len(values) > 0 {
-		moveToVector, err := s.vectorizer.Texts(ctx, values)
+		moveToVector, err := s.vectorizer.Texts(ctx, values, nil)
 		if err != nil {
 			return nil, errors.Errorf("vectorize move to: %v", err)
 		}

--- a/modules/text2vec-transformers/neartext/searcher.go
+++ b/modules/text2vec-transformers/neartext/searcher.go
@@ -47,19 +47,22 @@ func (s *Searcher) VectorSearches() map[string]modulecapabilities.VectorForParam
 func (s *Searcher) vectorForNearTextParam(ctx context.Context, params interface{},
 	findVectorFn modulecapabilities.FindVectorFn,
 	cfg moduletools.ClassConfig) ([]float32, error) {
-	return s.vectorFromNearTextParam(ctx, params.(*NearTextParams), findVectorFn)
+	return s.vectorFromNearTextParam(ctx, params.(*NearTextParams), findVectorFn, cfg)
 }
 
 func (s *Searcher) vectorFromNearTextParam(ctx context.Context,
-	params *NearTextParams, findVectorFn modulecapabilities.FindVectorFn) ([]float32, error) {
-	vector, err := s.vectorizer.Texts(ctx, params.Values, nil)
+	params *NearTextParams, findVectorFn modulecapabilities.FindVectorFn,
+	cfg moduletools.ClassConfig) ([]float32, error) {
+	settings := localvectorizer.NewClassSettings(cfg)
+	vector, err := s.vectorizer.Texts(ctx, params.Values, settings)
 	if err != nil {
 		return nil, errors.Errorf("vectorize keywords: %v", err)
 	}
 
 	moveTo := params.MoveTo
 	if moveTo.Force > 0 && (len(moveTo.Values) > 0 || len(moveTo.Objects) > 0) {
-		moveToVector, err := s.vectorFromValuesAndObjects(ctx, moveTo.Values, moveTo.Objects, findVectorFn)
+		moveToVector, err := s.vectorFromValuesAndObjects(ctx, moveTo.Values,
+			moveTo.Objects, findVectorFn, settings)
 		if err != nil {
 			return nil, errors.Errorf("vectorize move to: %v", err)
 		}
@@ -73,7 +76,8 @@ func (s *Searcher) vectorFromNearTextParam(ctx context.Context,
 
 	moveAway := params.MoveAwayFrom
 	if moveAway.Force > 0 && (len(moveAway.Values) > 0 || len(moveAway.Objects) > 0) {
-		moveAwayVector, err := s.vectorFromValuesAndObjects(ctx, moveAway.Values, moveAway.Objects, findVectorFn)
+		moveAwayVector, err := s.vectorFromValuesAndObjects(ctx, moveAway.Values,
+			moveAway.Objects, findVectorFn, settings)
 		if err != nil {
 			return nil, errors.Errorf("vectorize move away from: %v", err)
 		}
@@ -90,11 +94,12 @@ func (s *Searcher) vectorFromNearTextParam(ctx context.Context,
 
 func (s *Searcher) vectorFromValuesAndObjects(ctx context.Context,
 	values []string, objects []ObjectMove,
-	findVectorFn modulecapabilities.FindVectorFn) ([]float32, error) {
+	findVectorFn modulecapabilities.FindVectorFn,
+	settings localvectorizer.ClassSettings) ([]float32, error) {
 	var objectVectors [][]float32
 
 	if len(values) > 0 {
-		moveToVector, err := s.vectorizer.Texts(ctx, values, nil)
+		moveToVector, err := s.vectorizer.Texts(ctx, values, settings)
 		if err != nil {
 			return nil, errors.Errorf("vectorize move to: %v", err)
 		}

--- a/modules/text2vec-transformers/vectorizer/class_settings.go
+++ b/modules/text2vec-transformers/vectorizer/class_settings.go
@@ -22,15 +22,15 @@ const (
 	DefaultPoolingStrategy       = "masked_mean"
 )
 
-type indexChecker struct {
+type classSettings struct {
 	cfg moduletools.ClassConfig
 }
 
-func NewIndexChecker(cfg moduletools.ClassConfig) *indexChecker {
-	return &indexChecker{cfg: cfg}
+func NewClassSettings(cfg moduletools.ClassConfig) *classSettings {
+	return &classSettings{cfg: cfg}
 }
 
-func (ic *indexChecker) PropertyIndexed(propName string) bool {
+func (ic *classSettings) PropertyIndexed(propName string) bool {
 	vcn, ok := ic.cfg.Property(propName)["skip"]
 	if !ok {
 		return DefaultPropertyIndexed
@@ -44,7 +44,7 @@ func (ic *indexChecker) PropertyIndexed(propName string) bool {
 	return !asBool
 }
 
-func (ic *indexChecker) VectorizePropertyName(propName string) bool {
+func (ic *classSettings) VectorizePropertyName(propName string) bool {
 	vcn, ok := ic.cfg.Property(propName)["vectorizePropertyName"]
 	if !ok {
 		return DefaultVectorizePropertyName
@@ -58,7 +58,7 @@ func (ic *indexChecker) VectorizePropertyName(propName string) bool {
 	return asBool
 }
 
-func (ic *indexChecker) VectorizeClassName() bool {
+func (ic *classSettings) VectorizeClassName() bool {
 	vcn, ok := ic.cfg.Class()["vectorizeClassName"]
 	if !ok {
 		return DefaultVectorizeClassName
@@ -72,7 +72,7 @@ func (ic *indexChecker) VectorizeClassName() bool {
 	return asBool
 }
 
-func (ic *indexChecker) PoolingStrategy() string {
+func (ic *classSettings) PoolingStrategy() string {
 	vcn, ok := ic.cfg.Class()["poolingStrategy"]
 	if !ok {
 		return DefaultPoolingStrategy

--- a/modules/text2vec-transformers/vectorizer/class_settings_test.go
+++ b/modules/text2vec-transformers/vectorizer/class_settings_test.go
@@ -19,7 +19,7 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestIndexChecker(t *testing.T) {
+func TestClassSettings(t *testing.T) {
 	t.Run("with all defaults", func(t *testing.T) {
 		class := &models.Class{
 			Class: "MyClass",
@@ -29,7 +29,7 @@ func TestIndexChecker(t *testing.T) {
 		}
 
 		cfg := modules.NewClassBasedModuleConfig(class, "my-module")
-		ic := NewIndexChecker(cfg)
+		ic := NewClassSettings(cfg)
 
 		assert.True(t, ic.PropertyIndexed("someProp"))
 		assert.False(t, ic.VectorizePropertyName("someProp"))
@@ -58,7 +58,7 @@ func TestIndexChecker(t *testing.T) {
 		}
 
 		cfg := modules.NewClassBasedModuleConfig(class, "my-module")
-		ic := NewIndexChecker(cfg)
+		ic := NewClassSettings(cfg)
 
 		assert.True(t, ic.PropertyIndexed("someProp"))
 		assert.False(t, ic.VectorizePropertyName("someProp"))
@@ -87,7 +87,7 @@ func TestIndexChecker(t *testing.T) {
 		}
 
 		cfg := modules.NewClassBasedModuleConfig(class, "my-module")
-		ic := NewIndexChecker(cfg)
+		ic := NewClassSettings(cfg)
 
 		assert.False(t, ic.PropertyIndexed("someProp"))
 		assert.True(t, ic.VectorizePropertyName("someProp"))

--- a/modules/text2vec-transformers/vectorizer/texts.go
+++ b/modules/text2vec-transformers/vectorizer/texts.go
@@ -17,6 +17,7 @@ import (
 	"github.com/pkg/errors"
 )
 
-func (v *Vectorizer) Texts(ctx context.Context, inputs []string) ([]float32, error) {
+func (v *Vectorizer) Texts(ctx context.Context, inputs []string,
+	settings ClassSettings) ([]float32, error) {
 	return nil, errors.Errorf("vectorizers.Texts not implemented yet")
 }

--- a/modules/text2vec-transformers/vectorizer/vectorizer.go
+++ b/modules/text2vec-transformers/vectorizer/vectorizer.go
@@ -45,8 +45,8 @@ type ClassSettings interface {
 }
 
 func (v *Vectorizer) Object(ctx context.Context, object *models.Object,
-	icheck ClassSettings) error {
-	vec, err := v.object(ctx, object.Class, object.Properties, icheck)
+	settings ClassSettings) error {
+	vec, err := v.object(ctx, object.Class, object.Properties, settings)
 	if err != nil {
 		return err
 	}

--- a/usecases/modules/modules.go
+++ b/usecases/modules/modules.go
@@ -187,15 +187,46 @@ func (m *Provider) ValidateSearchParam(name string, value interface{}) error {
 	panic("ValidateParam was called without any known params present")
 }
 
-// VectorFromSearchParam gets a vector for a given argument
+// VectorFromSearchParam gets a vector for a given argument. This is used in
+// Get { Class() } for example
 func (m *Provider) VectorFromSearchParam(ctx context.Context,
+	className string, param string, params interface{},
+	findVectorFn modulecapabilities.FindVectorFn) ([]float32, error) {
+	sch := m.schemaGetter.GetSchemaSkipAuth()
+	class := sch.FindClassByName(schema.ClassName(className))
+	if class == nil {
+		return nil, errors.Errorf("class %q not found in schema", className)
+	}
+
+	for _, mod := range m.GetAll() {
+		if searcher, ok := mod.(modulecapabilities.Searcher); ok {
+			if vectorSearches := searcher.VectorSearches(); vectorSearches != nil {
+				if searchVectorFn := vectorSearches[param]; searchVectorFn != nil {
+					cfg := NewClassBasedModuleConfig(class, mod.Name())
+					vector, err := searchVectorFn(ctx, params, findVectorFn, cfg)
+					if err != nil {
+						return nil, errors.Errorf("vectorize params: %v", err)
+					}
+					return vector, nil
+				}
+			}
+		}
+	}
+
+	panic("VectorFromParams was called without any known params present")
+}
+
+// CrossClassVectorFromSearchParam gets a vector for a given argument without
+// being specific to any one class and it's configuration. This is used in
+// Explore() { } for example
+func (m *Provider) CrossClassVectorFromSearchParam(ctx context.Context,
 	param string, params interface{},
 	findVectorFn modulecapabilities.FindVectorFn) ([]float32, error) {
 	for _, mod := range m.GetAll() {
 		if searcher, ok := mod.(modulecapabilities.Searcher); ok {
 			if vectorSearches := searcher.VectorSearches(); vectorSearches != nil {
 				if searchVectorFn := vectorSearches[param]; searchVectorFn != nil {
-					vector, err := searchVectorFn(ctx, params, findVectorFn)
+					vector, err := searchVectorFn(ctx, params, findVectorFn, nil)
 					if err != nil {
 						return nil, errors.Errorf("vectorize params: %v", err)
 					}

--- a/usecases/modules/searchers_test.go
+++ b/usecases/modules/searchers_test.go
@@ -1,0 +1,128 @@
+package modules
+
+import (
+	"context"
+	"testing"
+
+	"github.com/go-openapi/strfmt"
+	"github.com/semi-technologies/weaviate/entities/models"
+	"github.com/semi-technologies/weaviate/entities/modulecapabilities"
+	"github.com/semi-technologies/weaviate/entities/moduletools"
+	"github.com/semi-technologies/weaviate/entities/schema"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestModulesWithSearchers(t *testing.T) {
+	sch := schema.Schema{
+		Objects: &models.Schema{
+			Classes: []*models.Class{
+				{
+					Class: "MyClass",
+					ModuleConfig: map[string]interface{}{
+						"mod": map[string]interface{}{
+							"some-config": "some-config-value",
+						},
+					},
+				},
+			},
+		},
+	}
+
+	t.Run("get a vector for a class", func(t *testing.T) {
+		p := NewProvider()
+		p.SetSchemaGetter(&fakeSchemaGetter{
+			schema: sch,
+		})
+		p.Register(newSearcherModule("mod").
+			withArg("nearGrape").
+			withSearcher("nearGrape", func(ctx context.Context, params interface{},
+				findVectorFn modulecapabilities.FindVectorFn,
+				cfg moduletools.ClassConfig) ([]float32, error) {
+				// verify that the config tool is set, as this is a per-class search,
+				// so it must be set
+				assert.NotNil(t, cfg)
+
+				// take the findVectorFn and append one dimension. This doesn't make too
+				// much sense, but helps verify that the modules method was used in the
+				// decisions
+				initial, _ := findVectorFn(ctx, "123")
+				return append(initial, 4), nil
+			}),
+		)
+		p.Init(nil)
+
+		res, err := p.VectorFromSearchParam(context.Background(), "MyClass",
+			"nearGrape", nil, fakeFindVector)
+
+		require.Nil(t, err)
+		assert.Equal(t, []float32{1, 2, 3, 4}, res)
+	})
+
+	t.Run("get a vector across classes", func(t *testing.T) {
+		p := NewProvider()
+		p.SetSchemaGetter(&fakeSchemaGetter{
+			schema: sch,
+		})
+		p.Register(newSearcherModule("mod").
+			withArg("nearGrape").
+			withSearcher("nearGrape", func(ctx context.Context, params interface{},
+				findVectorFn modulecapabilities.FindVectorFn,
+				cfg moduletools.ClassConfig) ([]float32, error) {
+				// this is a cross-class search, such as is used for Explore{}, in this
+				// case we do not have class-based config, so the optional argument is
+				// nil! Modules must be able to deal with this situation!
+				assert.Nil(t, cfg)
+
+				// take the findVectorFn and append one dimension. This doesn't make too
+				// much sense, but helps verify that the modules method was used in the
+				// decisions
+				initial, _ := findVectorFn(ctx, "123")
+				return append(initial, 4), nil
+			}),
+		)
+		p.Init(nil)
+
+		res, err := p.CrossClassVectorFromSearchParam(context.Background(),
+			"nearGrape", nil, fakeFindVector)
+
+		require.Nil(t, err)
+		assert.Equal(t, []float32{1, 2, 3, 4}, res)
+	})
+}
+
+func fakeFindVector(ctx context.Context, id strfmt.UUID) ([]float32, error) {
+	return []float32{1, 2, 3}, nil
+}
+
+func newSearcherModule(name string) *dummySearcherModule {
+	return &dummySearcherModule{
+		dummyGraphQLModule: newGraphQLModule(name),
+		searchers:          map[string]modulecapabilities.VectorForParams{},
+	}
+}
+
+type dummySearcherModule struct {
+	*dummyGraphQLModule
+	searchers map[string]modulecapabilities.VectorForParams
+}
+
+func (m *dummySearcherModule) withArg(arg string) *dummySearcherModule {
+	// call the super's withArg
+	m.dummyGraphQLModule.withArg(arg)
+
+	// but don't return their return type but ours :)
+	return m
+}
+
+// a helper for our test
+func (m *dummySearcherModule) withSearcher(arg string,
+	impl modulecapabilities.VectorForParams) *dummySearcherModule {
+	m.searchers[arg] = impl
+	return m
+}
+
+// public method to implement the modulecapabilities.Searcher interface
+func (m *dummySearcherModule) VectorSearches() map[string]modulecapabilities.VectorForParams {
+	return m.searchers
+}

--- a/usecases/modules/searchers_test.go
+++ b/usecases/modules/searchers_test.go
@@ -1,3 +1,14 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2021 SeMI Technologies B.V. All rights reserved.
+//
+//  CONTACT: hello@semi.technology
+//
+
 package modules
 
 import (

--- a/usecases/modules/vectorizer_test.go
+++ b/usecases/modules/vectorizer_test.go
@@ -72,6 +72,10 @@ func TestVectorizer(t *testing.T) {
 	})
 }
 
+func newDummyModuleWithName(name string) dummyModuleNoCapabilities {
+	return dummyModuleNoCapabilities{name: name}
+}
+
 type dummyModuleNoCapabilities struct {
 	name string
 }

--- a/usecases/traverser/explorer.go
+++ b/usecases/traverser/explorer.go
@@ -43,8 +43,10 @@ type Explorer struct {
 
 type ModulesProvider interface {
 	ValidateSearchParam(name string, value interface{}) error
-	VectorFromSearchParam(ctx context.Context, param string, params interface{},
-		findVectorFn modulecapabilities.FindVectorFn) ([]float32, error)
+	VectorFromSearchParam(ctx context.Context, className string, param string,
+		params interface{}, findVectorFn modulecapabilities.FindVectorFn) ([]float32, error)
+	CrossClassVectorFromSearchParam(ctx context.Context, param string,
+		params interface{}, findVectorFn modulecapabilities.FindVectorFn) ([]float32, error)
 }
 
 type distancer func(a, b []float32) (float32, error)
@@ -71,8 +73,8 @@ type pathBuilder interface {
 }
 
 // NewExplorer with search and connector repo
-func NewExplorer(search vectorClassSearch, distancer distancer,
-	logger logrus.FieldLogger, nnExtender nnExtender,
+func NewExplorer(search vectorClassSearch,
+	distancer distancer, logger logrus.FieldLogger, nnExtender nnExtender,
 	projector projector, pathBuilder pathBuilder, modulesProvider ModulesProvider) *Explorer {
 	return &Explorer{search, distancer, logger, nnExtender, projector, pathBuilder, modulesProvider}
 }
@@ -396,7 +398,7 @@ func (e *Explorer) vectorFromParams(ctx context.Context,
 
 	if len(params.ModuleParams) == 1 {
 		for name, value := range params.ModuleParams {
-			return e.vectorFromModules(ctx, name, value)
+			return e.vectorFromModules(ctx, params.ClassName, name, value)
 		}
 	}
 
@@ -427,7 +429,7 @@ func (e *Explorer) vectorFromExploreParams(ctx context.Context,
 
 	if len(params.ModuleParams) == 1 {
 		for name, value := range params.ModuleParams {
-			return e.vectorFromModules(ctx, name, value)
+			return e.crossClassVectorFromModules(ctx, name, value)
 		}
 	}
 
@@ -450,9 +452,24 @@ func (e *Explorer) vectorFromExploreParams(ctx context.Context,
 }
 
 func (e *Explorer) vectorFromModules(ctx context.Context,
-	paramName string, paramValue interface{}) ([]float32, error) {
+	className, paramName string, paramValue interface{}) ([]float32, error) {
 	if e.modulesProvider != nil {
 		vector, err := e.modulesProvider.VectorFromSearchParam(ctx,
+			className, paramName, paramValue, e.findVector,
+		)
+		if err != nil {
+			return nil, errors.Errorf("vectorize params: %v", err)
+		}
+		return vector, nil
+	}
+	return nil, errors.New("no modules defined")
+}
+
+// similar to vectorFromModules, but not specific to a single class
+func (e *Explorer) crossClassVectorFromModules(ctx context.Context,
+	paramName string, paramValue interface{}) ([]float32, error) {
+	if e.modulesProvider != nil {
+		vector, err := e.modulesProvider.CrossClassVectorFromSearchParam(ctx,
 			paramName, paramValue, e.findVector,
 		)
 		if err != nil {

--- a/usecases/traverser/explorer_test.go
+++ b/usecases/traverser/explorer_test.go
@@ -1912,11 +1912,20 @@ func ptFloat32(in float32) *float32 {
 
 type fakeModulesProvider struct{}
 
-func (p *fakeModulesProvider) VectorFromSearchParam(ctx context.Context, param string, params interface{},
+func (p *fakeModulesProvider) VectorFromSearchParam(ctx context.Context, className,
+	param string, params interface{},
 	findVectorFn modulecapabilities.FindVectorFn) ([]float32, error) {
 	txt2vec := &fakeText2vecContextionaryModule{}
 	vectorForParams := txt2vec.VectorSearches()["nearText"]
-	return vectorForParams(ctx, params, findVectorFn)
+	return vectorForParams(ctx, params, findVectorFn, nil)
+}
+
+func (p *fakeModulesProvider) CrossClassVectorFromSearchParam(ctx context.Context,
+	param string, params interface{},
+	findVectorFn modulecapabilities.FindVectorFn) ([]float32, error) {
+	txt2vec := &fakeText2vecContextionaryModule{}
+	vectorForParams := txt2vec.VectorSearches()["nearText"]
+	return vectorForParams(ctx, params, findVectorFn, nil)
 }
 
 func (p *fakeModulesProvider) ValidateSearchParam(name string, value interface{}) error {


### PR DESCRIPTION
This is a small intermezzo PR which closes #1478 in preparation for finishing #1473.

It deals with providing the class-based config `moduletool` where it makes sense and increases test coverage around the handling of this. Also refactors existing `usecase/module` tests to make them more concise and reusable.