### PR TITLE
gh-1850 fix nil-pointer in segment cursor

### DIFF
--- a/adapters/repos/db/lsmkv/cursor_segment_replace.go
+++ b/adapters/repos/db/lsmkv/cursor_segment_replace.go
@@ -29,9 +29,9 @@ func (s *segment) newCursor() *segmentCursorReplace {
 }
 
 func (s *SegmentGroup) newCursors() ([]innerCursorReplace, func()) {
+	s.maintenanceLock.RLock()
 	out := make([]innerCursorReplace, len(s.segments))
 
-	s.maintenanceLock.RLock()
 	for i, segment := range s.segments {
 		out[i] = segment.newCursor()
 	}


### PR DESCRIPTION
There was a small data race where a compaction could have already
occurred/finished between creating the array and initializing it, thus
leaving empty slots.

There is no test yet, as this will be tested through the stress-test
pipelines together with a potential fix for #1849

fixes #1850 

Test for this will be added to the stress-testing pipeline.