### PR TITLE
Fix LSM net additions count and add WAL threshold

### DIFF
--- a/adapters/repos/db/lsmkv/binary_search_tree_test.go
+++ b/adapters/repos/db/lsmkv/binary_search_tree_test.go
@@ -1,0 +1,101 @@
+package lsmkv
+
+import (
+	"math/rand"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+// This test asserts that the *binarySearchTree.insert
+// method properly calculates the net additions of a
+// new node into the tree
+func TestInsertNetAdditions_Replace(t *testing.T) {
+	rand.Seed(time.Now().UnixNano())
+
+	t.Run("single node entry", func(t *testing.T) {
+		tree := &binarySearchTree{}
+
+		key := make([]byte, 8)
+		val := make([]byte, 8)
+
+		rand.Read(key)
+		rand.Read(val)
+
+		n := tree.insert(key, val, nil)
+		require.Equal(t, len(key)+len(val), n)
+	})
+
+	t.Run("multiple unique node entries", func(t *testing.T) {
+		tree := &binarySearchTree{}
+
+		amount := 100
+		size := 8
+
+		var n int
+		for i := 0; i < amount; i++ {
+			key := make([]byte, size)
+			val := make([]byte, size)
+
+			rand.Read(key)
+			rand.Read(val)
+
+			n += tree.insert(key, val, nil)
+		}
+
+		require.Equal(t, amount*size*2, n)
+	})
+
+	t.Run("multiple non-unique node entries", func(t *testing.T) {
+		tree := &binarySearchTree{}
+
+		var (
+			amount      = 100
+			keySize     = 100
+			origValSize = 100
+			newValSize  = origValSize * 100
+			keys        = make([][]byte, amount)
+			vals        = make([][]byte, amount)
+
+			netAdditions int
+		)
+
+		// write the keys and original values
+		for i := range keys {
+			key := make([]byte, keySize)
+			rand.Read(key)
+
+			val := make([]byte, origValSize)
+			rand.Read(val)
+
+			keys[i], vals[i] = key, val
+		}
+
+		// make initial inserts
+		for i := range keys {
+			netAdditions += tree.insert(keys[i], vals[i], nil)
+		}
+
+		// change the values of the existing keys
+		// with new values of different length
+		for i := 0; i < amount; i++ {
+			val := make([]byte, newValSize)
+			rand.Read(val)
+
+			vals[i] = val
+		}
+
+		for i := 0; i < amount; i++ {
+			netAdditions += tree.insert(keys[i], vals[i], nil)
+		}
+
+		// Formulas for calculating the total net additions after
+		// updating the keys with differently sized values
+		expectedFirstNetAdd := amount * (keySize + origValSize)
+		expectedSecondNetAdd := (amount * (keySize + newValSize)) - (amount * keySize) - (amount * origValSize)
+		expectedNetAdditions := expectedFirstNetAdd + expectedSecondNetAdd
+
+		require.Equal(t, expectedNetAdditions, netAdditions)
+	})
+}

--- a/adapters/repos/db/lsmkv/bucket_options.go
+++ b/adapters/repos/db/lsmkv/bucket_options.go
@@ -35,6 +35,13 @@ func WithMemtableThreshold(threshold uint64) BucketOption {
 	}
 }
 
