### PR TITLE
gh-1591 fix issues around PATCH and vectorizer:none

### DIFF
--- a/test/acceptance/objects/custom_vectors.go
+++ b/test/acceptance/objects/custom_vectors.go
@@ -1,0 +1,78 @@
+package test
+
+import (
+	"testing"
+
+	"github.com/davecgh/go-spew/spew"
+	"github.com/go-openapi/strfmt"
+	"github.com/semi-technologies/weaviate/client/objects"
+	"github.com/semi-technologies/weaviate/entities/models"
+	"github.com/semi-technologies/weaviate/test/acceptance/helper"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func customVectors(t *testing.T) {
+	var id strfmt.UUID
+
+	t.Run("create object", func(t *testing.T) {
+		params := objects.NewObjectsCreateParams().WithBody(
+			&models.Object{
+				Class:      "TestObjectCustomVector",
+				Properties: map[string]interface{}{"description": "foo"},
+				Vector:     []float32{0.1, 0.2},
+			})
+		resp, err := helper.Client(t).Objects.ObjectsCreate(params, nil)
+		require.Nil(t, err, "creation should succeed")
+		id = resp.Payload.ID
+	})
+
+	t.Run("check custom vector is set", func(t *testing.T) {
+		include := "vector"
+		params := objects.NewObjectsGetParams().WithID(id).WithInclude(&include)
+		resp, err := helper.Client(t).Objects.ObjectsGet(params, nil)
+		require.Nil(t, err, "get should succeed")
+		assert.Equal(t, []float32{0.1, 0.2}, []float32(resp.Payload.Vector))
+	})
+
+	t.Run("replace object entirely (update)", func(t *testing.T) {
+		params := objects.NewObjectsUpdateParams().WithID(id).WithBody(&models.Object{
+			ID:         id,
+			Class:      "TestObjectCustomVector",
+			Properties: map[string]interface{}{"description": "foo updated"},
+			Vector:     []float32{0.1, 0.3},
+		})
+		_, err := helper.Client(t).Objects.ObjectsUpdate(params, nil)
+		require.Nil(t, err, "update should succeed")
+	})
+
+	t.Run("check custom vector is updated", func(t *testing.T) {
+		include := "vector"
+		params := objects.NewObjectsGetParams().WithID(id).WithInclude(&include)
+		resp, err := helper.Client(t).Objects.ObjectsGet(params, nil)
+		require.Nil(t, err, "get should succeed")
+		assert.Equal(t, []float32{0.1, 0.3}, []float32(resp.Payload.Vector))
+	})
+
+	t.Run("replace only vector through merge", func(t *testing.T) {
+		params := objects.NewObjectsPatchParams().WithID(id).WithBody(&models.Object{
+			ID:         id,
+			Class:      "TestObjectCustomVector",
+			Properties: map[string]interface{}{},
+			Vector:     []float32{0.4, 0.3},
+		})
+		_, err := helper.Client(t).Objects.ObjectsPatch(params, nil)
+		if err != nil {
+			spew.Dump(err.(*objects.ObjectsPatchInternalServerError).Payload.Error[0])
+		}
+		require.Nil(t, err, "patch should succeed")
+	})
+
+	t.Run("check custom vector is updated", func(t *testing.T) {
+		include := "vector"
+		params := objects.NewObjectsGetParams().WithID(id).WithInclude(&include)
+		resp, err := helper.Client(t).Objects.ObjectsGet(params, nil)
+		require.Nil(t, err, "get should succeed")
+		assert.Equal(t, []float32{0.4, 0.3}, []float32(resp.Payload.Vector))
+	})
+}

--- a/test/acceptance/objects/setup_test.go
+++ b/test/acceptance/objects/setup_test.go
@@ -55,6 +55,17 @@ func Test_Objects(t *testing.T) {
 				},
 			},
 		})
+
+		createObjectClass(t, &models.Class{
+			Class:      "TestObjectCustomVector",
+			Vectorizer: "none",
+			Properties: []*models.Property{
+				&models.Property{
+					Name:     "description",
+					DataType: []string{"text"},
+				},
+			},
+		})
 	})
 
 	// tests
@@ -63,8 +74,10 @@ func Test_Objects(t *testing.T) {
 	t.Run("running a feature projection", featureProjection)
 	t.Run("creating objects", creatingObjects)
 
+	t.Run("custom vector journey", customVectors)
 	// tear down
 	deleteObjectClass(t, "TestObject")
+	deleteObjectClass(t, "TestObjectCustomVector")
 }
 
 func createObjectClass(t *testing.T, class *models.Class) {

--- a/usecases/objects/obtain_vector.go
+++ b/usecases/objects/obtain_vector.go
@@ -45,6 +45,7 @@ func (vo *vectorObtainer) Do(ctx context.Context, obj *models.Object,
 	if err != nil {
 		return err
 	}
+
 	hnswConfig, ok := cfg.(hnsw.UserConfig)
 	if !ok {
 		return errors.Errorf("vector index config (%T) is not of type HNSW, "+

--- a/usecases/objects/references_add_test.go
+++ b/usecases/objects/references_add_test.go
@@ -160,6 +160,17 @@ func zooAnimalSchemaForTest() schema.Schema {
 						},
 					},
 				},
+				&models.Class{
+					Class:             "NotVectorized",
+					VectorIndexConfig: hnsw.UserConfig{},
+					Properties: []*models.Property{
+						&models.Property{
+							Name:     "description",
+							DataType: []string{"text"},
+						},
+					},
+					Vectorizer: "none",
+				},
 			},
 		},
 	}


### PR DESCRIPTION
* If no properties are provided, there is no longer a panic
* If no vector is provided, the old one stays intact
* If a vector is provided, the new one is taken for updates

closes #1591