### PR TITLE
gh-1900 add nil-check on findBestEntryPoint

### DIFF
--- a/adapters/repos/db/vector/hnsw/index.go
+++ b/adapters/repos/db/vector/hnsw/index.go
@@ -324,7 +324,8 @@ func (h *hnsw) findBestEntrypointForNode(currentMaxLevel, targetLevel int,
 			// if we could find a new entrypoint, use it
 			// in case everything was tombstoned, stick with the existing one
 			elem := res.Pop()
-			if !h.nodeByID(elem.ID).isUnderMaintenance() {
+			n := h.nodeByID(elem.ID)
+			if n != nil && !n.isUnderMaintenance() {
 				// but not if the entrypoint is under maintenance
 				entryPointID = elem.ID
 			}


### PR DESCRIPTION
As discussed on Slack this requires further investigation of why it's necessary in the first place. This may be a symptom of another undiscovered bug. For now, we have user confirmation in #1900 that this check adds value, so I'd say we should still include it. 