### PR TITLE
Panic on filtered vector search with flat-search-cutoff

### DIFF
--- a/adapters/repos/db/vector/hnsw/flat_search.go
+++ b/adapters/repos/db/vector/hnsw/flat_search.go
@@ -22,6 +22,15 @@ func (h *hnsw) flatSearch(queryVector []float32, limit int,
 
 	for candidate := range allowList {
 		h.Lock()
+		// Hot fix for https://github.com/semi-technologies/weaviate/issues/1937
+		// this if statement mitigates the problem but it doesn't resolve the issue
+		if candidate >= uint64(len(h.nodes)) {
+			h.logger.WithField("action", "flatSearch").
+				Warnf("trying to get candidate: %v but we only have: %v elements.",
+					candidate, len(h.nodes))
+			h.Unlock()
+			continue
+		}
 		c := h.nodes[candidate]
 		if c == nil || h.hasTombstone(candidate) {
 			h.Unlock()


### PR DESCRIPTION
Hot fix mitigating the bug described here:
https://github.com/semi-technologies/weaviate/issues/1937