### PR TITLE
1.5.0 rc.3 profiling cleanups

### DIFF
--- a/adapters/repos/db/lsmkv/compaction_integration_test.go
+++ b/adapters/repos/db/lsmkv/compaction_integration_test.go
@@ -31,7 +31,7 @@ func testCtx() context.Context {
 }
 
 func Test_CompactionReplaceStrategy(t *testing.T) {
-	size := 20
+	size := 200
 
 	type kv struct {
 		key    []byte
@@ -59,8 +59,8 @@ func Test_CompactionReplaceStrategy(t *testing.T) {
 		// 3.) created in the first segment, deleted in the second
 		// 4.) not present in the first segment, created in the second
 		for i := 0; i < size; i++ {
-			key := []byte(fmt.Sprintf("key-%2d", i))
-			originalValue := []byte(fmt.Sprintf("value-%2d-original", i))
+			key := []byte(fmt.Sprintf("key-%3d", i))
+			originalValue := []byte(fmt.Sprintf("value-%3d-original", i))
 
 			switch i % 4 {
 			case 0:
@@ -83,7 +83,7 @@ func Test_CompactionReplaceStrategy(t *testing.T) {
 				})
 
 				// update in the second segment
-				updatedValue := []byte(fmt.Sprintf("value-%2d-updated", i))
+				updatedValue := []byte(fmt.Sprintf("value-%3d-updated", i))
 				segment2 = append(segment2, kv{
 					key:   key,
 					value: updatedValue,
@@ -1032,7 +1032,7 @@ func Test_CompactionSetStrategy_RemoveUnnecessary(t *testing.T) {
 }
 
 func Test_CompactionMapStrategy(t *testing.T) {
-	size := 9
+	size := 999
 
 	type kv struct {
 		key    []byte
@@ -1073,15 +1073,15 @@ func Test_CompactionMapStrategy(t *testing.T) {
 		// 8.) present in an unrelated previous segment, deleted in the first
 		// 9.) present in an unrelated previous segment, deleted in the second
 		for i := 0; i < size; i++ {
-			rowKey := []byte(fmt.Sprintf("row-%2d", i))
+			rowKey := []byte(fmt.Sprintf("row-%3d", i))
 
 			pair1 := MapPair{
-				Key:   []byte(fmt.Sprintf("value-%2d-01", i)),
-				Value: []byte(fmt.Sprintf("value-%2d-01-original", i)),
+				Key:   []byte(fmt.Sprintf("value-%3d-01", i)),
+				Value: []byte(fmt.Sprintf("value-%3d-01-original", i)),
 			}
 			pair2 := MapPair{
-				Key:   []byte(fmt.Sprintf("value-%2d-02", i)),
-				Value: []byte(fmt.Sprintf("value-%2d-02-original", i)),
+				Key:   []byte(fmt.Sprintf("value-%3d-02", i)),
+				Value: []byte(fmt.Sprintf("value-%3d-02-original", i)),
 			}
 			pairs := []MapPair{pair1, pair2}
 

--- a/adapters/repos/db/lsmkv/compactor_map.go
+++ b/adapters/repos/db/lsmkv/compactor_map.go
@@ -31,17 +31,21 @@ type compactorMap struct {
 
 	w    io.WriteSeeker
 	bufw *bufio.Writer
+
+	scratchSpacePath string
 }
 
 func newCompactorMapCollection(w io.WriteSeeker,
-	c1, c2 *segmentCursorCollection, level, secondaryIndexCount uint16) *compactorMap {
+	c1, c2 *segmentCursorCollection, level, secondaryIndexCount uint16,
+	scratchSpacePath string) *compactorMap {
 	return &compactorMap{
 		c1:                  c1,
 		c2:                  c2,
 		w:                   w,
-		bufw:                bufio.NewWriter(w),
+		bufw:                bufio.NewWriterSize(w, 256*1024),
 		currentLevel:        level,
 		secondaryIndexCount: secondaryIndexCount,
+		scratchSpacePath:    scratchSpacePath,
 	}
 }
 
@@ -165,6 +169,7 @@ func (c *compactorMap) writeIndices(keys []keyIndex) error {
 	indices := segmentIndices{
 		keys:                keys,
 		secondaryIndexCount: c.secondaryIndexCount,
+		scratchSpacePath:    c.scratchSpacePath,
 	}
 
 	_, err := indices.WriteTo(c.bufw)

--- a/adapters/repos/db/lsmkv/compactor_replace.go
+++ b/adapters/repos/db/lsmkv/compactor_replace.go
@@ -30,19 +30,22 @@ type compactorReplace struct {
 
 	secondaryIndexCount uint16
 
-	w    io.WriteSeeker
-	bufw *bufio.Writer
+	w                io.WriteSeeker
+	bufw             *bufio.Writer
+	scratchSpacePath string
 }
 
 func newCompactorReplace(w io.WriteSeeker,
-	c1, c2 *segmentCursorReplace, level, secondaryIndexCount uint16) *compactorReplace {
+	c1, c2 *segmentCursorReplace, level, secondaryIndexCount uint16,
+	scratchSpacePath string) *compactorReplace {
 	return &compactorReplace{
 		c1:                  c1,
 		c2:                  c2,
 		w:                   w,
-		bufw:                bufio.NewWriterSize(w, 1e6),
+		bufw:                bufio.NewWriterSize(w, 256*1024),
 		currentLevel:        level,
 		secondaryIndexCount: secondaryIndexCount,
+		scratchSpacePath:    scratchSpacePath,
 	}
 }
 
@@ -162,6 +165,7 @@ func (c *compactorReplace) writeIndices(keys []keyIndex) error {
 	indices := &segmentIndices{
 		keys:                keys,
 		secondaryIndexCount: c.secondaryIndexCount,
+		scratchSpacePath:    c.scratchSpacePath,
 	}
 
 	_, err := indices.WriteTo(c.bufw)

--- a/adapters/repos/db/lsmkv/compactor_set.go
+++ b/adapters/repos/db/lsmkv/compactor_set.go
@@ -31,17 +31,21 @@ type compactorSet struct {
 
 	w    io.WriteSeeker
 	bufw *bufio.Writer
+
+	scratchSpacePath string
 }
 
 func newCompactorSetCollection(w io.WriteSeeker,
-	c1, c2 *segmentCursorCollection, level, secondaryIndexCount uint16) *compactorSet {
+	c1, c2 *segmentCursorCollection, level, secondaryIndexCount uint16,
+	scratchSpacePath string) *compactorSet {
 	return &compactorSet{
 		c1:                  c1,
 		c2:                  c2,
 		w:                   w,
-		bufw:                bufio.NewWriterSize(w, 1e6),
+		bufw:                bufio.NewWriterSize(w, 256*1024),
 		currentLevel:        level,
 		secondaryIndexCount: secondaryIndexCount,
+		scratchSpacePath:    scratchSpacePath,
 	}
 }
 
@@ -157,6 +161,7 @@ func (c *compactorSet) writeIndices(keys []keyIndex) error {
 	indices := &segmentIndices{
 		keys:                keys,
 		secondaryIndexCount: c.secondaryIndexCount,
+		scratchSpacePath:    c.scratchSpacePath,
 	}
 
 	_, err := indices.WriteTo(c.bufw)

--- a/adapters/repos/db/lsmkv/memtable_flush.go
+++ b/adapters/repos/db/lsmkv/memtable_flush.go
@@ -61,6 +61,7 @@ func (l *Memtable) flush() error {
 	indices := &segmentIndices{
 		keys:                keys,
 		secondaryIndexCount: l.secondaryIndices,
+		scratchSpacePath:    l.path + ".scratch.d",
 	}
 
 	if _, err := indices.WriteTo(w); err != nil {

--- a/adapters/repos/db/lsmkv/segment_group_compaction.go
+++ b/adapters/repos/db/lsmkv/segment_group_compaction.go
@@ -94,6 +94,8 @@ func (ig *SegmentGroup) compactOnce() error {
 		return err
 	}
 
+	scratchSpacePath := ig.segments[pair[1]].path + "compaction.scratch.d"
+
 	// the assumption is that both pairs are of the same level, so we can just
 	// take either value. If we want to support asymmetric compaction, then we
 	// might have to choose this value more intelligently
@@ -104,21 +106,23 @@ func (ig *SegmentGroup) compactOnce() error {
 	switch strategy {
 	case SegmentStrategyReplace:
 		c := newCompactorReplace(f, ig.segments[pair[0]].newCursor(),
-			ig.segments[pair[1]].newCursor(), level, secondaryIndices)
+			ig.segments[pair[1]].newCursor(), level, secondaryIndices, scratchSpacePath)
 
 		if err := c.do(); err != nil {
 			return err
 		}
 	case SegmentStrategySetCollection:
 		c := newCompactorSetCollection(f, ig.segments[pair[0]].newCollectionCursor(),
-			ig.segments[pair[1]].newCollectionCursor(), level, secondaryIndices)
+			ig.segments[pair[1]].newCollectionCursor(), level, secondaryIndices,
+			scratchSpacePath)
 
 		if err := c.do(); err != nil {
 			return err
 		}
 	case SegmentStrategyMapCollection:
 		c := newCompactorMapCollection(f, ig.segments[pair[0]].newCollectionCursor(),
-			ig.segments[pair[1]].newCollectionCursor(), level, secondaryIndices)
+			ig.segments[pair[1]].newCollectionCursor(), level, secondaryIndices,
+			scratchSpacePath)
 
 		if err := c.do(); err != nil {
 			return err

--- a/adapters/repos/db/lsmkv/segment_serialization.go
+++ b/adapters/repos/db/lsmkv/segment_serialization.go
@@ -137,7 +137,7 @@ type segmentIndices struct {
 	secondaryIndexCount uint16
 }
 
-func (s *segmentIndices) WriteTo(w io.Writer) (int64, error) {
+func (s segmentIndices) WriteTo(w io.Writer) (int64, error) {
 	currentOffset := uint64(s.keys[len(s.keys)-1].valueEnd)
 	var written int64
 	indexBytes, err := s.buildAndMarshalPrimary(s.keys)
@@ -458,7 +458,7 @@ type segmentCollectionNode struct {
 	offset     int
 }
 
-func (s *segmentCollectionNode) KeyIndexAndWriteTo(w io.Writer) (keyIndex, error) {
+func (s segmentCollectionNode) KeyIndexAndWriteTo(w io.Writer) (keyIndex, error) {
 	out := keyIndex{}
 	written := 0
 	valueLen := uint64(len(s.values))

--- a/adapters/repos/db/lsmkv/segment_serialization.go
+++ b/adapters/repos/db/lsmkv/segment_serialization.go
@@ -12,9 +12,12 @@
 package lsmkv
 
 import (
+	"bufio"
 	"bytes"
 	"encoding/binary"
 	"io"
+	"os"
+	"path/filepath"
 	"sort"
 
 	"github.com/pkg/errors"
@@ -135,39 +138,62 @@ func parseSegmentHeader(r io.Reader) (*segmentHeader, error) {
 type segmentIndices struct {
 	keys                []keyIndex
 	secondaryIndexCount uint16
+	scratchSpacePath    string
 }
 
 func (s segmentIndices) WriteTo(w io.Writer) (int64, error) {
 	currentOffset := uint64(s.keys[len(s.keys)-1].valueEnd)
 	var written int64
-	indexBytes, err := s.buildAndMarshalPrimary(s.keys)
+
+	if err := os.Mkdir(s.scratchSpacePath, 0o777); err != nil {
+		return written, errors.Wrap(err, "create scratch space")
+	}
+
+	primaryFileName := filepath.Join(s.scratchSpacePath, "primary")
+	primaryFD, err := os.Create(primaryFileName)
 	if err != nil {
 		return written, err
 	}
 
+	primaryFDBuffered := bufio.NewWriter(primaryFD)
+
+	n, err := s.buildAndMarshalPrimary(primaryFDBuffered, s.keys)
+	if err != nil {
+		return written, err
+	}
+
+	if err := primaryFDBuffered.Flush(); err != nil {
+		return written, err
+	}
+
+	primaryFD.Seek(0, io.SeekStart)
+
 	// pretend that primary index was already written, then also account for the
 	// additional offset pointers (one for each secondary index)
-	currentOffset = currentOffset + uint64(len(indexBytes)) +
+	currentOffset = currentOffset + uint64(n) +
 		uint64(s.secondaryIndexCount)*8
 
-	secondaryIndicesBytes := bytes.NewBuffer(nil)
+	// secondaryIndicesBytes := bytes.NewBuffer(nil)
+	secondaryFileName := filepath.Join(s.scratchSpacePath, "secondary")
+	secondaryFD, err := os.Create(secondaryFileName)
+	if err != nil {
+		return written, err
+	}
+
+	secondaryFDBuffered := bufio.NewWriter(secondaryFD)
 
 	if s.secondaryIndexCount > 0 {
 		offsets := make([]uint64, s.secondaryIndexCount)
 		for pos := range offsets {
-			secondaryBytes, err := s.buildAndMarshalSecondary(pos, s.keys)
+			n, err := s.buildAndMarshalSecondary(secondaryFDBuffered, pos, s.keys)
 			if err != nil {
-				return written, err
-			}
-
-			if n, err := secondaryIndicesBytes.Write(secondaryBytes); err != nil {
 				return written, err
 			} else {
 				written += int64(n)
 			}
 
 			offsets[pos] = currentOffset
-			currentOffset = offsets[pos] + uint64(len(secondaryBytes))
+			currentOffset = offsets[pos] + uint64(n)
 		}
 
 		if err := binary.Write(w, binary.LittleEndian, &offsets); err != nil {
@@ -177,18 +203,34 @@ func (s segmentIndices) WriteTo(w io.Writer) (int64, error) {
 		written += int64(len(offsets)) * 8
 	}
 
-	// write primary index
-	if n, err := w.Write(indexBytes); err != nil {
+	if err := secondaryFDBuffered.Flush(); err != nil {
+		return written, err
+	}
+
+	secondaryFD.Seek(0, io.SeekStart)
+
+	if n, err := io.Copy(w, primaryFD); err != nil {
 		return written, err
 	} else {
 		written += int64(n)
 	}
 
-	// write secondary indices
-	if n, err := secondaryIndicesBytes.WriteTo(w); err != nil {
+	if n, err := io.Copy(w, secondaryFD); err != nil {
 		return written, err
 	} else {
-		written += n
+		written += int64(n)
+	}
+
+	if err := primaryFD.Close(); err != nil {
+		return written, err
+	}
+
+	if err := secondaryFD.Close(); err != nil {
+		return written, err
+	}
+
+	if err := os.RemoveAll(s.scratchSpacePath); err != nil {
+		return written, err
 	}
 
 	return written, nil
@@ -196,8 +238,8 @@ func (s segmentIndices) WriteTo(w io.Writer) (int64, error) {
 
 // pos indicates the position of a secondary index, assumes unsorted keys and
 // sorts them
-func (s *segmentIndices) buildAndMarshalSecondary(pos int,
-	keys []keyIndex) ([]byte, error) {
+func (s *segmentIndices) buildAndMarshalSecondary(w io.Writer, pos int,
+	keys []keyIndex) (int64, error) {
 	keyNodes := make([]segmentindex.Node, len(keys))
 	i := 0
 	for _, key := range keys {
@@ -222,16 +264,16 @@ func (s *segmentIndices) buildAndMarshalSecondary(pos int,
 	})
 
 	index := segmentindex.NewBalanced(keyNodes)
-	indexBytes, err := index.MarshalBinary()
+	n, err := index.MarshalBinaryInto(w)
 	if err != nil {
-		return nil, err
+		return 0, err
 	}
 
-	return indexBytes, nil
+	return n, nil
 }
 
 // assumes sorted keys and does NOT sort them again
-func (s *segmentIndices) buildAndMarshalPrimary(keys []keyIndex) ([]byte, error) {
+func (s *segmentIndices) buildAndMarshalPrimary(w io.Writer, keys []keyIndex) (int64, error) {
 	keyNodes := make([]segmentindex.Node, len(keys))
 	for i, key := range keys {
 		keyNodes[i] = segmentindex.Node{
@@ -242,12 +284,12 @@ func (s *segmentIndices) buildAndMarshalPrimary(keys []keyIndex) ([]byte, error)
 	}
 	index := segmentindex.NewBalanced(keyNodes)
 
-	indexBytes, err := index.MarshalBinary()
+	n, err := index.MarshalBinaryInto(w)
 	if err != nil {
-		return nil, err
+		return -1, err
 	}
 
-	return indexBytes, nil
+	return n, nil
 }
 
 // a single node of strategy "replace"

--- a/adapters/repos/db/shard_write_batch_objects.go
+++ b/adapters/repos/db/shard_write_batch_objects.go
@@ -254,6 +254,12 @@ func (b *objectsBatcher) flushWALs(ctx context.Context) {
 			b.setErrorAtIndex(err, i)
 		}
 	}
+
+	if err := b.shard.vectorIndex.Flush(); err != nil {
+		for i := range b.objects {
+			b.setErrorAtIndex(err, i)
+		}
+	}
 }
 
 // returns the originalIndexIDs to be ignored

--- a/adapters/repos/db/shard_write_batch_references.go
+++ b/adapters/repos/db/shard_write_batch_references.go
@@ -307,4 +307,10 @@ func (b *referencesBatcher) flushWALs(ctx context.Context) {
 			b.setErrorAtIndex(err, i)
 		}
 	}
+
+	if err := b.shard.vectorIndex.Flush(); err != nil {
+		for i := range b.refs {
+			b.setErrorAtIndex(err, i)
+		}
+	}
 }

--- a/adapters/repos/db/shard_write_delete.go
+++ b/adapters/repos/db/shard_write_delete.go
@@ -63,6 +63,10 @@ func (s *Shard) deleteObject(ctx context.Context, id strfmt.UUID) error {
 		return errors.Wrap(err, "flush all buffered WALs")
 	}
 
+	if err := s.vectorIndex.Flush(); err != nil {
+		return errors.Wrap(err, "flush all vector index buffered WALs")
+	}
+
 	return nil
 }
 

--- a/adapters/repos/db/shard_write_merge.go
+++ b/adapters/repos/db/shard_write_merge.go
@@ -41,6 +41,10 @@ func (s *Shard) mergeObject(ctx context.Context, merge objects.MergeDocument) er
 		return errors.Wrap(err, "flush all buffered WALs")
 	}
 
+	if err := s.vectorIndex.Flush(); err != nil {
+		return errors.Wrap(err, "flush all vector index buffered WALs")
+	}
+
 	return nil
 }
 

--- a/adapters/repos/db/shard_write_put.go
+++ b/adapters/repos/db/shard_write_put.go
@@ -49,6 +49,10 @@ func (s *Shard) putObject(ctx context.Context, object *storobj.Object) error {
 		return errors.Wrap(err, "flush all buffered WALs")
 	}
 
+	if err := s.vectorIndex.Flush(); err != nil {
+		return errors.Wrap(err, "flush all vector index buffered WALs")
+	}
+
 	return nil
 }
 

--- a/adapters/repos/db/vector/hnsw/commit_logger_buffered_links_logger.go
+++ b/adapters/repos/db/vector/hnsw/commit_logger_buffered_links_logger.go
@@ -64,7 +64,7 @@ func (b *bufferedLinksLogger) Close() error {
 	b.base.Lock()
 	defer b.base.Unlock()
 
-	_, err := b.base.logFile.Write(b.buf.Bytes())
+	_, err := b.base.logWriter.Write(b.buf.Bytes())
 	if err != nil {
 		return errors.Wrap(err, "flush link buffer to commit logger")
 	}

--- a/adapters/repos/db/vector/hnsw/commit_logger_noop.go
+++ b/adapters/repos/db/vector/hnsw/commit_logger_noop.go
@@ -19,6 +19,10 @@ func (n *NoopCommitLogger) AddNode(node *vertex) error {
 	return nil
 }
 
+func (n *NoopCommitLogger) Flush() error {
+	return nil
+}
+
 func (n *NoopCommitLogger) SetEntryPointWithMaxLayer(id uint64, level int) error {
 	return nil
 }

--- a/adapters/repos/db/vector/hnsw/condensor_integration_test.go
+++ b/adapters/repos/db/vector/hnsw/condensor_integration_test.go
@@ -84,7 +84,7 @@ func TestCondensor(t *testing.T) {
 		uncondensed.SetEntryPointWithMaxLayer(3, 3)
 		uncondensed.AddTombstone(2)
 
-		time.Sleep(100 * time.Millisecond) // make sure evertyhing is flushed
+		require.Nil(t, uncondensed.Flush())
 	})
 
 	t.Run("create a hypothetical perfect log", func(t *testing.T) {
@@ -105,7 +105,7 @@ func TestCondensor(t *testing.T) {
 		perfect.SetEntryPointWithMaxLayer(3, 3)
 		perfect.AddTombstone(2)
 
-		time.Sleep(100 * time.Millisecond) // make sure evertyhing is flushed
+		require.Nil(t, perfect.Flush())
 	})
 
 	t.Run("condense the original and verify against the perfect one", func(t *testing.T) {
@@ -158,7 +158,7 @@ func TestCondensorWithoutEntrypoint(t *testing.T) {
 	t.Run("add data, but do not set an entrypoint", func(t *testing.T) {
 		uncondensed.AddNode(&vertex{id: 0, level: 3})
 
-		time.Sleep(100 * time.Millisecond) // make sure evertyhing is flushed
+		require.Nil(t, uncondensed.Flush())
 	})
 
 	t.Run("condense the original and verify it doesn't overwrite the EP", func(t *testing.T) {

--- a/adapters/repos/db/vector/hnsw/index.go
+++ b/adapters/repos/db/vector/hnsw/index.go
@@ -110,6 +110,7 @@ type CommitLogger interface {
 	Reset() error
 	Drop() error
 	NewBufferedLinksLogger() BufferedLinksLogger
+	Flush() error
 }
 
 type BufferedLinksLogger interface {
@@ -492,4 +493,8 @@ func (h *hnsw) Drop() error {
 	// cancel tombstone cleanup goroutine
 	h.cancel <- struct{}{}
 	return nil
+}
+
+func (h *hnsw) Flush() error {
+	return h.commitLog.Flush()
 }

--- a/adapters/repos/db/vector/hnsw/index_corrupt_commitlogs_integration_test.go
+++ b/adapters/repos/db/vector/hnsw/index_corrupt_commitlogs_integration_test.go
@@ -82,6 +82,8 @@ func TestStartupWithCorruptCondenseFiles(t *testing.T) {
 		}
 	})
 
+	index.Flush()
+
 	t.Run("create a corrupt commit log file without deleting the original",
 		func(t *testing.T) {
 			input, ok, err := getCurrentCommitLogFileName(commitLogDirectory(rootPath,

--- a/adapters/repos/db/vector/hnsw/insert.go
+++ b/adapters/repos/db/vector/hnsw/insert.go
@@ -157,7 +157,7 @@ func (h *hnsw) selectNeighborsHeuristic(input *priorityqueue.Queue,
 		closestFirst.Insert(elem.ID, elem.Dist)
 	}
 
-	returnList := []priorityqueue.Item{}
+	returnList := make([]*priorityqueue.Item, 0, max)
 
 	for closestFirst.Len() > 0 && len(returnList) < max {
 		curr := closestFirst.Pop()
@@ -185,7 +185,7 @@ func (h *hnsw) selectNeighborsHeuristic(input *priorityqueue.Queue,
 		}
 
 		if good {
-			returnList = append(returnList, curr)
+			returnList = append(returnList, &curr)
 		}
 
 	}

--- a/adapters/repos/db/vector/hnsw/persistence_integration_test.go
+++ b/adapters/repos/db/vector/hnsw/persistence_integration_test.go
@@ -58,6 +58,8 @@ func TestHnswPersistence(t *testing.T) {
 		require.Nil(t, err)
 	}
 
+	require.Nil(t, index.Flush())
+
 	// see index_test.go for more context
 	expectedResults := []uint64{
 		3, 5, 4, // cluster 2
@@ -143,6 +145,8 @@ func TestHnswPersistence_WithDeletion_WithoutTombstoneCleanup(t *testing.T) {
 		2, 1, 0, // cluster 1
 	}
 
+	require.Nil(t, index.Flush())
+
 	t.Run("verify that the results match originally", func(t *testing.T) {
 		position := 3
 		res, err := index.knnSearchByVector(testVectors[position], 50, 36, nil)
@@ -208,7 +212,8 @@ func TestHnswPersistence_WithDeletion_WithTombstoneCleanup(t *testing.T) {
 		err := index.Add(uint64(i), vec)
 		require.Nil(t, err)
 	}
-	// dumpIndex(index, "with cleanup after import")
+	dumpIndex(index, "with cleanup after import")
+	require.Nil(t, index.Flush())
 
 	t.Run("delete some elements and permanently delete tombstoned elements",
 		func(t *testing.T) {
@@ -221,7 +226,9 @@ func TestHnswPersistence_WithDeletion_WithTombstoneCleanup(t *testing.T) {
 			require.Nil(t, err)
 		})
 
-	// dumpIndex(index, "with cleanup after delete")
+	dumpIndex(index, "with cleanup after delete")
+
+	require.Nil(t, index.Flush())
 
 	// see index_test.go for more context
 	expectedResults := []uint64{
@@ -252,7 +259,7 @@ func TestHnswPersistence_WithDeletion_WithTombstoneCleanup(t *testing.T) {
 		EFConstruction: 60,
 	})
 	require.Nil(t, err)
-	// dumpIndex(secondIndex, "with cleanup second index")
+	dumpIndex(secondIndex, "with cleanup second index")
 
 	t.Run("verify that the results match after rebuiling from disk",
 		func(t *testing.T) {
@@ -277,7 +284,9 @@ func TestHnswPersistence_WithDeletion_WithTombstoneCleanup(t *testing.T) {
 		require.Nil(t, err)
 	})
 
-	// dumpIndex(secondIndex)
+	require.Nil(t, secondIndex.Flush())
+
+	dumpIndex(secondIndex)
 
 	secondIndex = nil
 	// build a new index from the (uncondensed) commit log
@@ -293,7 +302,7 @@ func TestHnswPersistence_WithDeletion_WithTombstoneCleanup(t *testing.T) {
 	})
 	require.Nil(t, err)
 
-	// dumpIndex(thirdIndex)
+	dumpIndex(thirdIndex)
 
 	t.Run("verify that the results match after rebuiling from disk",
 		func(t *testing.T) {
@@ -314,6 +323,8 @@ func TestHnswPersistence_WithDeletion_WithTombstoneCleanup(t *testing.T) {
 		err = thirdIndex.CleanUpTombstonedNodes()
 		require.Nil(t, err)
 	})
+
+	require.Nil(t, thirdIndex.Flush())
 
 	thirdIndex = nil
 	// build a new index from the (uncondensed) commit log

--- a/adapters/repos/db/vector/hnsw/priorityqueue/queue_test.go
+++ b/adapters/repos/db/vector/hnsw/priorityqueue/queue_test.go
@@ -80,8 +80,3 @@ func TestPriorityQueueMax(t *testing.T) {
 
 	assert.Equal(t, expectedResults, results)
 }
-
-func BenchPriorityQueueMin(b *testing.B) {
-	for i := 0; i < b.N; i++ {
-	}
-}

--- a/adapters/repos/db/vector/hnsw/priorityqueue/queue_test.go
+++ b/adapters/repos/db/vector/hnsw/priorityqueue/queue_test.go
@@ -80,3 +80,8 @@ func TestPriorityQueueMax(t *testing.T) {
 
 	assert.Equal(t, expectedResults, results)
 }
+
+func BenchPriorityQueueMin(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+	}
+}

--- a/adapters/repos/db/vector/noop/index.go
+++ b/adapters/repos/db/vector/noop/index.go
@@ -45,3 +45,7 @@ func (i *Index) Drop() error {
 	// silently ignore
 	return nil
 }
+
+func (i *Index) Flush() error {
+	return nil
+}

--- a/adapters/repos/db/vector_index.go
+++ b/adapters/repos/db/vector_index.go
@@ -24,4 +24,5 @@ type VectorIndex interface {
 	SearchByVector(vector []float32, k int, allow helpers.AllowList) ([]uint64, error)
 	UpdateUserConfig(updated schema.VectorIndexConfig) error
 	Drop() error
+	Flush() error
 }


### PR DESCRIPTION
- gh-1619 make all hnsw wals buffered
- gh-1619 do not use "double buffered" commit logger
- gh-1619 clean up map compactor
- gh-1619 use disk scratch space in segment serializer

closes #1619
