### PR TITLE
gh-1868 properly propagate "clear links" across commit logs.

### DIFF
--- a/adapters/repos/db/vector/hnsw/commit_logger_functional_options.go
+++ b/adapters/repos/db/vector/hnsw/commit_logger_functional_options.go
@@ -1,0 +1,17 @@
+package hnsw
+
+type CommitlogOption func(l *hnswCommitLogger) error
+
+func WithCommitlogThreshold(size int64) CommitlogOption {
+	return func(l *hnswCommitLogger) error {
+		l.maxSizeIndividual = size
+		return nil
+	}
+}
+
+func WithCommitlogThresholdForCombining(size int64) CommitlogOption {
+	return func(l *hnswCommitLogger) error {
+		l.maxSizeCombining = size
+		return nil
+	}
+}

--- a/adapters/repos/db/vector/hnsw/condensor2.go
+++ b/adapters/repos/db/vector/hnsw/condensor2.go
@@ -69,12 +69,12 @@ func (c *MemoryCondensor2) Do(fileName string) error {
 			if res.ReplaceLinks(node.id, uint16(level)) {
 				if err := c.SetLinksAtLevel(node.id, level, links); err != nil {
 					return errors.Wrapf(err,
-						"write links for node %d at level %dto commit log", node.id, level)
+						"write links for node %d at level %d to commit log", node.id, level)
 				}
 			} else {
 				if err := c.AddLinksAtLevel(node.id, uint16(level), links); err != nil {
 					return errors.Wrapf(err,
-						"write links for node %d at level %dto commit log", node.id, level)
+						"write links for node %d at level %d to commit log", node.id, level)
 				}
 			}
 		}

--- a/adapters/repos/db/vector/hnsw/index_too_many_links_bug_integration_test.go
+++ b/adapters/repos/db/vector/hnsw/index_too_many_links_bug_integration_test.go
@@ -9,8 +9,8 @@
 //  CONTACT: hello@semi.technology
 //
 
-//go:build integrationTest
-// +build integrationTest
+//go:build (integrationTest && !race
+// +build integrationTest,!race
 
 package hnsw
 
