### PR TITLE
Fix unlimited vec search with aggregate queries

### DIFF
--- a/adapters/repos/db/crud_noindex_property_integration_test.go
+++ b/adapters/repos/db/crud_noindex_property_integration_test.go
@@ -131,6 +131,21 @@ func TestCRUD_NoIndexProp(t *testing.T) {
 		assert.Contains(t, err.Error(),
 			"bucket for prop hiddenStringProp not found - is it indexed?")
 	})
+
+	t.Run("class search on timestamp prop with no timestamp indexing error", func(t *testing.T) {
+		_, err := repo.ClassSearch(context.Background(), traverser.GetParams{
+			ClassName: "ThingClassWithNoIndexProps",
+			Pagination: &filters.Pagination{
+				Limit: 10,
+			},
+			Filters: buildFilter("_creationTimeUnix", "1234567891011", eq, dtString),
+		})
+
+		require.NotNil(t, err)
+		assert.Contains(t, err.Error(),
+			"timestamps must be indexed to be filterable! "+
+				"add `indexTimestaps: true` to the invertedIndexConfig")
+	})
 }
 
 func ptBool(in bool) *bool {

--- a/adapters/repos/db/inverted/prop_value_pairs.go
+++ b/adapters/repos/db/inverted/prop_value_pairs.go
@@ -49,8 +49,8 @@ func (pv *propValuePair) fetchDocIDs(s *Searcher, limit int,
 		}
 		b := s.store.Bucket(id)
 
-		if b == nil && pv.prop == filters.InternalPropCreationTimeUnix ||
-			pv.prop == filters.InternalPropLastUpdateTimeUnix {
+		if b == nil && (pv.prop == filters.InternalPropCreationTimeUnix ||
+			pv.prop == filters.InternalPropLastUpdateTimeUnix) {
 			return errors.Errorf("timestamps must be indexed to be filterable! " +
 				"add `indexTimestaps: true` to the invertedIndexConfig")
 		}

--- a/adapters/repos/db/inverted/prop_value_pairs.go
+++ b/adapters/repos/db/inverted/prop_value_pairs.go
@@ -48,6 +48,13 @@ func (pv *propValuePair) fetchDocIDs(s *Searcher, limit int,
 			pv.hasFrequency = false
 		}
 		b := s.store.Bucket(id)
+
+		if b == nil && pv.prop == filters.InternalPropCreationTimeUnix ||
+			pv.prop == filters.InternalPropLastUpdateTimeUnix {
+			return errors.Errorf("timestamps must be indexed to be filterable! " +
+				"add `indexTimestaps: true` to the invertedIndexConfig")
+		}
+
 		if b == nil && pv.operator != filters.OperatorWithinGeoRange {
 			// a nil bucket is ok for a WithinGeoRange filter, as this query is not
 			// served by the inverted index, but propagated to a secondary index in

--- a/adapters/repos/db/vector/hnsw/search.go
+++ b/adapters/repos/db/vector/hnsw/search.go
@@ -506,7 +506,7 @@ func (params *searchByDistParams) iterate() {
 
 func (params *searchByDistParams) maxLimitReached() bool {
 	if params.maximumSearchLimit < 0 {
-		return true
+		return false
 	}
 
 	return int64(params.totalLimit) > params.maximumSearchLimit

--- a/test/acceptance/graphql_resolvers/local_aggregate_test.go
+++ b/test/acceptance/graphql_resolvers/local_aggregate_test.go
@@ -1034,6 +1034,33 @@ func localMetaWithObjectLimit(t *testing.T) {
 		})
 	})
 
+	t.Run("with nearObject and very low certainty, no objectLimit", func(t *testing.T) {
+		result := AssertGraphQL(t, helper.RootAuth, `
+			{
+				Aggregate {
+    				RansomNote(
+      					nearText: {
+							concepts: ["abc"]
+							certainty: 0.0001
+      					}
+    				) {
+					  meta {
+						count
+					  }
+   					}
+  				}
+			}
+		`)
+
+		t.Run("validate nearMedia runs unlimited without objectLimit", func(t *testing.T) {
+			res := result.Get("Aggregate", "RansomNote").AsSlice()
+			require.Len(t, res, 1)
+			meta := res[0].(map[string]interface{})["meta"]
+			count := meta.(map[string]interface{})["count"]
+			assert.Equal(t, json.Number("500"), count)
+		})
+	})
+
 	t.Run("with nearText and no certainty, where filter and groupBy", func(t *testing.T) {
 		objectLimit := 1
 		result := AssertGraphQL(t, helper.RootAuth, fmt.Sprintf(`


### PR DESCRIPTION
- Fix unlimited search to work properly when called internally by aggregate queries, add test
- Improve error message when user attempts to filter by timestamps but the weaviate instance is not configured to index objects by timestamps, add test