### PR TITLE
gh-1616 aggregate alloc improvements and bugfixes

### DIFF
--- a/adapters/repos/db/aggregator/text.go
+++ b/adapters/repos/db/aggregator/text.go
@@ -49,22 +49,16 @@ type textAggregator struct {
 
 func (a *Aggregator) parseAndAddTextRow(agg *textAggregator,
 	v []byte, propName schema.PropertyName) error {
-	obj, err := storobj.FromBinary(v)
+	item, ok, err := storobj.ParseAndExtractTextProp(v, propName.String())
 	if err != nil {
-		return errors.Wrap(err, "unmarshal object")
+		return errors.Wrap(err, "parse and extract prop")
 	}
 
-	s := obj.Properties()
-	if s == nil {
-		return nil
-	}
-
-	item, ok := s.(map[string]interface{})[propName.String()]
 	if !ok {
 		return nil
 	}
 
-	return agg.AddText(item.(string))
+	return agg.AddText(item)
 }
 
 func (a *textAggregator) AddText(value string) error {

--- a/adapters/repos/db/lsmkv/compaction_integration_test.go
+++ b/adapters/repos/db/lsmkv/compaction_integration_test.go
@@ -186,9 +186,11 @@ func Test_CompactionReplaceStrategy(t *testing.T) {
 		defer c.Close()
 
 		for k, v := c.First(); k != nil; k, v = c.Next() {
+			keyCopy := copyByteSlice(k)
+			valueCopy := copyByteSlice(v)
 			retrieved = append(retrieved, kv{
-				key:   k,
-				value: v,
+				key:   keyCopy,
+				value: valueCopy,
 			})
 		}
 
@@ -212,9 +214,11 @@ func Test_CompactionReplaceStrategy(t *testing.T) {
 		defer c.Close()
 
 		for k, v := c.First(); k != nil; k, v = c.Next() {
+			keyCopy := copyByteSlice(k)
+			valueCopy := copyByteSlice(v)
 			retrieved = append(retrieved, kv{
-				key:   k,
-				value: v,
+				key:   keyCopy,
+				value: valueCopy,
 			})
 		}
 
@@ -1522,4 +1526,10 @@ func Test_CompactionMapStrategy_RemoveUnnecessary(t *testing.T) {
 func nullLogger() logrus.FieldLogger {
 	log, _ := test.NewNullLogger()
 	return log
+}
+
+func copyByteSlice(src []byte) []byte {
+	dst := make([]byte, len(src))
+	copy(dst, src)
+	return dst
 }

--- a/adapters/repos/db/lsmkv/cursor_segment_collection.go
+++ b/adapters/repos/db/lsmkv/cursor_segment_collection.go
@@ -26,14 +26,15 @@ func (s *segment) newCollectionCursor() *segmentCursorCollection {
 	}
 }
 
-func (s *SegmentGroup) newCollectionCursors() []innerCursorCollection {
+func (s *SegmentGroup) newCollectionCursors() ([]innerCursorCollection, func()) {
+	s.maintenanceLock.RLock()
 	out := make([]innerCursorCollection, len(s.segments))
 
 	for i, segment := range s.segments {
 		out[i] = segment.newCollectionCursor()
 	}
 
-	return out
+	return out, s.maintenanceLock.RUnlock
 }
 
 func (s *segmentCursorCollection) seek(key []byte) ([]byte, []value, error) {

--- a/adapters/repos/db/lsmkv/cursor_segment_replace.go
+++ b/adapters/repos/db/lsmkv/cursor_segment_replace.go
@@ -28,14 +28,15 @@ func (s *segment) newCursor() *segmentCursorReplace {
 	}
 }
 
-func (s *SegmentGroup) newCursors() []innerCursorReplace {
+func (s *SegmentGroup) newCursors() ([]innerCursorReplace, func()) {
 	out := make([]innerCursorReplace, len(s.segments))
 
+	s.maintenanceLock.RLock()
 	for i, segment := range s.segments {
 		out[i] = segment.newCursor()
 	}
 
-	return out
+	return out, s.maintenanceLock.RUnlock
 }
 
 func (s *segmentCursorReplace) seek(key []byte) ([]byte, []byte, error) {

--- a/adapters/repos/db/lsmkv/segment_replace_strategy.go
+++ b/adapters/repos/db/lsmkv/segment_replace_strategy.go
@@ -107,3 +107,23 @@ func (i *segment) replaceStratParseDataWithKey(in []byte) (segmentReplaceNode, e
 
 	return out, nil
 }
+
+func (i *segment) replaceStratParseDataWithKeyInto(in []byte,
+	node *segmentReplaceNode) error {
+	if len(in) == 0 {
+		return NotFound
+	}
+
+	r := bytes.NewReader(in)
+
+	err := ParseReplaceNodeInto(r, i.secondaryIndexCount, node)
+	if err != nil {
+		return err
+	}
+
+	if node.tombstone {
+		return Deleted
+	}
+
+	return nil
+}

--- a/adapters/repos/db/lsmkv/strategies_replace_integration_test.go
+++ b/adapters/repos/db/lsmkv/strategies_replace_integration_test.go
@@ -813,8 +813,8 @@ func TestReplaceStrategy_Cursors(t *testing.T) {
 			c := b.Cursor()
 			defer c.Close()
 			for k, v := c.Seek([]byte("key-016")); k != nil; k, v = c.Next() {
-				retrievedKeys = append(retrievedKeys, k)
-				retrievedValues = append(retrievedValues, v)
+				retrievedKeys = copyAndAppend(retrievedKeys, k)
+				retrievedValues = copyAndAppend(retrievedValues, v)
 			}
 
 			assert.Equal(t, expectedKeys, retrievedKeys)
@@ -840,8 +840,8 @@ func TestReplaceStrategy_Cursors(t *testing.T) {
 			retrieved := 0
 			for k, v := c.First(); k != nil && retrieved < 3; k, v = c.Next() {
 				retrieved++
-				retrievedKeys = append(retrievedKeys, k)
-				retrievedValues = append(retrievedValues, v)
+				retrievedKeys = copyAndAppend(retrievedKeys, k)
+				retrievedValues = copyAndAppend(retrievedValues, v)
 			}
 
 			assert.Equal(t, expectedKeys, retrievedKeys)
@@ -871,8 +871,8 @@ func TestReplaceStrategy_Cursors(t *testing.T) {
 			retrieved := 0
 			for k, v := c.Seek([]byte("key-001")); k != nil && retrieved < 2; k, v = c.Next() {
 				retrieved++
-				retrievedKeys = append(retrievedKeys, k)
-				retrievedValues = append(retrievedValues, v)
+				retrievedKeys = copyAndAppend(retrievedKeys, k)
+				retrievedValues = copyAndAppend(retrievedValues, v)
 			}
 
 			assert.Equal(t, expectedKeys, retrievedKeys)
@@ -901,8 +901,8 @@ func TestReplaceStrategy_Cursors(t *testing.T) {
 				retrieved := 0
 				for k, v := c.Seek([]byte("key-001")); k != nil && retrieved < 2; k, v = c.Next() {
 					retrieved++
-					retrievedKeys = append(retrievedKeys, k)
-					retrievedValues = append(retrievedValues, v)
+					retrievedKeys = copyAndAppend(retrievedKeys, k)
+					retrievedValues = copyAndAppend(retrievedValues, v)
 				}
 
 				assert.Equal(t, expectedKeys, retrievedKeys)
@@ -928,8 +928,8 @@ func TestReplaceStrategy_Cursors(t *testing.T) {
 				retrieved := 0
 				for k, v := c.First(); k != nil && retrieved < 3; k, v = c.Next() {
 					retrieved++
-					retrievedKeys = append(retrievedKeys, k)
-					retrievedValues = append(retrievedValues, v)
+					retrievedKeys = copyAndAppend(retrievedKeys, k)
+					retrievedValues = copyAndAppend(retrievedValues, v)
 				}
 
 				assert.Equal(t, expectedKeys, retrievedKeys)
@@ -959,8 +959,8 @@ func TestReplaceStrategy_Cursors(t *testing.T) {
 				retrieved := 0
 				for k, v := c.Seek([]byte("key-000")); k != nil && retrieved < 2; k, v = c.Next() {
 					retrieved++
-					retrievedKeys = append(retrievedKeys, k)
-					retrievedValues = append(retrievedValues, v)
+					retrievedKeys = copyAndAppend(retrievedKeys, k)
+					retrievedValues = copyAndAppend(retrievedValues, v)
 				}
 
 				assert.Equal(t, expectedKeys, retrievedKeys)
@@ -984,8 +984,8 @@ func TestReplaceStrategy_Cursors(t *testing.T) {
 				retrieved := 0
 				for k, v := c.First(); k != nil && retrieved < 2; k, v = c.Next() {
 					retrieved++
-					retrievedKeys = append(retrievedKeys, k)
-					retrievedValues = append(retrievedValues, v)
+					retrievedKeys = copyAndAppend(retrievedKeys, k)
+					retrievedValues = copyAndAppend(retrievedValues, v)
 				}
 
 				assert.Equal(t, expectedKeys, retrievedKeys)
@@ -1055,8 +1055,8 @@ func TestReplaceStrategy_Cursors(t *testing.T) {
 			c := b.Cursor()
 			defer c.Close()
 			for k, v := c.Seek([]byte("key-016")); k != nil; k, v = c.Next() {
-				retrievedKeys = append(retrievedKeys, k)
-				retrievedValues = append(retrievedValues, v)
+				retrievedKeys = copyAndAppend(retrievedKeys, k)
+				retrievedValues = copyAndAppend(retrievedValues, v)
 			}
 
 			assert.Equal(t, expectedKeys, retrievedKeys)
@@ -1082,8 +1082,8 @@ func TestReplaceStrategy_Cursors(t *testing.T) {
 			retrieved := 0
 			for k, v := c.First(); k != nil && retrieved < 3; k, v = c.Next() {
 				retrieved++
-				retrievedKeys = append(retrievedKeys, k)
-				retrievedValues = append(retrievedValues, v)
+				retrievedKeys = copyAndAppend(retrievedKeys, k)
+				retrievedValues = copyAndAppend(retrievedValues, v)
 			}
 
 			assert.Equal(t, expectedKeys, retrievedKeys)
@@ -1113,8 +1113,8 @@ func TestReplaceStrategy_Cursors(t *testing.T) {
 
 			for i := 0; i < pairs; i++ {
 				if i%3 == 0 {
-					keys = append(keys, []byte(fmt.Sprintf("key-%03d", i)))
-					values = append(values, []byte(fmt.Sprintf("value-%03d", i)))
+					keys = copyAndAppend(keys, []byte(fmt.Sprintf("key-%03d", i)))
+					values = copyAndAppend(values, []byte(fmt.Sprintf("value-%03d", i)))
 				}
 			}
 
@@ -1142,8 +1142,8 @@ func TestReplaceStrategy_Cursors(t *testing.T) {
 
 			for i := 0; i < pairs; i++ {
 				if i%3 == 1 {
-					keys = append(keys, []byte(fmt.Sprintf("key-%03d", i)))
-					values = append(values, []byte(fmt.Sprintf("value-%03d", i)))
+					keys = copyAndAppend(keys, []byte(fmt.Sprintf("key-%03d", i)))
+					values = copyAndAppend(values, []byte(fmt.Sprintf("value-%03d", i)))
 				}
 			}
 
@@ -1176,8 +1176,8 @@ func TestReplaceStrategy_Cursors(t *testing.T) {
 
 			for i := 0; i < pairs; i++ {
 				if i%3 == 2 {
-					keys = append(keys, []byte(fmt.Sprintf("key-%03d", i)))
-					values = append(values, []byte(fmt.Sprintf("value-%03d", i)))
+					keys = copyAndAppend(keys, []byte(fmt.Sprintf("key-%03d", i)))
+					values = copyAndAppend(values, []byte(fmt.Sprintf("value-%03d", i)))
 				}
 			}
 
@@ -1221,8 +1221,8 @@ func TestReplaceStrategy_Cursors(t *testing.T) {
 			c := b.Cursor()
 			defer c.Close()
 			for k, v := c.Seek([]byte("key-016")); k != nil; k, v = c.Next() {
-				retrievedKeys = append(retrievedKeys, k)
-				retrievedValues = append(retrievedValues, v)
+				retrievedKeys = copyAndAppend(retrievedKeys, k)
+				retrievedValues = copyAndAppend(retrievedValues, v)
 			}
 
 			assert.Equal(t, expectedKeys, retrievedKeys)
@@ -1251,8 +1251,8 @@ func TestReplaceStrategy_Cursors(t *testing.T) {
 			retrieved := 0
 			for k, v := c.First(); k != nil && retrieved < 4; k, v = c.Next() {
 				retrieved++
-				retrievedKeys = append(retrievedKeys, k)
-				retrievedValues = append(retrievedValues, v)
+				retrievedKeys = copyAndAppend(retrievedKeys, k)
+				retrievedValues = copyAndAppend(retrievedValues, v)
 			}
 
 			assert.Equal(t, expectedKeys, retrievedKeys)
@@ -1284,8 +1284,8 @@ func TestReplaceStrategy_Cursors(t *testing.T) {
 			c := b.Cursor()
 			defer c.Close()
 			for k, v := c.Seek([]byte("key-016")); k != nil; k, v = c.Next() {
-				retrievedKeys = append(retrievedKeys, k)
-				retrievedValues = append(retrievedValues, v)
+				retrievedKeys = copyAndAppend(retrievedKeys, k)
+				retrievedValues = copyAndAppend(retrievedValues, v)
 			}
 
 			assert.Equal(t, expectedKeys, retrievedKeys)
@@ -1313,8 +1313,8 @@ func TestReplaceStrategy_Cursors(t *testing.T) {
 			retrieved := 0
 			for k, v := c.First(); k != nil && retrieved < 4; k, v = c.Next() {
 				retrieved++
-				retrievedKeys = append(retrievedKeys, k)
-				retrievedValues = append(retrievedValues, v)
+				retrievedKeys = copyAndAppend(retrievedKeys, k)
+				retrievedValues = copyAndAppend(retrievedValues, v)
 			}
 
 			assert.Equal(t, expectedKeys, retrievedKeys)
@@ -1344,8 +1344,8 @@ func TestReplaceStrategy_Cursors(t *testing.T) {
 			c := b.Cursor()
 			defer c.Close()
 			for k, v := c.Seek([]byte("key-016")); k != nil; k, v = c.Next() {
-				retrievedKeys = append(retrievedKeys, k)
-				retrievedValues = append(retrievedValues, v)
+				retrievedKeys = copyAndAppend(retrievedKeys, k)
+				retrievedValues = copyAndAppend(retrievedValues, v)
 			}
 
 			assert.Equal(t, expectedKeys, retrievedKeys)
@@ -1373,8 +1373,8 @@ func TestReplaceStrategy_Cursors(t *testing.T) {
 			retrieved := 0
 			for k, v := c.First(); k != nil && retrieved < 4; k, v = c.Next() {
 				retrieved++
-				retrievedKeys = append(retrievedKeys, k)
-				retrievedValues = append(retrievedValues, v)
+				retrievedKeys = copyAndAppend(retrievedKeys, k)
+				retrievedValues = copyAndAppend(retrievedValues, v)
 			}
 
 			assert.Equal(t, expectedKeys, retrievedKeys)
@@ -1441,12 +1441,18 @@ func TestReplaceStrategy_Cursors(t *testing.T) {
 			retrieved := 0
 			for k, v := c.First(); k != nil && retrieved < 4; k, v = c.Next() {
 				retrieved++
-				retrievedKeys = append(retrievedKeys, k)
-				retrievedValues = append(retrievedValues, v)
+				retrievedKeys = copyAndAppend(retrievedKeys, k)
+				retrievedValues = copyAndAppend(retrievedValues, v)
 			}
 
 			assert.Equal(t, expectedKeys, retrievedKeys)
 			assert.Equal(t, expectedValues, retrievedValues)
 		})
 	})
+}
+
+func copyAndAppend(list [][]byte, elem []byte) [][]byte {
+	elemCopy := make([]byte, len(elem))
+	copy(elemCopy, elem)
+	return append(list, elemCopy)
 }

--- a/adapters/repos/db/storobj/parse_single_object.go
+++ b/adapters/repos/db/storobj/parse_single_object.go
@@ -1,0 +1,73 @@
+package storobj
+
+import (
+	"bytes"
+	"encoding/binary"
+	"encoding/json"
+	"io"
+
+	"github.com/pkg/errors"
+)
+
+func ParseAndExtractTextProp(data []byte, propName string) (string, bool, error) {
+	var version uint8
+	r := bytes.NewReader(data)
+	le := binary.LittleEndian
+	if err := binary.Read(r, le, &version); err != nil {
+		return "", false, err
+	}
+
+	if version != 1 {
+		return "", false, errors.Errorf("unsupported binary marshaller version %d", version)
+	}
+
+	io.CopyN(io.Discard, r, discardBytesPreVector)
+
+	var vecLen uint16
+	if err := binary.Read(r, le, &vecLen); err != nil {
+		return "", false, err
+	}
+
+	io.CopyN(io.Discard, r, int64(vecLen*4))
+
+	var classNameLen uint16
+	if err := binary.Read(r, le, &classNameLen); err != nil {
+		return "", false, err
+	}
+
+	io.CopyN(io.Discard, r, int64(classNameLen))
+
+	var propsLen uint32
+	if err := binary.Read(r, le, &propsLen); err != nil {
+		return "", false, err
+	}
+
+	start := int64(1 + discardBytesPreVector + 2 + 4*vecLen + 2 + classNameLen + 4)
+	end := start + int64(propsLen)
+
+	// propsBytes := make([]byte, propsLen)
+	// if _, err := r.Read(propsBytes); err != nil {
+	// 	return "", false, err
+	// }
+	propsBytes := data[start:end]
+	// _ = propsBytes
+	// return "", false, nil
+
+	var propsMap map[string]interface{}
+	// if err := json.Unmarshal(propsBytes, &propsMap); err != nil {
+	// 	return "", false, err
+	// }
+
+	if err := json.NewDecoder(bytes.NewReader(propsBytes)).Decode(&propsMap); err != nil {
+		return "", false, err
+	}
+
+	prop, ok := propsMap[propName]
+	if !ok {
+		return "", false, nil
+	}
+
+	return prop.(string), true, nil
+}
+
+const discardBytesPreVector = 8 + 1 + 16 + 8 + 8

--- a/adapters/repos/db/storobj/parse_single_object.go
+++ b/adapters/repos/db/storobj/parse_single_object.go
@@ -1,73 +1,45 @@
 package storobj
 
 import (
-	"bytes"
 	"encoding/binary"
-	"encoding/json"
-	"io"
 
+	"github.com/buger/jsonparser"
 	"github.com/pkg/errors"
 )
 
 func ParseAndExtractTextProp(data []byte, propName string) (string, bool, error) {
-	var version uint8
-	r := bytes.NewReader(data)
-	le := binary.LittleEndian
-	if err := binary.Read(r, le, &version); err != nil {
+	propsBytes, err := extractPropsBytes(data)
+	if err != nil {
 		return "", false, err
 	}
 
-	if version != 1 {
-		return "", false, errors.Errorf("unsupported binary marshaller version %d", version)
-	}
-
-	io.CopyN(io.Discard, r, discardBytesPreVector)
-
-	var vecLen uint16
-	if err := binary.Read(r, le, &vecLen); err != nil {
+	val, _, _, err := jsonparser.Get(propsBytes, propName)
+	if err != nil {
 		return "", false, err
 	}
 
-	io.CopyN(io.Discard, r, int64(vecLen*4))
-
-	var classNameLen uint16
-	if err := binary.Read(r, le, &classNameLen); err != nil {
-		return "", false, err
-	}
-
-	io.CopyN(io.Discard, r, int64(classNameLen))
-
-	var propsLen uint32
-	if err := binary.Read(r, le, &propsLen); err != nil {
-		return "", false, err
-	}
-
-	start := int64(1 + discardBytesPreVector + 2 + 4*vecLen + 2 + classNameLen + 4)
-	end := start + int64(propsLen)
-
-	// propsBytes := make([]byte, propsLen)
-	// if _, err := r.Read(propsBytes); err != nil {
-	// 	return "", false, err
-	// }
-	propsBytes := data[start:end]
-	// _ = propsBytes
-	// return "", false, nil
-
-	var propsMap map[string]interface{}
-	// if err := json.Unmarshal(propsBytes, &propsMap); err != nil {
-	// 	return "", false, err
-	// }
-
-	if err := json.NewDecoder(bytes.NewReader(propsBytes)).Decode(&propsMap); err != nil {
-		return "", false, err
-	}
-
-	prop, ok := propsMap[propName]
-	if !ok {
-		return "", false, nil
-	}
-
-	return prop.(string), true, nil
+	return string(val), len(val) > 0, err
 }
 
-const discardBytesPreVector = 8 + 1 + 16 + 8 + 8
+func extractPropsBytes(data []byte) ([]byte, error) {
+	version := uint8(data[0])
+	if version != 1 {
+		return nil, errors.Errorf("unsupported binary marshaller version %d", version)
+	}
+
+	vecLen := binary.LittleEndian.Uint16(data[discardBytesPreVector : discardBytesPreVector+2])
+
+	classNameStart := discardBytesPreVector + 2 + vecLen*4
+
+	classNameLen := binary.LittleEndian.Uint16(data[classNameStart : classNameStart+2])
+
+	propsLenStart := classNameStart + 2 + classNameLen
+	propsLen := binary.LittleEndian.Uint32(data[propsLenStart : propsLenStart+4])
+
+	start := int64(propsLenStart + 4)
+	end := start + int64(propsLen)
+
+	return data[start:end], nil
+}
+
+const discardBytesPreVector = 1 + 8 + 1 + 16 + 8 + 8

--- a/adapters/repos/db/storobj/storage_object_test.go
+++ b/adapters/repos/db/storobj/storage_object_test.go
@@ -68,6 +68,13 @@ func TestStorageObjectMarshalling(t *testing.T) {
 		require.Nil(t, err)
 		assert.Equal(t, uint64(7), id)
 	})
+
+	t.Run("extract single text prop", func(t *testing.T) {
+		prop, ok, err := ParseAndExtractTextProp(asBinary, "name")
+		require.Nil(t, err)
+		require.True(t, ok)
+		assert.Equal(t, "MyName", prop)
+	})
 }
 
 func TestNewStorageObject(t *testing.T) {

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/semi-technologies/weaviate
 require (
 	github.com/asaskevich/govalidator v0.0.0-20210307081110-f21760c49a8d // indirect
 	github.com/bmatcuk/doublestar v1.1.3
+	github.com/buger/jsonparser v1.1.1 // indirect
 	github.com/coreos/go-oidc v2.0.0+incompatible
 	github.com/danaugrs/go-tsne v0.0.0-20200708172100-6b7d1d577fd3
 	github.com/davecgh/go-spew v1.1.1

--- a/go.sum
+++ b/go.sum
@@ -20,6 +20,8 @@ github.com/aws/aws-sdk-go v1.34.28/go.mod h1:H7NKnBqNVzoTJpGfLrQkkD+ytBA93eiDYi/
 github.com/bmatcuk/doublestar v1.1.3 h1:S4Ka/fLvUtm+5TqKuByWyuGenBjTP8w+Z/GpQIWB9Yg=
 github.com/bmatcuk/doublestar v1.1.3/go.mod h1:wiQtGV+rzVYxB7WIlirSN++5HPtPlXEo9MEoZQC/PmE=
 github.com/boombuler/barcode v1.0.0/go.mod h1:paBWMcWSl3LHKBqUq+rly7CNSldXjb2rDl3JlRe0mD8=
+github.com/buger/jsonparser v1.1.1 h1:2PnMjfWD7wBILjqQbt530v576A/cAbQvEW9gGIpYMUs=
+github.com/buger/jsonparser v1.1.1/go.mod h1:6RYKKt7H4d4+iWqouImQ9R2FZql3VbhNgx27UK13J/0=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
 github.com/coreos/go-oidc v2.0.0+incompatible h1:+RStIopZ8wooMx+Vs5Bt8zMXxV1ABl5LbakNExNmZIg=
 github.com/coreos/go-oidc v2.0.0+incompatible/go.mod h1:CgnwVTmzoESiwO9qyAFEMiHoZ1nMCKZlZ9V6mm3/LKc=


### PR DESCRIPTION
- gh-1616 reduce allocations for 'replace' cursor
- gh-1616 reduce allocs when aggregating single prop
- gh-1616 exchange json parser and remove unnecessary allocations
- gh-1617 add missing segment group lock to cursors

closes #1616
closes #1617
