### PR TITLE
gh-1872 clean up disk segment list properly on shutdown

### DIFF
--- a/adapters/repos/db/lsmkv/segment_group.go
+++ b/adapters/repos/db/lsmkv/segment_group.go
@@ -286,6 +286,11 @@ func (ig *SegmentGroup) shutdown(ctx context.Context) error {
 		ig.segments[i] = nil
 	}
 
+	// make sure the segment list itself is set to nil. In case a memtable will
+	// still flush after closing, it might try to read from a disk segment list
+	// otherwise and run into nil-pointer problems.
+	ig.segments = nil
+
 	return nil
 }
 


### PR DESCRIPTION
This prevents a nil-pointer panic that showed as part of a flaky test.
The actual cause is described in:
https://github.com/semi-technologies/weaviate/issues/1872#issuecomment-1076357479

To assure the test is fixed you can run run

```go
go test -race -tags integrationTest -count 10 -run TestMemtableThreshold_Replace ./adapters/repos/db/lsmkv
```

which reliably failed before, but no longer does so with the fix.

fixes #1872