### PR TITLE
Fix/memory condensor zero alloc

### DIFF
--- a/adapters/repos/db/vector/hnsw/bufiowriter.go
+++ b/adapters/repos/db/vector/hnsw/bufiowriter.go
@@ -1,0 +1,175 @@
+package hnsw
+
+import (
+	"io"
+	"os"
+	"unicode/utf8"
+)
+
+const (
+	defaultBufSize = 4096
+)
+
+// bufWriter implements buffering for an *os.File object.
+// If an error occurs writing to a bufWriter, no more data will be
+// accepted and all subsequent writes, and Flush, will return the error.
+// After all data has been written, the client should call the
+// Flush method to guarantee all data has been forwarded to
+// the underlying *os.File.
+type bufWriter struct {
+	err error
+	buf []byte
+	n   int
+	wr  *os.File
+}
+
+// NewWriterSize returns a new Writer whose buffer has at least the specified
+// size. If the argument *os.File is already a Writer with large enough
+// size, it returns the underlying Writer.
+func NewWriterSize(w *os.File, size int) *bufWriter {
+	if size <= 0 {
+		size = defaultBufSize
+	}
+	return &bufWriter{
+		buf: make([]byte, size),
+		wr:  w,
+	}
+}
+
+// NewWriter returns a new Writer whose buffer has the default size.
+func NewWriter(w *os.File) *bufWriter {
+	return NewWriterSize(w, defaultBufSize)
+}
+
+// Size returns the size of the underlying buffer in bytes.
+func (b *bufWriter) Size() int { return len(b.buf) }
+
+// Reset discards any unflushed buffered data, clears any error, and
+// resets b to write its output to w.
+func (b *bufWriter) Reset(w *os.File) {
+	b.err = nil
+	b.n = 0
+	b.wr = w
+}
+
+// Flush writes any buffered data to the underlying *os.File.
+func (b *bufWriter) Flush() error {
+	if b.err != nil {
+		return b.err
+	}
+	if b.n == 0 {
+		return nil
+	}
+	n, err := b.wr.Write(b.buf[0:b.n])
+	if n < b.n && err == nil {
+		err = io.ErrShortWrite
+	}
+	if err != nil {
+		if n > 0 && n < b.n {
+			copy(b.buf[0:b.n-n], b.buf[n:b.n])
+		}
+		b.n -= n
+		b.err = err
+		return err
+	}
+	b.n = 0
+	return nil
+}
+
+// Available returns how many bytes are unused in the buffer.
+func (b *bufWriter) Available() int { return len(b.buf) - b.n }
+
+// Buffered returns the number of bytes that have been written into the current buffer.
+func (b *bufWriter) Buffered() int { return b.n }
+
+// Write writes the contents of p into the buffer.
+// It returns the number of bytes written.
+// If nn < len(p), it also returns an error explaining
+// why the write is short.
+func (b *bufWriter) Write(p []byte) (nn int, err error) {
+	for len(p) > b.Available() && b.err == nil {
+		var n int
+		if b.Buffered() == 0 {
+			// Large write, empty buffer.
+			// Write directly from p to avoid copy.
+			n, b.err = b.wr.Write(p)
+		} else {
+			n = copy(b.buf[b.n:], p)
+			b.n += n
+			b.Flush()
+		}
+		nn += n
+		p = p[n:]
+	}
+	if b.err != nil {
+		return nn, b.err
+	}
+	n := copy(b.buf[b.n:], p)
+	b.n += n
+	nn += n
+	return nn, nil
+}
+
+// WriteByte writes a single byte.
+func (b *bufWriter) WriteByte(c byte) error {
+	if b.err != nil {
+		return b.err
+	}
+	if b.Available() <= 0 && b.Flush() != nil {
+		return b.err
+	}
+	b.buf[b.n] = c
+	b.n++
+	return nil
+}
+
+// WriteRune writes a single Unicode code point, returning
+// the number of bytes written and any error.
+func (b *bufWriter) WriteRune(r rune) (size int, err error) {
+	if r < utf8.RuneSelf {
+		err = b.WriteByte(byte(r))
+		if err != nil {
+			return 0, err
+		}
+		return 1, nil
+	}
+	if b.err != nil {
+		return 0, b.err
+	}
+	n := b.Available()
+	if n < utf8.UTFMax {
+		if b.Flush(); b.err != nil {
+			return 0, b.err
+		}
+		n = b.Available()
+		if n < utf8.UTFMax {
+			// Can only happen if buffer is silly small.
+			return b.WriteString(string(r))
+		}
+	}
+	size = utf8.EncodeRune(b.buf[b.n:], r)
+	b.n += size
+	return size, nil
+}
+
+// WriteString writes a string.
+// It returns the number of bytes written.
+// If the count is less than len(s), it also returns an error explaining
+// why the write is short.
+func (b *bufWriter) WriteString(s string) (int, error) {
+	nn := 0
+	for len(s) > b.Available() && b.err == nil {
+		n := copy(b.buf[b.n:], s)
+		b.n += n
+		nn += n
+		s = s[n:]
+		b.Flush()
+	}
+	if b.err != nil {
+		return nn, b.err
+	}
+	n := copy(b.buf[b.n:], s)
+	b.n += n
+	nn += n
+	return nn, nil
+}