@@ -30,7 +30,15 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func Test_ManySmallCommitlogs(t *testing.T) {
+// The !race build tag makes sure that this test is EXCLUDED from running with
+// the race detector on, but now we also need to make sure that it runs in the
+// separate no-race test run. To INCLUDE it there we use the Test_NoRace_
+// prefix.
+// This test imports 10,000 objects concurrently which is extremly expensive
+// with the race detector on.
+// It prevents a regresssion on
+// https://github.com/semi-technologies/weaviate/issues/1868
+func Test_NoRace_ManySmallCommitlogs(t *testing.T) {
 	n := 10000
 	dim := 16
 	m := 8

--- a/adapters/repos/db/vector/hnsw/index_too_many_links_bug_integration_test.go
+++ b/adapters/repos/db/vector/hnsw/index_too_many_links_bug_integration_test.go
@@ -1,0 +1,176 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2022 SeMI Technologies B.V. All rights reserved.
+//
+//  CONTACT: hello@semi.technology
+//
+
+//go:build integrationTest
+// +build integrationTest
+
+package hnsw
+
+import (
+	"context"
+	"fmt"
+	"math/rand"
+	"os"
+	"runtime"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/semi-technologies/weaviate/adapters/repos/db/vector/hnsw/distancer"
+	"github.com/sirupsen/logrus/hooks/test"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func Test_ManySmallCommitlogs(t *testing.T) {
+	n := 10000
+	dim := 16
+	m := 8
+
+	rand.Seed(time.Now().UnixNano())
+	rootPath := fmt.Sprintf("./testdata/%d", rand.Intn(10000000))
+	os.MkdirAll(rootPath, 0o777)
+	defer func() {
+		err := os.RemoveAll(rootPath)
+		fmt.Println(err)
+	}()
+
+	logger, _ := test.NewNullLogger()
+	original, err := NewCommitLogger(rootPath, "too_many_links_test", 1, logger,
+		WithCommitlogThreshold(1e5), WithCommitlogThresholdForCombining(5e5))
+	require.Nil(t, err)
+
+	data := make([][]float32, n)
+	for i := range data {
+		data[i] = make([]float32, dim)
+		for j := range data[i] {
+			data[i][j] = rand.Float32()
+		}
+
+	}
+
+	var index *hnsw
+
+	t.Run("set up an index with the specified commit logger", func(t *testing.T) {
+		idx, err := New(Config{
+			MakeCommitLoggerThunk: func() (CommitLogger, error) {
+				return original, nil
+			},
+			ID:               "too_many_links_test",
+			RootPath:         rootPath,
+			DistanceProvider: distancer.NewCosineProvider(),
+			Logger:           logger,
+			VectorForIDThunk: func(ctx context.Context, id uint64) ([]float32, error) {
+				return data[int(id)], nil
+			},
+		}, UserConfig{
+			MaxConnections:         m,
+			EFConstruction:         128,
+			CleanupIntervalSeconds: 0,
+		})
+		require.Nil(t, err)
+		index = idx
+	})
+
+	t.Run("add data", func(t *testing.T) {
+		type tuple struct {
+			vec []float32
+			id  uint64
+		}
+
+		jobs := make(chan tuple)
+
+		wg := sync.WaitGroup{}
+		worker := func(jobs chan tuple) {
+			for job := range jobs {
+				index.Add(job.id, job.vec)
+			}
+
+			wg.Done()
+		}
+
+		for i := 0; i < runtime.GOMAXPROCS(0); i++ {
+			wg.Add(1)
+			go worker(jobs)
+		}
+
+		for i, vec := range data {
+			jobs <- tuple{id: uint64(i), vec: vec}
+		}
+
+		close(jobs)
+
+		wg.Wait()
+	})
+
+	index.Flush()
+
+	t.Run("verify there are no nodes with too many links - control", func(t *testing.T) {
+		for i, node := range index.nodes {
+			if node == nil {
+				continue
+			}
+
+			for level, conns := range node.connections {
+				m := index.maximumConnections
+				if level == 0 {
+					m = index.maximumConnectionsLayerZero
+				}
+
+				assert.LessOrEqualf(t, len(conns), m, "node %d at level %d with %d conns",
+					i, level, len(conns))
+			}
+		}
+	})
+
+	t.Run("destroy the old index", func(t *testing.T) {
+		// kill the index
+		index = nil
+		original = nil
+	})
+
+	t.Run("create a new one from the disk files", func(t *testing.T) {
+		idx, err := New(Config{
+			MakeCommitLoggerThunk: MakeNoopCommitLogger, // no longer need a real one
+			ID:                    "too_many_links_test",
+			RootPath:              rootPath,
+			DistanceProvider:      distancer.NewCosineProvider(),
+			Logger:                logger,
+			VectorForIDThunk: func(ctx context.Context, id uint64) ([]float32, error) {
+				return data[int(id)], nil
+			},
+		}, UserConfig{
+			MaxConnections:         m,
+			EFConstruction:         128,
+			CleanupIntervalSeconds: 1,
+		})
+		require.Nil(t, err)
+		index = idx
+	})
+
+	t.Run("verify there are no nodes with too many links - after restart", func(t *testing.T) {
+		for i, node := range index.nodes {
+			if node == nil {
+				continue
+			}
+
+			for level, conns := range node.connections {
+				m := index.maximumConnections
+				if level == 0 {
+					m = index.maximumConnectionsLayerZero
+				}
+
+				require.LessOrEqualf(t, len(conns), m, "node %d at level %d with %d conns",
+					i, level, len(conns))
+			}
+		}
+	})
+}

--- a/adapters/repos/db/vector/hnsw/index_too_many_links_bug_integration_test.go
+++ b/adapters/repos/db/vector/hnsw/index_too_many_links_bug_integration_test.go
@@ -141,6 +141,7 @@ func Test_NoRace_ManySmallCommitlogs(t *testing.T) {
 
 	t.Run("destroy the old index", func(t *testing.T) {
 		// kill the index
+		original.cancel <- struct{}{}
 		index = nil
 		original = nil
 	})

--- a/adapters/repos/db/vector/hnsw/index_too_many_links_bug_integration_test.go
+++ b/adapters/repos/db/vector/hnsw/index_too_many_links_bug_integration_test.go
@@ -34,9 +34,9 @@ import (
 // the race detector on, but now we also need to make sure that it runs in the
 // separate no-race test run. To INCLUDE it there we use the Test_NoRace_
 // prefix.
-// This test imports 10,000 objects concurrently which is extremly expensive
+// This test imports 10,000 objects concurrently which is extremely expensive
 // with the race detector on.
-// It prevents a regresssion on
+// It prevents a regression on
 // https://github.com/semi-technologies/weaviate/issues/1868
 func Test_NoRace_ManySmallCommitlogs(t *testing.T) {
 	n := 10000
@@ -94,7 +94,7 @@ func Test_NoRace_ManySmallCommitlogs(t *testing.T) {
 			id  uint64
 		}
 
-		jobs := make(chan tuple)
+		jobs := make(chan tuple, n)
 
 		wg := sync.WaitGroup{}
 		worker := func(jobs chan tuple) {
@@ -140,8 +140,8 @@ func Test_NoRace_ManySmallCommitlogs(t *testing.T) {
 	})
 
 	t.Run("destroy the old index", func(t *testing.T) {
-		// kill the index
-		original.cancel <- struct{}{}
+		// kill the commit loger and index
+		original.Shutdown()
 		index = nil
 		original = nil
 	})

--- a/adapters/repos/db/vector/hnsw/index_too_many_links_bug_integration_test.go
+++ b/adapters/repos/db/vector/hnsw/index_too_many_links_bug_integration_test.go
@@ -9,7 +9,7 @@
 //  CONTACT: hello@semi.technology
 //
 
-//go:build (integrationTest && !race
+//go:build (integrationTest && !race)
 // +build integrationTest,!race
 
 package hnsw

--- a/test/integration/run.sh
+++ b/test/integration/run.sh
@@ -25,5 +25,9 @@ else
   echo "Found no --include-slow flag, skipping the slow ones"
 fi
 
+echo "Run the regular integration tests with race detector ON"
 go test -count 1 -coverpkg=./adapters/repos/... -coverprofile=coverage-integration.txt -race -tags=$tags "$@" ./adapters/repos/...
+echo "Run the !race integration tests with race detector OFF"
+go test -count 1 -coverpkg=./adapters/repos/... -tags=$tags "$@" -run Test_NoRace ./adapters/repos/...
+echo "Run the classification integration tests with race detector ON"
 go test -count 1 -race -tags=$tags "$@" ./usecases/classification/...


### PR DESCRIPTION
The following situation caused an issue. Imagine there are two commit
logs in chronological order:

Log 1:
- AddLink for Node/Level/Link 0/0/1
- AddLink for Node/Level/Link 0/0/2

Log 2:
- ClearLinks for Node/Level 0/0
- AddLink for Node/Level/Link 0/0/3
- AddLink for Node/Level/Link 0/0/4

It should be quite obvious that after reading all the logs back in the
correct order node 0 will have the connections [3,4] at level zero, as
there was a "clear" event in between.

However, prior to this fix we would have ended up with [1,2,3,4] because
the clear information got lost when condensing each log independently.
This fix makes sure that information that relates to changes from prior
commit logs is kept when condensing a commit log. The actual bug was
when reading (as part of condensing) as we used the clear only to clear
the links (which from the perspective of log 2 were already empty). This
led us to condensing log 2 to just "add 3, add 4", whereas the correctly
condensed log would have been "clear, add 3, add 4". This is the case
now.

To write the tests needed for this fix, it was required to add some
functional options to the commit logger to control the commit log size
thresholds. As of now these are not yet exposed to the user, but this
would also add value.

fixes #1868

Potential follow-up tasks:

1. Expose Commitlog configuration (e.g. thresholds) to user, so they can
   finetune them to their needs
2. Clean up the redundant and partly unused code, and the confusion
   between condensor/condensor2 and deserializer/deserializer2