### PR TITLE
Gh 1579 allow vector index skip

### DIFF
--- a/adapters/repos/db/shard.go
+++ b/adapters/repos/db/shard.go
@@ -26,6 +26,7 @@ import (
 	"github.com/semi-technologies/weaviate/adapters/repos/db/propertyspecific"
 	"github.com/semi-technologies/weaviate/adapters/repos/db/vector/hnsw"
 	"github.com/semi-technologies/weaviate/adapters/repos/db/vector/hnsw/distancer"
+	"github.com/semi-technologies/weaviate/adapters/repos/db/vector/noop"
 	"github.com/semi-technologies/weaviate/entities/models"
 	"github.com/semi-technologies/weaviate/entities/schema"
 	"github.com/sirupsen/logrus"
@@ -67,23 +68,29 @@ func NewShard(shardName string, index *Index) (*Shard, error) {
 			index.vectorIndexUserConfig)
 	}
 
-	vi, err := hnsw.New(hnsw.Config{
-		Logger:   index.logger,
-		RootPath: s.index.Config.RootPath,
-		ID:       s.ID(),
-		MakeCommitLoggerThunk: func() (hnsw.CommitLogger, error) {
-			return hnsw.NewCommitLogger(s.index.Config.RootPath, s.ID(), 10*time.Second,
-				index.logger)
-		},
-		VectorForIDThunk: s.vectorByIndexID,
-		DistanceProvider: distancer.NewDotProductProvider(),
-	}, hnswUserConfig)
-	if err != nil {
-		return nil, errors.Wrapf(err, "init shard %q: hnsw index", s.ID())
-	}
-	s.vectorIndex = vi
+	if hnswUserConfig.Skip {
+		s.vectorIndex = noop.NewIndex()
+	} else {
+		vi, err := hnsw.New(hnsw.Config{
+			Logger:   index.logger,
+			RootPath: s.index.Config.RootPath,
+			ID:       s.ID(),
+			MakeCommitLoggerThunk: func() (hnsw.CommitLogger, error) {
+				return hnsw.NewCommitLogger(s.index.Config.RootPath, s.ID(), 10*time.Second,
+					index.logger)
+			},
+			VectorForIDThunk: s.vectorByIndexID,
+			DistanceProvider: distancer.NewDotProductProvider(),
+		}, hnswUserConfig)
+		if err != nil {
+			return nil, errors.Wrapf(err, "init shard %q: hnsw index", s.ID())
+		}
+		s.vectorIndex = vi
 
-	err = s.initDBFile()
+		defer vi.PostStartup()
+	}
+
+	err := s.initDBFile()
 	if err != nil {
 		return nil, errors.Wrapf(err, "init shard %q: shard db", s.ID())
 	}
@@ -104,7 +111,6 @@ func NewShard(shardName string, index *Index) (*Shard, error) {
 	}
 
 	s.startPeriodicCleanup()
-	vi.PostStartup()
 
 	return s, nil
 }

--- a/adapters/repos/db/vector/hnsw/config.go
+++ b/adapters/repos/db/vector/hnsw/config.go
@@ -98,15 +98,17 @@ const (
 	DefaultEFConstruction         = 128
 	DefaultEF                     = -1 // indicates "let Weaviate pick"
 	DefaultVectorCacheMaxObjects  = 2000000
+	DefaultSkip                   = false
 )
 
 // UserConfig bundles all values settable by a user in the per-class settings
 type UserConfig struct {
-	CleanupIntervalSeconds int `json:"cleanupIntervalSeconds"`
-	MaxConnections         int `json:"maxConnections"`
-	EFConstruction         int `json:"efConstruction"`
-	EF                     int `json:"ef"`
-	VectorCacheMaxObjects  int `json:"vectorCacheMaxObjects"`
+	Skip                   bool `json:"skip"`
+	CleanupIntervalSeconds int  `json:"cleanupIntervalSeconds"`
+	MaxConnections         int  `json:"maxConnections"`
+	EFConstruction         int  `json:"efConstruction"`
+	EF                     int  `json:"ef"`
+	VectorCacheMaxObjects  int  `json:"vectorCacheMaxObjects"`
 }
 
 // IndexType returns the type of the underlying vector index, thus making sure
