### PR TITLE
gh-1781 add cluster-roundtrip for PATCH object

### DIFF
--- a/adapters/clients/remote_index.go
+++ b/adapters/clients/remote_index.go
@@ -304,6 +304,40 @@ func (c *RemoteIndex) DeleteObject(ctx context.Context, hostName, indexName,
 	return nil
 }
 
+func (c *RemoteIndex) MergeObject(ctx context.Context, hostName, indexName,
+	shardName string, mergeDoc objects.MergeDocument) error {
+	path := fmt.Sprintf("/indices/%s/shards/%s/objects/%s", indexName, shardName,
+		mergeDoc.ID)
+	method := http.MethodPatch
+	url := url.URL{Scheme: "http", Host: hostName, Path: path}
+
+	marshalled, err := clusterapi.IndicesPayloads.MergeDoc.Marshal(mergeDoc)
+	if err != nil {
+		return errors.Wrap(err, "marshal payload")
+	}
+
+	req, err := http.NewRequestWithContext(ctx, method, url.String(),
+		bytes.NewReader(marshalled))
+	if err != nil {
+		return errors.Wrap(err, "open http request")
+	}
+
+	clusterapi.IndicesPayloads.MergeDoc.SetContentTypeHeaderReq(req)
+	res, err := c.client.Do(req)
+	if err != nil {
+		return errors.Wrap(err, "send http request")
+	}
+
+	defer res.Body.Close()
+	if res.StatusCode != http.StatusNoContent {
+		body, _ := ioutil.ReadAll(res.Body)
+		return errors.Errorf("unexpected status code %d (%s)", res.StatusCode,
+			body)
+	}
+
+	return nil
+}
+
 func (c *RemoteIndex) MultiGetObjects(ctx context.Context, hostName, indexName,
 	shardName string, ids []strfmt.UUID) ([]*storobj.Object, error) {
 	idsBytes, err := json.Marshal(ids)

--- a/adapters/repos/db/fakes_for_test.go
+++ b/adapters/repos/db/fakes_for_test.go
@@ -113,6 +113,11 @@ func (f *fakeRemoteClient) DeleteObject(ctx context.Context, hostName, indexName
 	return nil
 }
 
+func (f *fakeRemoteClient) MergeObject(ctx context.Context, hostName, indexName,
+	shardName string, mergeDoc objects.MergeDocument) error {
+	return nil
+}
+
 func (f *fakeRemoteClient) MultiGetObjects(ctx context.Context, hostName, indexName,
 	shardName string, ids []strfmt.UUID) ([]*storobj.Object, error) {
 	return nil, nil

--- a/usecases/classification/integrationtest/fakes_for_integration_test.go
+++ b/usecases/classification/integrationtest/fakes_for_integration_test.go
@@ -337,6 +337,11 @@ func (f *fakeRemoteClient) DeleteObject(ctx context.Context, hostName, indexName
 	return nil
 }
 
+func (f *fakeRemoteClient) MergeObject(ctx context.Context, hostName, indexName,
+	shardName string, mergeDoc objects.MergeDocument) error {
+	return nil
+}
+
 func (f *fakeRemoteClient) SearchShard(ctx context.Context, hostName, indexName,
 	shardName string, vector []float32, limit int, filters *filters.LocalFilter,
 	additional additional.Properties) ([]*storobj.Object, []float32, error) {

--- a/usecases/objects/merge.go
+++ b/usecases/objects/merge.go
@@ -24,13 +24,13 @@ import (
 )
 
 type MergeDocument struct {
-	Class                string
-	ID                   strfmt.UUID
-	PrimitiveSchema      map[string]interface{}
-	References           BatchReferences
-	Vector               []float32
-	UpdateTime           int64
-	AdditionalProperties models.AdditionalProperties
+	Class                string                      `json:"class"`
+	ID                   strfmt.UUID                 `json:"id"`
+	PrimitiveSchema      map[string]interface{}      `json:"primitiveSchema"`
+	References           BatchReferences             `json:"references"`
+	Vector               []float32                   `json:"vector"`
+	UpdateTime           int64                       `json:"updateTime"`
+	AdditionalProperties models.AdditionalProperties `json:"additionalProperties"`
 }
 
 func (m *Manager) MergeObject(ctx context.Context, principal *models.Principal,

--- a/usecases/sharding/remote_index_incoming.go
+++ b/usecases/sharding/remote_index_incoming.go
@@ -43,6 +43,8 @@ type RemoteIndexIncomingRepo interface {
 		id strfmt.UUID) (bool, error)
 	IncomingDeleteObject(ctx context.Context, shardName string,
 		id strfmt.UUID) error
+	IncomingMergeObject(ctx context.Context, shardName string,
+		mergeDoc objects.MergeDocument) error
 	IncomingMultiGetObjects(ctx context.Context, shardName string,
 		ids []strfmt.UUID) ([]*storobj.Object, error)
 	IncomingSearch(ctx context.Context, shardName string,
@@ -123,6 +125,16 @@ func (rii *RemoteIndexIncoming) DeleteObject(ctx context.Context, indexName,
 	}
 
 	return index.IncomingDeleteObject(ctx, shardName, id)
+}
+
+func (rii *RemoteIndexIncoming) MergeObject(ctx context.Context, indexName,
+	shardName string, mergeDoc objects.MergeDocument) error {
+	index := rii.repo.GetIndexForIncoming(schema.ClassName(indexName))
+	if index == nil {
+		return errors.Errorf("local index %q not found", indexName)
+	}
+
+	return index.IncomingMergeObject(ctx, shardName, mergeDoc)
 }
 
 func (rii *RemoteIndexIncoming) MultiGetObjects(ctx context.Context, indexName,


### PR DESCRIPTION
marshals the payload as JSON under the assumption that this is not a
performance-bottleneck. If it becomes one, a binary protocal similarly
to the object list, etc. may be more appropriate.

closes #1781