### PR TITLE
Bugfix for #1903 (LSM crash recovery journey for "Map" type)

### DIFF
--- a/adapters/repos/db/lsmkv/bucket_recover_from_wal.go
+++ b/adapters/repos/db/lsmkv/bucket_recover_from_wal.go
@@ -95,7 +95,7 @@ func (b *Bucket) parseWALIntoMemtable(fname string) error {
 	b.active.commitlog.pause()
 	defer b.active.commitlog.unpause()
 
-	err := newCommitLoggerParser(fname, b.active).Do()
+	err := newCommitLoggerParser(fname, b.active, b.strategy).Do()
 	if errors.Is(err, io.EOF) || errors.Is(err, io.ErrUnexpectedEOF) {
 		// we need to check for both EOF or UnexpectedEOF, as we don't know where
 		// the commit log got corrupted, a field ending that weset a longer

--- a/adapters/repos/db/lsmkv/commitlogger_parser.go
+++ b/adapters/repos/db/lsmkv/commitlogger_parser.go
@@ -22,12 +22,18 @@ import (
 
 type commitloggerParser struct {
 	path     string
+	strategy string
 	memtable *Memtable
 	reader   io.Reader
 }
 
-func newCommitLoggerParser(path string, activeMemtable *Memtable) *commitloggerParser {
-	return &commitloggerParser{path: path, memtable: activeMemtable}
+func newCommitLoggerParser(path string, activeMemtable *Memtable,
+	strategy string) *commitloggerParser {
+	return &commitloggerParser{
+		path:     path,
+		memtable: activeMemtable,
+		strategy: strategy,
+	}
 }
 
 func (p *commitloggerParser) Do() error {
@@ -90,5 +96,24 @@ func (p *commitloggerParser) parseCollectionNode() error {
 		return err
 	}
 
+	if p.strategy == StrategyMapCollection {
+		return p.parseMapNode(n)
+	}
 	return p.memtable.append(n.primaryKey, n.values)
+}
+
+func (p *commitloggerParser) parseMapNode(n segmentCollectionNode) error {
+	for _, val := range n.values {
+		mp := MapPair{}
+		if err := mp.FromBytes(val.value, false); err != nil {
+			return err
+		}
+		mp.Tombstone = val.tombstone
+
+		if err := p.memtable.appendMapSorted(n.primaryKey, mp); err != nil {
+			return err
+		}
+	}
+
+	return nil
 }


### PR DESCRIPTION
# closes #1903 

## Status of this PR

DRAFT - until the chaos engineering build for this scenario is set up correctly and green with a new build from this branch. 

## Summary of Cause
* There was no existing test to test recovery for "Map" types in the LSM store. Those same tests did exist for "Replace" and "Set"
* Unfortunately, the chaos-engineering stress test only used numbers in the inverted index, so it didn't actually use the "Map" type at all. Thus, it also didn't catch this
* This behavior most likely broke with the introduction of the BM25 feature when we changed the memtable type for "Map"
* The old behavior on recovery ignored the bucket type and tried to parse every collection (=Set+Map) type into a Set memtable. Then, when flushing from the correct Map memtable - it was emtpy. This led to the `index out of range` panic we saw in #1903. However, the panic was just one of the symptoms. Even if there had been no panic we would have never recovered the data as we were flushing the wrong (and empty) memtable, but ignoring the one that was filled

## Changes done in this PR
* This PR fixes the behavior by making sure that each of the three strategies is reflected correctly in a recovery scenario
* It adds the missing test

## Preventing a regression of this bug
* Most likely the missing test would have already prevented this bug if it had existed. It does now.
* As