### PR TITLE
gh-1770 make sure checksum is set correctly when merging OR

### DIFF
--- a/adapters/repos/db/inverted/merge.go
+++ b/adapters/repos/db/inverted/merge.go
@@ -110,7 +110,8 @@ func mergeOrAcceptDuplicates(in []*docPointers) (*docPointers, error) {
 	}
 
 	out := docPointers{
-		docIDs: make([]docPointer, size),
+		docIDs:   make([]docPointer, size),
+		checksum: combineSetChecksums(in, filters.OperatorOr),
 	}
 
 	index := 0


### PR DESCRIPTION
otherwise it could lead to false positives if combining AND and OR where
the second operand is the one that contains no matches as evidenced by
the new test.

closes #1770