### PR TITLE
WEAVIATE-69 fix broken dynamic ef calculation

### DIFF
--- a/adapters/repos/db/vector/hnsw/dynamic_ef_test.go
+++ b/adapters/repos/db/vector/hnsw/dynamic_ef_test.go
@@ -1,0 +1,90 @@
+package hnsw
+
+import (
+	"context"
+	"testing"
+
+	"github.com/pkg/errors"
+	"github.com/semi-technologies/weaviate/adapters/repos/db/vector/hnsw/distancer"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// To prevent a regression on
+// https://github.com/semi-technologies/weaviate/issues/1878
+func Test_DynamicEF(t *testing.T) {
+	type test struct {
+		name       string
+		config     UserConfig
+		limit      int
+		expectedEf int
+	}
+
+	tests := []test{
+		{
+			name: "all defaults explicitly entered, limit: 100",
+			config: UserConfig{
+				VectorCacheMaxObjects: 10,
+				EF:                    -1,
+				DynamicEFMin:          100,
+				DynamicEFMax:          500,
+				DynamicEFFactor:       8,
+			},
+			limit:      100,
+			expectedEf: 500,
+		},
+		{
+			name: "limit lower than min",
+			config: UserConfig{
+				VectorCacheMaxObjects: 10,
+				EF:                    -1,
+				DynamicEFMin:          100,
+				DynamicEFMax:          500,
+				DynamicEFFactor:       8,
+			},
+			limit:      10,
+			expectedEf: 100,
+		},
+		{
+			name: "limit within the dynamic range",
+			config: UserConfig{
+				VectorCacheMaxObjects: 10,
+				EF:                    -1,
+				DynamicEFMin:          100,
+				DynamicEFMax:          500,
+				DynamicEFFactor:       8,
+			},
+			limit:      23,
+			expectedEf: 184,
+		},
+		{
+			name: "explicit ef",
+			config: UserConfig{
+				VectorCacheMaxObjects: 10,
+				EF:                    78,
+			},
+			limit:      5,
+			expectedEf: 78,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			index, err := New(Config{
+				RootPath:              "doesnt-matter-as-committlogger-is-mocked-out",
+				ID:                    "dynaimc-ef-test",
+				MakeCommitLoggerThunk: MakeNoopCommitLogger,
+				DistanceProvider:      distancer.NewCosineProvider(),
+				VectorForIDThunk: func(ctx context.Context, id uint64) ([]float32, error) {
+					return nil, errors.Errorf("not implemented")
+				},
+			}, test.config)
+			require.Nil(t, err)
+
+			defer index.Drop()
+
+			actualEF := index.searchTimeEF(test.limit)
+			assert.Equal(t, test.expectedEf, actualEF)
+		})
+	}
+}

--- a/adapters/repos/db/vector/hnsw/index.go
+++ b/adapters/repos/db/vector/hnsw/index.go
@@ -167,7 +167,6 @@ func New(cfg Config, uc UserConfig) (*hnsw, error) {
 		// inspired by c++ implementation
 		levelNormalizer:   1 / math.Log(float64(uc.MaxConnections)),
 		efConstruction:    uc.EFConstruction,
-		ef:                int64(uc.EF),
 		flatSearchCutoff:  int64(uc.FlatSearchCutoff),
 		nodes:             make([]*vertex, initialSize),
 		cache:             vectorCache,
@@ -182,6 +181,11 @@ func New(cfg Config, uc UserConfig) (*hnsw, error) {
 		tombstoneLock:     &sync.RWMutex{},
 		initialInsertOnce: &sync.Once{},
 		cleanupInterval:   time.Duration(uc.CleanupIntervalSeconds) * time.Second,
+
+		ef:       int64(uc.EF),
+		efMin:    int64(uc.DynamicEFMin),
+		efMax:    int64(uc.DynamicEFMax),
+		efFactor: int64(uc.DynamicEFFactor),
 	}
 
 	if err := index.init(cfg); err != nil {


### PR DESCRIPTION
while the calculation itself was working perfectly, the configuration
was not applied correctly meaning that the resulting calculation didn't
make sense. A simple unit test (this PR adds one) could have caught
this, unfortunately there was none.

fixes #1878