### PR TITLE
Fix deprecation log field typo

### DIFF
--- a/deprecations/main.go
+++ b/deprecations/main.go
@@ -17,5 +17,5 @@ import "github.com/sirupsen/logrus"
 //go:generate goimports -w data.go
 
 func Log(logger logrus.FieldLogger, id string) {
-	logger.WithField("depreaction", ByID[id]).Warning(ByID[id].Msg)
+	logger.WithField("deprecation", ByID[id]).Warning(ByID[id].Msg)
 }


### PR DESCRIPTION
Hey all,

Was reading through the codebase and came across this typo. Considering that this is potentially user-facing (?) the correct spelling is probably warranted.

By the way, I really like the template+`go:generate` to handle the deprecation data. Very clever!