--- a/adapters/repos/db/vector/hnsw/commit_logger.go
+++ b/adapters/repos/db/vector/hnsw/commit_logger.go
@@ -44,7 +44,7 @@ func NewCommitLogger(rootPath, name string,
 		rootPath:             rootPath,
 		id:                   name,
 		maintainenceInterval: maintainenceInterval,
-		condensor:            NewMemoryCondensor(logger),
+		condensor:            NewMemoryCondensor2(logger),
 		logger:               logger,
 		maxSize:              maxUncondensedCommitLogSize, // TODO: make configurable
 	}

--- a/adapters/repos/db/vector/hnsw/condensor2.go
+++ b/adapters/repos/db/vector/hnsw/condensor2.go
@@ -131,8 +131,9 @@ func (c *MemoryCondensor2) writeCommitType(w *bufWriter, in HnswCommitType) erro
 }
 
 func (c *MemoryCondensor2) writeUint64Slice(w *bufWriter, in []uint64) error {
-	buf := make([]byte, 64)
-	for i := 0; i < len(in); i++{
+	buf := make([]byte, 8*len(in))
+	i := 0
+	for i < len(in){
 		if i != 0 && i%8 == 0 {
 			if _, err := w.Write(buf); err != nil {
 				return err
@@ -143,6 +144,19 @@ func (c *MemoryCondensor2) writeUint64Slice(w *bufWriter, in []uint64) error {
 		start := pos * 8
 		end := start + 8
 		binary.LittleEndian.PutUint64(buf[start:end], in[i])
+		i++
+	}
+
+	if i != 0 {
+		start := 0
+		end := i % 8 * 8
+		if end == 0 {
+			end = 64
+		}
+
+		if _, err := w.Write(buf[start:end]); err != nil {
+			return err
+		}
 	}
 
 	return nil

--- a/adapters/repos/db/vector/hnsw/condensor2.go
+++ b/adapters/repos/db/vector/hnsw/condensor2.go
@@ -1,0 +1,201 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2021 SeMI Technologies B.V. All rights reserved.
+//
+//  CONTACT: hello@semi.technology
+//
+
+package hnsw
+
+import (
+	"bufio"
+	"encoding/binary"
+	"fmt"
+	"math"
+	"os"
+
+	"github.com/pkg/errors"
+	"github.com/sirupsen/logrus"
+)
+
+type MemoryCondensor2 struct {
+	newLogFile *os.File
+	newLog     *bufWriter
+	logger     logrus.FieldLogger
+}
+
+func (c *MemoryCondensor2) Do(fileName string) error {
+	fd, err := os.Open(fileName)
+	if err != nil {
+		return errors.Wrap(err, "open commit log to be condensed")
+	}
+	fdBuf := bufio.NewReaderSize(fd, 256*1024)
+
+	res, err := NewDeserializer(c.logger).Do(fdBuf, nil)
+	if err != nil {
+		return errors.Wrap(err, "read commit log to be condensed")
+	}
+
+	newLogFile, err := os.OpenFile(fmt.Sprintf("%s.condensed", fileName),
+		os.O_WRONLY|os.O_APPEND|os.O_CREATE, 0o666)
+	if err != nil {
+		return errors.Wrap(err, "open new commit log file for writing")
+	}
+
+	c.newLogFile = newLogFile
+
+	c.newLog = NewWriterSize(c.newLogFile, 1*1024*1024)
+
+	for _, node := range res.Nodes {
+		if node == nil {
+			// nil nodes occur when we've grown, but not inserted anything yet
+			continue
+		}
+
+		if err := c.AddNode(node); err != nil {
+			return errors.Wrapf(err, "write node %d to commit log", node.id)
+		}
+
+		for level, links := range node.connections {
+			if err := c.SetLinksAtLevel(node.id, level, links); err != nil {
+				return errors.Wrapf(err,
+					"write links for node %d at level %dto commit log", node.id, level)
+			}
+		}
+	}
+
+	if res.EntrypointChanged {
+		if err := c.SetEntryPointWithMaxLayer(res.Entrypoint,
+			int(res.Level)); err != nil {
+			return errors.Wrap(err, "write entrypoint to commit log")
+		}
+	}
+
+	for ts := range res.Tombstones {
+		if err := c.AddTombstone(ts); err != nil {
+			return errors.Wrapf(err,
+				"write tombstone for node %d to commit log", ts)
+		}
+	}
+
+	if err := c.newLog.Flush(); err != nil {
+		return errors.Wrap(err, "close new commit log")
+	}
+
+	if err := c.newLogFile.Close(); err != nil {
+		return errors.Wrap(err, "close new commit log")
+	}
+
+	if err := os.Remove(fileName); err != nil {
+		return errors.Wrap(err, "cleanup old (uncondensed) commit log")
+	}
+
+	return nil
+}
+
+func (c *MemoryCondensor2) writeUint64(w *bufWriter, in uint64) error {
+	toWrite := make([]byte, 8)
+	binary.LittleEndian.PutUint64(toWrite[0:8], in)
+	_, err := w.Write(toWrite)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (c *MemoryCondensor2) writeUint16(w *bufWriter, in uint16) error {
+	toWrite := make([]byte, 2)
+	binary.LittleEndian.PutUint16(toWrite, in)
+	_, err := w.Write(toWrite)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (c *MemoryCondensor2) writeCommitType(w *bufWriter, in HnswCommitType) error {
+	toWrite := make([]byte, 1)
+	toWrite[0] = byte(in)
+	_, err := w.Write(toWrite)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (c *MemoryCondensor2) writeUint64Slice(w *bufWriter, in []uint64) error {
+	buf := make([]byte, 64)
+	for i := 0; i < len(in); i++{
+		if i != 0 && i%8 == 0 {
+			if _, err := w.Write(buf); err != nil {
+				return err
+			}
+		}
+
+		pos := i%8
+		start := pos * 8
+		end := start + 8
+		binary.LittleEndian.PutUint64(buf[start:end], in[i])
+	}
+
+	return nil
+}
+
+// AddNode adds an empty node
+func (c *MemoryCondensor2) AddNode(node *vertex) error {
+	ec := &errorCompounder{}
+	ec.add(c.writeCommitType(c.newLog, AddNode))
+	ec.add(c.writeUint64(c.newLog, node.id))
+	ec.add(c.writeUint16(c.newLog, uint16(node.level)))
+
+	return ec.toError()
+}
+
+func (c *MemoryCondensor2) SetLinksAtLevel(nodeid uint64, level int, targets []uint64) error {
+	ec := &errorCompounder{}
+	ec.add(c.writeCommitType(c.newLog, ReplaceLinksAtLevel))
+	ec.add(c.writeUint64(c.newLog, nodeid))
+	ec.add(c.writeUint16(c.newLog, uint16(level)))
+
+	targetLength := len(targets)
+	if targetLength > math.MaxUint16 {
+		// TODO: investigate why we get such massive connections
+		targetLength = math.MaxUint16
+		c.logger.WithField("action", "condense_commit_log").
+			WithField("original_length", len(targets)).
+			WithField("maximum_length", targetLength).
+			Warning("condensor length of connections would overflow uint16, cutting off")
+	}
+	ec.add(c.writeUint16(c.newLog, uint16(targetLength)))
+	ec.add(c.writeUint64Slice(c.newLog, targets[:targetLength]))
+
+	return ec.toError()
+}
+
+func (c *MemoryCondensor2) SetEntryPointWithMaxLayer(id uint64, level int) error {
+	ec := &errorCompounder{}
+	ec.add(c.writeCommitType(c.newLog, SetEntryPointMaxLevel))
+	ec.add(c.writeUint64(c.newLog, id))
+	ec.add(c.writeUint16(c.newLog, uint16(level)))
+
+	return ec.toError()
+}
+
+func (c *MemoryCondensor2) AddTombstone(nodeid uint64) error {
+	ec := &errorCompounder{}
+	ec.add(c.writeCommitType(c.newLog, AddTombstone))
+	ec.add(c.writeUint64(c.newLog, nodeid))
+
+	return ec.toError()
+}
+
+func NewMemoryCondensor2(logger logrus.FieldLogger) *MemoryCondensor2 {
+	return &MemoryCondensor2{logger: logger}
+}

--- a/adapters/repos/db/vector/hnsw/condensor2.go
+++ b/adapters/repos/db/vector/hnsw/condensor2.go
@@ -133,14 +133,14 @@ func (c *MemoryCondensor2) writeCommitType(w *bufWriter, in HnswCommitType) erro
 func (c *MemoryCondensor2) writeUint64Slice(w *bufWriter, in []uint64) error {
 	buf := make([]byte, 8*len(in))
 	i := 0
-	for i < len(in){
+	for i < len(in) {
 		if i != 0 && i%8 == 0 {
 			if _, err := w.Write(buf); err != nil {
 				return err
 			}
 		}
 
-		pos := i%8
+		pos := i % 8
 		start := pos * 8
 		end := start + 8
 		binary.LittleEndian.PutUint64(buf[start:end], in[i])

--- a/adapters/repos/db/vector/hnsw/condensor_integration_test.go
+++ b/adapters/repos/db/vector/hnsw/condensor_integration_test.go
@@ -194,7 +194,6 @@ func TestCondensorWithoutEntrypoint(t *testing.T) {
 		assert.Equal(t, uint64(17), res.Entrypoint)
 		assert.Equal(t, uint16(3), res.Level)
 
-		
 	})
 }
 

--- a/adapters/repos/db/vector/hnsw/condensor_integration_test.go
+++ b/adapters/repos/db/vector/hnsw/condensor_integration_test.go
@@ -114,7 +114,7 @@ func TestCondensor(t *testing.T) {
 		require.Nil(t, err)
 		require.True(t, ok)
 
-		err = NewMemoryCondensor(logger).Do(commitLogFileName(rootPath, "uncondensed", input))
+		err = NewMemoryCondensor2(logger).Do(commitLogFileName(rootPath, "uncondensed", input))
 		require.Nil(t, err)
 
 		control, ok, err := getCurrentCommitLogFileName(
@@ -167,7 +167,7 @@ func TestCondensorWithoutEntrypoint(t *testing.T) {
 		require.Nil(t, err)
 		require.True(t, ok)
 
-		err = NewMemoryCondensor(logger).Do(commitLogFileName(rootPath, "uncondensed", input))
+		err = NewMemoryCondensor2(logger).Do(commitLogFileName(rootPath, "uncondensed", input))
 		require.Nil(t, err)
 
 		actual, ok, err := getCurrentCommitLogFileName(
@@ -193,6 +193,8 @@ func TestCondensorWithoutEntrypoint(t *testing.T) {
 		assert.Contains(t, res.Nodes, &vertex{id: 0, level: 3, connections: map[int][]uint64{}})
 		assert.Equal(t, uint64(17), res.Entrypoint)
 		assert.Equal(t, uint16(3), res.Level)
+
+		
 	})
 }
 

--- a/adapters/repos/db/vector/hnsw/condensor_test.go
+++ b/adapters/repos/db/vector/hnsw/condensor_test.go
@@ -1,0 +1,133 @@
+package hnsw
+
+import (
+	_ "fmt"
+	"math/rand"
+	"testing"
+
+	std_bufio "bufio"
+
+	"github.com/sirupsen/logrus/hooks/test"
+	"github.com/stretchr/testify/assert"
+)
+
+
+func BenchmarkCondensorUint64Write(b *testing.B) {
+	b.StopTimer()
+	logger, _ := test.NewNullLogger()
+	c := NewMemoryCondensor(logger)
+	// c.newLog =  NewWriterSize(c.newLogFile, 1*1024*1024)
+	c.newLog = std_bufio.NewWriterSize(c.newLogFile, 1*1024*1024)
+	b.StartTimer()
+	for i := 0; i < b.N; i++ {
+		c.writeUint64(c.newLog, rand.Uint64())
+	}
+
+}
+
+func BenchmarkCondensor2NewUint64Write(b *testing.B) {
+	b.StopTimer()
+	logger, _ := test.NewNullLogger()
+	c := NewMemoryCondensor2(logger)
+	c.newLog = NewWriterSize(c.newLogFile, 1*1024*1024)
+	b.StartTimer()
+	for i := 0; i < b.N; i++ {
+		c.writeUint64(c.newLog, rand.Uint64())
+	}
+
+}
+
+func BenchmarkCondensorUint16Write(b *testing.B) {
+	b.StopTimer()
+	logger, _ := test.NewNullLogger()
+	c := NewMemoryCondensor(logger)
+	c.newLog = std_bufio.NewWriterSize(c.newLogFile, 1*1024*1024)
+	b.StartTimer()
+	for i := 0; i < b.N; i++ {
+		c.writeUint16(c.newLog, uint16(rand.Uint32()))
+	}
+}
+
+func BenchmarkCondensor2NewUint16Write(b *testing.B) {
+	b.StopTimer()
+	logger, _ := test.NewNullLogger()
+	c := NewMemoryCondensor2(logger)
+	c.newLog = NewWriterSize(c.newLogFile, 1*1024*1024)
+	b.StartTimer()
+	for i := 0; i < b.N; i++ {
+		c.writeUint16(c.newLog, uint16(rand.Uint32()))
+	}
+}
+
+func BenchmarkCondensorWriteCommitType(b *testing.B) {
+	b.StopTimer()
+	logger, _ := test.NewNullLogger()
+	c := NewMemoryCondensor(logger)
+	c.newLog = std_bufio.NewWriterSize(c.newLogFile, 1*1024*1024)
+	b.StartTimer()
+	for i := 0; i < b.N; i++ {
+		c.writeCommitType(c.newLog, HnswCommitType(1))
+	}
+}
+
+
+func BenchmarkCondensor2WriteCommitType(b *testing.B) {
+	b.StopTimer()
+	logger, _ := test.NewNullLogger()
+	c := NewMemoryCondensor2(logger)
+	c.newLog = NewWriterSize(c.newLogFile, 1*1024*1024)
+	b.StartTimer()
+	for i := 0; i < b.N; i++ {
+		c.writeCommitType(c.newLog, HnswCommitType(1))
+	}
+}
+
+
+func BenchmarkCondensorWriteUint64Slice(b *testing.B) {
+	b.StopTimer()
+	logger, _ := test.NewNullLogger()
+	c := NewMemoryCondensor(logger)
+	c.newLog = std_bufio.NewWriterSize(c.newLogFile, 1*1024*1024)
+	testInts := make([]uint64, 100)
+	for i := 0; i < 100; i++ {
+		testInts[i] = rand.Uint64()
+	}
+	b.StartTimer()
+	for i := 0; i < b.N; i++ {
+		c.writeUint64Slice(c.newLog, testInts)
+	}
+}
+
+func BenchmarkCondensor2WriteUint64Slice(b *testing.B) {
+	b.StopTimer()
+	logger, _ := test.NewNullLogger()
+	c := NewMemoryCondensor2(logger)
+	c.newLog = NewWriterSize(c.newLogFile, 1*1024*1024)
+	testInts := make([]uint64, 100)
+	for i := 0; i < 100; i++ {
+		testInts[i] = rand.Uint64()
+	}
+	b.StartTimer()
+	for i := 0; i < b.N; i++ {
+		c.writeUint64Slice(c.newLog, testInts)
+	}
+}
+
+func TestNewCondensorEqualsOld(t *testing.T) {
+	logger1, _ := test.NewNullLogger()
+	c1 := NewMemoryCondensor(logger1)
+	c1.newLog = std_bufio.NewWriterSize(c1.newLogFile, 1*1024*1024)
+
+	err := c1.writeUint64(c1.newLog, uint64(1))
+	if err != nil {
+		t.Error(err)
+	}
+
+	logger2, _ := test.NewNullLogger()
+	c2 := NewMemoryCondensor2(logger2)
+	c2.newLog = NewWriterSize(c1.newLogFile, 1*1024*1024)
+	c2.writeUint64(c2.newLog, uint64(1))
+
+	assert.Equal(t, c1.newLogFile, c2.newLogFile)
+
+}

--- a/adapters/repos/db/vector/hnsw/condensor_test.go
+++ b/adapters/repos/db/vector/hnsw/condensor_test.go
@@ -11,7 +11,6 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-
 func BenchmarkCondensorUint64Write(b *testing.B) {
 	b.StopTimer()
 	logger, _ := test.NewNullLogger()
@@ -70,7 +69,6 @@ func BenchmarkCondensorWriteCommitType(b *testing.B) {
 	}
 }
 
-
 func BenchmarkCondensor2WriteCommitType(b *testing.B) {
 	b.StopTimer()
 	logger, _ := test.NewNullLogger()
@@ -81,7 +79,6 @@ func BenchmarkCondensor2WriteCommitType(b *testing.B) {
 		c.writeCommitType(c.newLog, HnswCommitType(1))
 	}
 }
-
 
 func BenchmarkCondensorWriteUint64Slice(b *testing.B) {
 	b.StopTimer()


### PR DESCRIPTION
This PR provides on update on the current `MemoryCondensor` used by the HNSW index commit logger that uses the custom bufio writer to perform all of its writes rather than the `io.Writer` interface which was resulting in some unnecessary alloc overhead.

Included are some benchmarking tests to show the difference in allocations between the new and old condensor, the condensor integration test has also been updated to use the new condensor. 