### PR TITLE
sort the keys of the schema to ensure consistency

### DIFF
--- a/modules/text2vec-transformers/vectorizer/objects.go
+++ b/modules/text2vec-transformers/vectorizer/objects.go
@@ -45,6 +45,15 @@ type ClassSettings interface {
 	PoolingStrategy() string
 }
 
+func sortStringKeys(schema_map map[string]interface{}) []string {
+	keys := make([]string, 0, len(schema_map))
+	for k := range schema_map {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	return keys
+}
+
 func (v *Vectorizer) Object(ctx context.Context, object *models.Object,
 	settings ClassSettings) error {
 	vec, err := v.object(ctx, object.Class, object.Properties, settings)
@@ -54,15 +63,6 @@ func (v *Vectorizer) Object(ctx context.Context, object *models.Object,
 
 	object.Vector = vec
 	return nil
-}
-
-func sortStringKeys(schema_map map[string]interface{}) []string {
-	keys := make([]string, 0, len(schema_map))
-	for k := range schema_map {
-		keys = append(keys, k)
-	}
-	sort.Strings(keys)
-	return keys
 }
 
 func (v *Vectorizer) object(ctx context.Context, className string,

--- a/modules/text2vec-transformers/vectorizer/objects.go
+++ b/modules/text2vec-transformers/vectorizer/objects.go
@@ -14,6 +14,7 @@ package vectorizer
 import (
 	"context"
 	"fmt"
+	"sort"
 	"strings"
 
 	"github.com/fatih/camelcase"
@@ -55,6 +56,16 @@ func (v *Vectorizer) Object(ctx context.Context, object *models.Object,
 	return nil
 }
 
+func sortStringKeys(schema_map map[string]interface{}) []string {
+
+	keys := make([]string, 0, len(schema_map))
+	for k := range schema_map {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	return keys
+}
+
 func (v *Vectorizer) object(ctx context.Context, className string,
 	schema interface{}, icheck ClassSettings) ([]float32, error) {
 	var corpi []string
@@ -64,12 +75,13 @@ func (v *Vectorizer) object(ctx context.Context, className string,
 	}
 
 	if schema != nil {
-		for prop, value := range schema.(map[string]interface{}) {
+		schemamap := schema.(map[string]interface{})
+		for _, prop := range sortStringKeys(schemamap) {
 			if !icheck.PropertyIndexed(prop) {
 				continue
 			}
 
-			valueString, ok := value.(string)
+			valueString, ok := schemamap[prop].(string)
 			if ok {
 				if icheck.VectorizePropertyName(prop) {
 					// use prop and value

--- a/modules/text2vec-transformers/vectorizer/objects.go
+++ b/modules/text2vec-transformers/vectorizer/objects.go
@@ -57,7 +57,6 @@ func (v *Vectorizer) Object(ctx context.Context, object *models.Object,
 }
 
 func sortStringKeys(schema_map map[string]interface{}) []string {
-
 	keys := make([]string, 0, len(schema_map))
 	for k := range schema_map {
 		keys = append(keys, k)

--- a/modules/text2vec-transformers/vectorizer/objects_test.go
+++ b/modules/text2vec-transformers/vectorizer/objects_test.go
@@ -166,7 +166,7 @@ func TestVectorizingObjects(t *testing.T) {
 			assert.Equal(t, models.C11yVector{0, 1, 2, 3}, test.input.Vector)
 			expected := strings.Split(test.expectedClientCall, " ")
 			actual := strings.Split(client.lastInput, " ")
-			assert.ElementsMatch(t, expected, actual)
+			assert.Equal(t, expected, actual)
 			assert.Equal(t, client.lastConfig.PoolingStrategy, test.expectedPoolingStrategy)
 		})
 	}


### PR DESCRIPTION
Add a sort function, `sortStringKeys`, that returns the sorted map keys.