@@ -122,6 +124,7 @@ func (c *UserConfig) SetDefaults() {
 	c.CleanupIntervalSeconds = DefaultCleanupIntervalSeconds
 	c.VectorCacheMaxObjects = DefaultVectorCacheMaxObjects
 	c.EF = DefaultEF
+	c.Skip = DefaultSkip
 }
 
 // ParseUserConfig from an unknown input value, as this is not further
@@ -169,6 +172,12 @@ func ParseUserConfig(input interface{}) (schema.VectorIndexConfig, error) {
 		return uc, err
 	}
 
+	if err := optionalBoolFromMap(asMap, "skip", func(v bool) {
+		uc.Skip = v
+	}); err != nil {
+		return uc, err
+	}
+
 	return uc, nil
 }
 
@@ -195,6 +204,24 @@ func optionalIntFromMap(in map[string]interface{}, name string,
 	}
 
 	setFn(int(asInt64))
+	return nil
+}
+
+func optionalBoolFromMap(in map[string]interface{}, name string,
+	setFn func(v bool)) error {
+	value, ok := in[name]
+	if !ok {
+		fmt.Printf("not present\n")
+		return nil
+	}
+
+	asBool, ok := value.(bool)
+	if !ok {
+		fmt.Printf("not a bool\n")
+		return nil
+	}
+
+	setFn(asBool)
 	return nil
 }
 

--- a/adapters/repos/db/vector/hnsw/config_test.go
+++ b/adapters/repos/db/vector/hnsw/config_test.go
@@ -102,6 +102,7 @@ func Test_UserConfig(t *testing.T) {
 				EFConstruction:         DefaultEFConstruction,
 				VectorCacheMaxObjects:  DefaultVectorCacheMaxObjects,
 				EF:                     DefaultEF,
+				Skip:                   DefaultSkip,
 			},
 		},
 
@@ -127,6 +128,7 @@ func Test_UserConfig(t *testing.T) {
 				"efConstruction":         json.Number("13"),
 				"vectorCacheMaxObjects":  json.Number("14"),
 				"ef":                     json.Number("15"),
+				"skip":                   true,
 			},
 			expected: UserConfig{
 				CleanupIntervalSeconds: 11,
@@ -134,6 +136,7 @@ func Test_UserConfig(t *testing.T) {
 				EFConstruction:         13,
 				VectorCacheMaxObjects:  14,
 				EF:                     15,
+				Skip:                   true,
 			},
 		},
 

--- a/adapters/repos/db/vector/noop/index.go
+++ b/adapters/repos/db/vector/noop/index.go
@@ -1,0 +1,36 @@
+package noop
+
+import (
+	"github.com/pkg/errors"
+	"github.com/semi-technologies/weaviate/adapters/repos/db/helpers"
+	"github.com/semi-technologies/weaviate/entities/schema"
+)
+
+type Index struct{}
+
+func NewIndex() *Index {
+	return &Index{}
+}
+
+func (i *Index) Add(id uint64, vector []float32) error {
+	// silently ignore
+	return nil
+}
+
+func (i *Index) Delete(id uint64) error {
+	// silently ignore
+	return nil
+}
+
+func (i *Index) SearchByVector(vector []float32, k int, allow helpers.AllowList) ([]uint64, error) {
+	return nil, errors.Errorf("cannot vector-search on a class not vector-indexed")
+}
+
+func (i *Index) UpdateUserConfig(updated schema.VectorIndexConfig) error {
+	return errors.Errorf("cannot update vector index config on a non-indexed class. Delete and re-create without skip property")
+}
+
+func (i *Index) Drop() error {
+	// silently ignore
+	return nil
+}

--- a/test/acceptance/schema/get_schema_without_client_test.go
+++ b/test/acceptance/schema/get_schema_without_client_test.go
@@ -38,6 +38,7 @@ func testGetSchemaWithoutClient(t *testing.T) {
 				"properties":      (interface{})(nil),
 				"vectorIndexType": "hnsw", // from default
 				"vectorIndexConfig": map[string]interface{}{ // from default
+					"skip":                   false,
 					"cleanupIntervalSeconds": float64(300),
 					"efConstruction":         float64(128),
 					"ef":                     float64(-1),


### PR DESCRIPTION
closes #1579

does not yet change validation or "detect" duplicaties, only allows setting `vectorIndexConfig.skip: <bool>`