### PR TITLE
Build tag regex pattern update

### DIFF
--- a/adapters/repos/db/disk_use.go
+++ b/adapters/repos/db/disk_use.go
@@ -31,7 +31,7 @@ func (d diskUse) percentUsed() float64 {
 func (d diskUse) String() string {
 	GB := 1024 * 1024 * 1024
 
-	return fmt.Sprintf("total: %.2fGB, free: %.2fGB, used: %.2fGB (avail: %.2fGF)",
+	return fmt.Sprintf("total: %.2fGB, free: %.2fGB, used: %.2fGB (avail: %.2fGB)",
 		float64(d.total)/float64(GB),
 		float64(d.free)/float64(GB),
 		float64(d.total-d.free)/float64(GB),

--- a/tools/license_headers/main.go
+++ b/tools/license_headers/main.go
@@ -29,7 +29,7 @@ var (
 
 func init() {
 	headerSectionRe = regexp.MustCompile(`^(//.*\n)*\n`)
-	buildTagRe = regexp.MustCompile(`^//\s\+build`)
+	buildTagRe = regexp.MustCompile(`^//go:build`)
 	h, err := ioutil.ReadFile("tools/license_headers/header.txt")
 	fatal(err)
 	targetHeader = bytes.TrimSpace(h)


### PR DESCRIPTION
Updated the license header addition script to look for `//go:build`, the conditional compilation directive added in go1.17, so that build tags are not overwritten in the process. Also small typo fix in a disk use debug log.