### PR TITLE
gh-1837 WEAVIATE-2 fix segfault by copying memory

### DIFF
--- a/adapters/repos/db/lsmkv/segment_collection_strategy.go
+++ b/adapters/repos/db/lsmkv/segment_collection_strategy.go
@@ -39,7 +39,23 @@ func (i *segment) getCollection(key []byte) ([]value, error) {
 		}
 	}
 
-	return i.collectionStratParseData(i.contents[node.Start:node.End])
+	// We need to copy the data we read from the segment exactly once in this
+	// place. This means that future processing can share this memory as much as
+	// it wants to, as it can now be considered immutable. If we didn't copy in
+	// this place it would only be safe to hold this data while still under the
+	// protection of the segmentGroup.maintenanceLock. This lock makes sure that
+	// no compaction is started during an ongoing read. However, as we could show
+	// as part of https://github.com/semi-technologies/weaviate/issues/1837
+	// further processing, such as map-decoding and eventually map-merging would
+	// happen inside the bucket.MapList() method. This scope has its own lock,
+	// but that lock can only protecting against flushing (i.e. changing the
+	// active/flushing memtable), not against removing the disk segment. If a
+	// compaction completes and the old segment is removed, we would be accessing
+	// invalid memory without the copy, thus leading to a SEGFAULT.
+	contentsCopy := make([]byte, node.End-node.Start)
+	copy(contentsCopy, i.contents[node.Start:node.End])
+
+	return i.collectionStratParseData(contentsCopy)
 }
 
 func (i *segment) collectionStratParseData(in []byte) ([]value, error) {


### PR DESCRIPTION
This still requires a chaos-engineering pipeline to make sure this is
really fixed, so far manual testing seems to indicate that it is indeed
gone.

fixes #1837