### PR TITLE
Reduce allocations for map compaction: Overall 264 GB -> 126 GB

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -3,4 +3,5 @@ Dockerfile.*
 Dockerfile
 docker-compose.yml
 data/
+data_wiki/
 test/acceptance/

--- a/adapters/repos/db/lsmkv/compactor_map.go
+++ b/adapters/repos/db/lsmkv/compactor_map.go
@@ -105,6 +105,7 @@ func (c *compactorMap) writeKeys() ([]keyIndex, error) {
 
 	var kis []keyIndex
 	pairs := newReusableMapPairs()
+	me := newMapEncoder()
 
 	for {
 		// TODO: each iteration makes a massive amount of allocations, this could
@@ -147,7 +148,7 @@ func (c *compactorMap) writeKeys() ([]keyIndex, error) {
 				return nil, err
 			}
 
-			mergedEncoded, err := newMapEncoder().DoMulti(mergedPairs)
+			mergedEncoded, err := me.DoMultiReusable(mergedPairs)
 			if err != nil {
 				return nil, err
 			}

--- a/adapters/repos/db/lsmkv/compactor_map.go
+++ b/adapters/repos/db/lsmkv/compactor_map.go
@@ -106,6 +106,7 @@ func (c *compactorMap) writeKeys() ([]keyIndex, error) {
 	var kis []keyIndex
 	pairs := newReusableMapPairs()
 	me := newMapEncoder()
+	ssm := newSortedMapMerger()
 
 	for {
 		// TODO: each iteration makes a massive amount of allocations, this could
@@ -142,8 +143,9 @@ func (c *compactorMap) writeKeys() ([]keyIndex, error) {
 				})
 			}
 
-			mergedPairs, err := newSortedMapMerger().
-				doKeepTombstones([][]MapPair{pairs.left, pairs.right})
+			ssm.reset([][]MapPair{pairs.left, pairs.right})
+			mergedPairs, err := ssm.
+				doKeepTombstonesReusable()
 			if err != nil {
 				return nil, err
 			}

--- a/adapters/repos/db/lsmkv/compactor_map.go
+++ b/adapters/repos/db/lsmkv/compactor_map.go
@@ -109,10 +109,6 @@ func (c *compactorMap) writeKeys() ([]keyIndex, error) {
 	ssm := newSortedMapMerger()
 
 	for {
-		// TODO: each iteration makes a massive amount of allocations, this could
-		// probably be made more efficiently if all the [][]MapPair, etc would be
-		// reused
-
 		if key1 == nil && key2 == nil {
 			break
 		}

--- a/adapters/repos/db/lsmkv/compactor_map.go
+++ b/adapters/repos/db/lsmkv/compactor_map.go
@@ -23,8 +23,8 @@ import (
 type compactorMap struct {
 	// c1 is always the older segment, so when there is a conflict c2 wins
 	// (because of the replace strategy)
-	c1 *segmentCursorCollection
-	c2 *segmentCursorCollection
+	c1 *segmentCursorCollectionReusable
+	c2 *segmentCursorCollectionReusable
 
 	// the level matching those of the cursors
 	currentLevel        uint16
@@ -41,7 +41,7 @@ type compactorMap struct {
 }
 
 func newCompactorMapCollection(w io.WriteSeeker,
-	c1, c2 *segmentCursorCollection, level, secondaryIndexCount uint16,
+	c1, c2 *segmentCursorCollectionReusable, level, secondaryIndexCount uint16,
 	scratchSpacePath string, requiresSorting bool) *compactorMap {
 	return &compactorMap{
 		c1:                  c1,

--- a/adapters/repos/db/lsmkv/compactor_map_reusable_pairs.go
+++ b/adapters/repos/db/lsmkv/compactor_map_reusable_pairs.go
@@ -1,0 +1,42 @@
+package lsmkv
+
+// reusableMapPairs is not thread-safe and intended for usage from a single
+// thread. The caller is resoponsible for initializing each element themselves,
+// the Resize functions will only set the size. If the size is reduced, this
+// will only truncate elements, but will not reset values.
+type reusableMapPairs struct {
+	left  []MapPair
+	right []MapPair
+}
+
+func newReusableMapPairs() *reusableMapPairs {
+	return &reusableMapPairs{}
+}
+
+func (rmp *reusableMapPairs) ResizeLeft(size int) {
+	if cap(rmp.left) >= size {
+		rmp.left = rmp.left[:size]
+	} else {
+		// The 25% overhead for the capacity was chosen because we saw a lot
+		// re-allocations during testing with just a few elements more than before.
+		// This is something that really depends on the user's usage pattern, but
+		// in the test scenarios based on the
+		// weaviate-chaos-engineering/apps/importer-no-vector-index test script a
+		// simple 25% overhead reduced the resizing needs to almost zero.
+		rmp.left = make([]MapPair, size, int(float64(size)*1.25))
+	}
+}
+
+func (rmp *reusableMapPairs) ResizeRight(size int) {
+	if cap(rmp.right) >= size {
+		rmp.right = rmp.right[:size]
+	} else {
+		// The 25% overhead for the capacity was chosen because we saw a lot
+		// re-allocations during testing with just a few elements more than before.
+		// This is something that really depends on the user's usage pattern, but
+		// in the test scenarios based on the
+		// weaviate-chaos-engineering/apps/importer-no-vector-index test script a
+		// simple 25% overhead reduced the resizing needs to almost zero.
+		rmp.right = make([]MapPair, size, int(float64(size)*1.25))
+	}
+}

--- a/adapters/repos/db/lsmkv/cursor_segment_collection_reusable.go
+++ b/adapters/repos/db/lsmkv/cursor_segment_collection_reusable.go
@@ -1,0 +1,81 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2022 SeMI Technologies B.V. All rights reserved.
+//
+//  CONTACT: hello@semi.technology
+//
+
+package lsmkv
+
+import (
+	"github.com/semi-technologies/weaviate/adapters/repos/db/lsmkv/segmentindex"
+)
+
+type segmentCursorCollectionReusable struct {
+	segment    *segment
+	nextOffset uint64
+	nodeBuf    segmentCollectionNode
+}
+
+func (s *segment) newCollectionCursorReusable() *segmentCursorCollectionReusable {
+	return &segmentCursorCollectionReusable{
+		segment: s,
+	}
+}
+
+func (s *segmentCursorCollectionReusable) seek(key []byte) ([]byte, []value, error) {
+	node, err := s.segment.index.Seek(key)
+	if err != nil {
+		if err == segmentindex.NotFound {
+			return nil, nil, NotFound
+		}
+
+		return nil, nil, err
+	}
+
+	err = s.segment.collectionStratParseDataWithKeyInto(
+		s.segment.contents[node.Start:node.End], &s.nodeBuf)
+	if err != nil {
+		return s.nodeBuf.primaryKey, nil, err
+	}
+
+	s.nextOffset = node.End
+
+	return s.nodeBuf.primaryKey, s.nodeBuf.values, nil
+}
+
+func (s *segmentCursorCollectionReusable) next() ([]byte, []value, error) {
+	if s.nextOffset >= s.segment.dataEndPos {
+		return nil, nil, NotFound
+	}
+
+	err := s.segment.collectionStratParseDataWithKeyInto(
+		s.segment.contents[s.nextOffset:], &s.nodeBuf)
+
+	// make sure to set the next offset before checking the error. The error
+	// could be 'Deleted' which would require that the offset is still advanced
+	// for the next cycle
+	s.nextOffset = s.nextOffset + uint64(s.nodeBuf.offset)
+	if err != nil {
+		return s.nodeBuf.primaryKey, nil, err
+	}
+
+	return s.nodeBuf.primaryKey, s.nodeBuf.values, nil
+}
+
+func (s *segmentCursorCollectionReusable) first() ([]byte, []value, error) {
+	s.nextOffset = s.segment.dataStartPos
+	err := s.segment.collectionStratParseDataWithKeyInto(
+		s.segment.contents[s.nextOffset:], &s.nodeBuf)
+	if err != nil {
+		return s.nodeBuf.primaryKey, nil, err
+	}
+
+	s.nextOffset = s.nextOffset + uint64(s.nodeBuf.offset)
+
+	return s.nodeBuf.primaryKey, s.nodeBuf.values, nil
+}

--- a/adapters/repos/db/lsmkv/segment_collection_strategy.go
+++ b/adapters/repos/db/lsmkv/segment_collection_strategy.go
@@ -95,3 +95,11 @@ func (i *segment) collectionStratParseDataWithKey(in []byte) (segmentCollectionN
 
 	return ParseCollectionNode(r)
 }
+
+func (i *segment) collectionStratParseDataWithKeyInto(in []byte, node *segmentCollectionNode) error {
+	if len(in) == 0 {
+		return NotFound
+	}
+
+	return ParseCollectionNodeInto(in, node)
+}

--- a/adapters/repos/db/lsmkv/segment_group_compaction.go
+++ b/adapters/repos/db/lsmkv/segment_group_compaction.go
@@ -145,9 +145,10 @@ func (ig *SegmentGroup) compactOnce() error {
 			return err
 		}
 	case SegmentStrategyMapCollection:
-		c := newCompactorMapCollection(f, ig.segmentAtPos(pair[0]).newCollectionCursor(),
-			ig.segmentAtPos(pair[1]).newCollectionCursor(), level, secondaryIndices,
-			scratchSpacePath, ig.mapRequiresSorting)
+		c := newCompactorMapCollection(f,
+			ig.segmentAtPos(pair[0]).newCollectionCursorReusable(),
+			ig.segmentAtPos(pair[1]).newCollectionCursorReusable(),
+			level, secondaryIndices, scratchSpacePath, ig.mapRequiresSorting)
 
 		if err := c.do(); err != nil {
 			return err

--- a/adapters/repos/db/lsmkv/segment_serialization.go
+++ b/adapters/repos/db/lsmkv/segment_serialization.go
@@ -15,7 +15,6 @@ import (
 	"bufio"
 	"bytes"
 	"encoding/binary"
-	"fmt"
 	"io"
 	"os"
 	"path/filepath"
@@ -634,7 +633,7 @@ func ParseCollectionNode(r io.Reader) (segmentCollectionNode, error) {
 // compactions. Use at your own risk!
 //
 // If the buffers of the provided node have enough capacity they will be
-// reused. Only if the capacity is not enogh, will an allocation occur. This
+// reused. Only if the capacity is not enough, will an allocation occur. This
 // allocation uses 25% overhead to avoid future allocations for nodes of
 // similar size.
 //
@@ -677,7 +676,8 @@ func resizeValuesOfCollectionNode(node *segmentCollectionNode, size uint64) {
 	if cap(node.values) >= int(size) {
 		node.values = node.values[:size]
 	} else {
-		fmt.Println(size)
+		// Allocate with 25% overhead to reduce chance of having to do multiple
+		// allocations sequentially.
 		node.values = make([]value, size, int(float64(size)*1.25))
 	}
 }
@@ -687,6 +687,8 @@ func resizeValueOfCollectionNodeAtPos(node *segmentCollectionNode, pos int,
 	if cap(node.values[pos].value) >= int(size) {
 		node.values[pos].value = node.values[pos].value[:size]
 	} else {
+		// Allocate with 25% overhead to reduce chance of having to do multiple
+		// allocations sequentially.
 		node.values[pos].value = make([]byte, size, int(float64(size)*1.25))
 	}
 }
@@ -695,6 +697,8 @@ func resizeKeyOfCollectionNode(node *segmentCollectionNode, size uint32) {
 	if cap(node.primaryKey) >= int(size) {
 		node.primaryKey = node.primaryKey[:size]
 	} else {
+		// Allocate with 25% overhead to reduce chance of having to do multiple
+		// allocations sequentially.
 		node.primaryKey = make([]byte, size, int(float64(size)*1.25))
 	}
 }

--- a/adapters/repos/db/lsmkv/segment_serialization_test.go
+++ b/adapters/repos/db/lsmkv/segment_serialization_test.go
@@ -1,0 +1,50 @@
+package lsmkv
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func Test_SerializeAndParseCollectionNode(t *testing.T) {
+	before := segmentCollectionNode{
+		primaryKey: []byte("this-is-my-primary-key"),
+		values: []value{{
+			value: []byte("the-first-value"),
+		}, {
+			value:     []byte("the-second-value-with-a-tombstone"),
+			tombstone: true,
+		}},
+	}
+
+	buf := &bytes.Buffer{}
+	_, err := before.KeyIndexAndWriteTo(buf)
+	require.Nil(t, err)
+	encoded := buf.Bytes()
+
+	expected := segmentCollectionNode{
+		primaryKey: []byte("this-is-my-primary-key"),
+		values: []value{{
+			value: []byte("the-first-value"),
+		}, {
+			value:     []byte("the-second-value-with-a-tombstone"),
+			tombstone: true,
+		}},
+		offset: buf.Len(),
+	}
+
+	t.Run("parse using the _regular_ way", func(t *testing.T) {
+		after, err := ParseCollectionNode(bytes.NewReader(encoded))
+		assert.Nil(t, err)
+		assert.Equal(t, expected, after)
+	})
+
+	t.Run("parse using the reusable way", func(t *testing.T) {
+		var node segmentCollectionNode
+		err := ParseCollectionNodeInto(encoded, &node)
+		assert.Nil(t, err)
+		assert.Equal(t, expected, node)
+	})
+}

--- a/adapters/repos/db/lsmkv/strategies_map_test.go
+++ b/adapters/repos/db/lsmkv/strategies_map_test.go
@@ -334,3 +334,19 @@ func mustEncode(kvs []MapPair) []value {
 
 	return res
 }
+
+func Test_MapPair_EncodingBytes(t *testing.T) {
+	kv := MapPair{
+		Key:   []byte("hello-world-key1"),
+		Value: []byte("this is the value ;-)"),
+	}
+
+	control, err := kv.Bytes()
+	assert.Nil(t, err)
+
+	encoded := make([]byte, kv.Size())
+	err = kv.EncodeBytes(encoded)
+	assert.Nil(t, err)
+
+	assert.Equal(t, control, encoded)
+}


### PR DESCRIPTION
## Status

- Please wait with merging until the `v1.12.2` release is out, so we can include this in `v1.13.0`
- All existing tests are passing as well as new tests were added. 
- Has not yet been run in the chaos pipeline

## Motivation
While fixing #1903 we created a new test setup that only used the inverted index (LSM store), but no vector index. While running this setup it became quite obvious that this kind of usage puts a ton of load on the GC, see #1908 for details.

## Changes
* The scope for this PR is only the Map Compactor. No changes were made to other Compactor types or other areas.
* One by one (you can browse the commits from oldest to newest) the worst offender according to the alloc profile was tackled.
* For each element that made a lot of allocations it was rewritten in a way that memory allocated "in the previous round" can be reused in the next.
* By generally choosing an allocation overhead of 25% we can completely eliminate future allocations if they fit. This seems to be the case for the test setup used. This may not apply to other setups, we may want to think about making this value configurable. For now I don't see any need for this.

## Evaluation

### Setup
| Field | Value |
| --- | --- |
| Test Environment | MBP 2021 M1 Max |
| Compiler |`go version go1.17.6 darwin/arm64` |
| Import script | [`apps/importer-no-vector-index`](https://github.com/semi-technologies/weaviate-chaos-engineering/tree/main/apps/importer-no-vector-index) |
| Import parameters | `SHARDS=1 BATCH_SIZE=128 SIZE=200000 ORIGIN=http://localhost:8080 go run .` |

### Results

| Area | Value before | Value after | Improvement | Screenshots |
| --- | --- | --- | --- | --- |
| Overall allocations | 264 GB | 126 GB | 109 % | Before:<br><img width="296" alt="Screen Shot 2022-04-12 at 1 09 30 PM" src="https://user-images.githubusercontent.com/8974479/162952461-3275e2d4-1cc3-4a15-944c-133c5a6d0830.png">After:<br><img width="285" alt="Screen Shot 2022-04-12 at 1 09 42 PM" src="https://user-images.githubusercontent.com/8974479/162952459-b5fb4c88-ba00-4c3f-85e1-b665a6ac7e21.png"> |
| MapCompactor allocations | 144GB | < 10 GB (*does not show up on the profile at all anymore*) | 1340% | Before: <br><img width="1304" alt="Screen Shot 2022-04-12 at 1 08 40 PM" src="https://user-images.githubusercontent.com/8974479/162952882-fdcbc625-93dc-4861-b735-aa16a764dc65.png"> After: <br><img width="639" alt="Screen Shot 2022-04-12 at 1 10 10 PM" src="https://user-images.githubusercontent.com/8974479/162952875-fbf6eddb-4689-4459-9cbd-cebb42c2dfb7.png"> |
| Import time | 176s | 149s | 18% | Before: <br><img width="926" alt="Screen Shot 2022-04-12 at 1 27 35 PM" src="https://user-images.githubusercontent.com/8974479/162950456-a3b0940d-b94b-4ace-bc07-231fe5111d80.png">After: <br><img width="910" alt="Screen Shot 2022-04-12 at 1 24 14 PM" src="https://user-images.githubusercontent.com/8974479/162950466-6ed0a473-0d8f-43c9-bf25-255924e84963.png"> |

## Next steps

Looking at the current alloc profile, it seems the next worst offenders are the `inverted.Analyzer`, the Memtable itself (adding), and the Memtable Flush cycle
![profile014](https://user-images.githubusercontent.com/8974479/162954110-6d6f27ad-d67e-495d-8375-c7cfb55369f6.png)