+func WithWalThreshold(threshold uint64) BucketOption {
+	return func(b *Bucket) error {
+		b.walThreshold = threshold
+		return nil
+	}
+}
+
 func WithSecondaryIndicies(count uint16) BucketOption {
 	return func(b *Bucket) error {
 		b.secondaryIndices = count

--- a/adapters/repos/db/lsmkv/bucket_threshold_test.go
+++ b/adapters/repos/db/lsmkv/bucket_threshold_test.go
@@ -164,9 +164,9 @@ func TestMemtableThreshold_Replace(t *testing.T) {
 		// give the bucket time to fill up beyond threshold
 		time.Sleep(time.Millisecond)
 
-		if !isSizeWithinTolerance(t, bucket.active.size, memtableThreshold, tolerance) {
+		if !isSizeWithinTolerance(t, bucket.active.Size(), memtableThreshold, tolerance) {
 			t.Fatalf("memtable size (%d) was allowed to increase beyond threshold (%d) with tolerance of (%f)%%",
-				bucket.active.size, memtableThreshold, tolerance)
+				bucket.active.Size(), memtableThreshold, tolerance)
 		} else {
 			done <- true
 		}

--- a/adapters/repos/db/lsmkv/bucket_threshold_test.go
+++ b/adapters/repos/db/lsmkv/bucket_threshold_test.go
@@ -1,0 +1,183 @@
+//go:build integrationTest
+// +build integrationTest
+
+package lsmkv
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"math/rand"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// This test ensures that the WAL threshold is being adhered to, and that a
+// flush to segment followed by a switch to a new WAL is being performed
+// once the threshold is reached
+func TestWriteAheadLogThreshold_Replace(t *testing.T) {
+	dirName := fmt.Sprintf("./testdata/%d", rand.Intn(10000000))
+	os.MkdirAll(dirName, 0o777)
+	defer func() {
+		err := os.RemoveAll(dirName)
+		fmt.Println(err)
+	}()
+
+	amount := 100
+	keys := make([][]byte, amount)
+	values := make([][]byte, amount)
+
+	walThreshold := uint64(4096)
+	tolerance := 0.5
+
+	bucket, err := NewBucket(testCtx(), dirName, nullLogger(),
+		WithStrategy(StrategyReplace),
+		WithMemtableThreshold(1024*1024*1024),
+		WithWalThreshold(walThreshold))
+	require.Nil(t, err)
+
+	// generate only a small amount of sequential values. this allows
+	// us to keep the memtable small (the net additions will be close
+	// to zero), and focus on testing the WAL threshold
+	t.Run("generate sequential data", func(t *testing.T) {
+		for i := range keys {
+			n, err := json.Marshal(i)
+			require.Nil(t, err)
+
+			keys[i], values[i] = n, n
+		}
+	})
+
+	t.Run("check switchover during insertion", func(t *testing.T) {
+		var (
+			done        = make(chan bool)
+			origWalFile string
+		)
+		go func() {
+			for {
+				select {
+				case <-done:
+					return
+				default:
+					for i := range keys {
+						err := bucket.Put(keys[i], values[i])
+						assert.Nil(t, err)
+						time.Sleep(time.Millisecond)
+					}
+				}
+			}
+		}()
+
+	out:
+		for {
+			entries, err := os.ReadDir(dirName)
+			require.Nil(t, err)
+
+			for _, entry := range entries {
+				if filepath.Ext(entry.Name()) == ".wal" {
+					info, err := entry.Info()
+					require.Nil(t, err)
+
+					if !isSizeWithinTolerance(t, uint64(info.Size()), walThreshold, tolerance) {
+						t.Fatalf("WAL size (%d) was allowed to increase beyond threshold (%d) with tolerance of (%f)%%",
+							info.Size(), walThreshold, tolerance*100)
+					}
+
+					// Set the name of the first WAL file created
+					if origWalFile == "" {
+						origWalFile = entry.Name()
+					} else if entry.Name() != origWalFile {
+						// If a new WAL is detected, the switch over was successful
+						done <- true
+						break out
+					}
+				}
+			}
+		}
+	})
+
+	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
+	defer cancel()
+
+	require.Nil(t, bucket.Shutdown(ctx))
+}
+
+// This test ensures that the Memtable threshold is being adhered to, and
+// that a flush to segment followed by a switch to a new WAL is being
+// performed once the threshold is reached
+func TestMemtableThreshold_Replace(t *testing.T) {
+	dirName := fmt.Sprintf("./testdata/%d", rand.Intn(10000000))
+	os.MkdirAll(dirName, 0o777)
+	defer func() {
+		err := os.RemoveAll(dirName)
+		fmt.Println(err)
+	}()
+
+	amount := 10000
+	sizePerValue := 8
+
+	keys := make([][]byte, amount)
+	values := make([][]byte, amount)
+
+	memtableThreshold := uint64(4096)
+	tolerance := float64(0.5)
+
+	bucket, err := NewBucket(testCtx(), dirName, nullLogger(),
+		WithStrategy(StrategyReplace),
+		WithMemtableThreshold(memtableThreshold))
+	require.Nil(t, err)
+
+	t.Run("generate random data", func(t *testing.T) {
+		for i := range keys {
+			n, err := json.Marshal(i)
+			require.Nil(t, err)
+
+			keys[i] = n
+			values[i] = make([]byte, sizePerValue)
+			rand.Read(values[i])
+		}
+	})
+
+	t.Run("check switchover during insertion", func(t *testing.T) {
+		done := make(chan bool)
+
+		go func() {
+			for {
+				select {
+				case <-done:
+					return
+				default:
+					for i := range keys {
+						err := bucket.Put(keys[i], values[i])
+						assert.Nil(t, err)
+						time.Sleep(time.Microsecond)
+					}
+				}
+			}
+		}()
+
+		// give the bucket time to fill up beyond threshold
+		time.Sleep(time.Millisecond)
+
+		if !isSizeWithinTolerance(t, bucket.active.size, memtableThreshold, tolerance) {
+			t.Fatalf("memtable size (%d) was allowed to increase beyond threshold (%d) with tolerance of (%f)%%",
+				bucket.active.size, memtableThreshold, tolerance)
+		} else {
+			done <- true
+		}
+	})
+
+	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
+	defer cancel()
+
+	require.Nil(t, bucket.Shutdown(ctx))
+}
+
+func isSizeWithinTolerance(t *testing.T, detectedSize uint64, threshold uint64, tolerance float64) bool {
+	return float64(detectedSize) <= float64(threshold)*(tolerance+1)
+}

--- a/adapters/repos/db/lsmkv/concurrent_writing_integration_test.go
+++ b/adapters/repos/db/lsmkv/concurrent_writing_integration_test.go
@@ -30,7 +30,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// This test continiuously writes into a bucket with a small memtable threshold,
+// This test continuously writes into a bucket with a small memtable threshold,
 // so that a lot of flushing is happening while writing. This is to ensure that
 // there will be no lost writes or other inconsistencies under load
 func TestConcurrentWriting_Replace(t *testing.T) {
@@ -126,7 +126,7 @@ func TestConcurrentWriting_Replace(t *testing.T) {
 	require.Nil(t, bucket.Shutdown(ctx))
 }
 
-// This test continiuously writes into a bucket with a small memtable threshold,
+// This test continuously writes into a bucket with a small memtable threshold,
 // so that a lot of flushing is happening while writing. This is to ensure that
 // there will be no lost writes or other inconsistencies under load
 func TestConcurrentWriting_Set(t *testing.T) {
@@ -220,7 +220,7 @@ func TestConcurrentWriting_Set(t *testing.T) {
 	require.Nil(t, bucket.Shutdown(ctx))
 }
 
-// This test continiuously writes into a bucket with a small memtable threshold,
+// This test continuously writes into a bucket with a small memtable threshold,
 // so that a lot of flushing is happening while writing. This is to ensure that
 // there will be no lost writes or other inconsistencies under load
 func TestConcurrentWriting_Map(t *testing.T) {

--- a/adapters/repos/db/lsmkv/memtable.go
+++ b/adapters/repos/db/lsmkv/memtable.go
@@ -131,9 +131,8 @@ func (l *Memtable) put(key, value []byte, opts ...SecondaryKeyOption) error {
 		return errors.Wrap(err, "write into commit log")
 	}
 
-	l.key.insert(key, value, secondaryKeys)
-	l.size += uint64(len(key))
-	l.size += uint64(len(value))
+	netAdditions := l.key.insert(key, value, secondaryKeys)
+	l.size += uint64(netAdditions)
 
 	for i, sec := range secondaryKeys {
 		l.secondaryToPrimary[i][string(sec)] = key


### PR DESCRIPTION
## Changes

#### Count Memtable Net Additions

Prior to these changes, the length in bytes of each key+value was used to calculate the approximate size of the memtable. This led to the bug described in this PR's related issue, where the memtable flushes too early, as the parent bucket overestimated the memtable's size.

This PR introduces the counting of the *net* additions, where if an existing key is updated, the size of the memtable is incremented only by the difference in length of the original value's bytes with the length of the new value's.

#### WAL Threshold

Added WAL threshold to be monitored in addition to the existing memtable threshold.  Reason is, with the counting of net additions to the memtable vs gross additions, the WAL can grow without bound in certain situation. 

An example is if the majority of writes to the memtable are updates to existing keys, with values of similar size, the bucket's active memtable will grow extremely slowly, if at all. Therefore threshold is never reached and the WAL increases in size unbounded.

To mitigate this problem, the WAL threshold will `stat` the current WAL and check to ensure that its size is below the threshold. Otherwise, like with the memtable threshold, the log is flushed to a segment and switched.

---

Closes #1830 