### PR TITLE
WEAVIATE-76 make sure bm25 fails gracefully on multi-shard indexes

### DIFF
--- a/adapters/repos/db/index.go
+++ b/adapters/repos/db/index.go
@@ -643,6 +643,11 @@ func (i *Index) objectSearch(ctx context.Context, limit int,
 	shardNames := i.getSchema.ShardingState(i.Config.ClassName.String()).
 		AllPhysicalShards()
 
+	if len(shardNames) > 1 && keywordRanking != nil {
+		return nil, errors.Errorf("bm25 support limited to single-shard setups for now." +
+			" Multi-shard support expected in v1.13.0")
+	}
+
 	out := make([]*storobj.Object, 0, len(shardNames)*limit)
 	for _, shardName := range shardNames {
 		local := i.getSchema.


### PR DESCRIPTION
Support anticipated in the next release (`v1.13.0`), so failing explicitly with a nice message in `v1.12.0`)>

Single shard setup:
<img width="2016" alt="Screenshot 2022-04-04 at 12 10 38" src="https://user-images.githubusercontent.com/8974479/161523689-3c955de2-844a-4e62-9e09-6251c4986752.png">


Multi shard setup: 
<img width="2071" alt="Screenshot 2022-04-04 at 12 11 32" src="https://user-images.githubusercontent.com/8974479/161523707-72dd030c-cf42-4e42-acdb-e01258701b76.png">
