### PR TITLE
Fix batch delete by ref bug, unify whereFilter parsing

### DIFF
--- a/adapters/handlers/graphql/local/common_filters/parse_filters_into_ast.go
+++ b/adapters/handlers/graphql/local/common_filters/parse_filters_into_ast.go
@@ -14,11 +14,10 @@ package common_filters
 import (
 	"encoding/json"
 	"fmt"
-	"time"
 
+	"github.com/semi-technologies/weaviate/adapters/handlers/rest/filterext"
 	"github.com/semi-technologies/weaviate/entities/filters"
 	"github.com/semi-technologies/weaviate/entities/models"
-	"github.com/semi-technologies/weaviate/entities/schema"
 )
 
 // Extract the filters from the arguments of a Local->Get or Local->Meta query.
@@ -29,327 +28,26 @@ func ExtractFilters(args map[string]interface{}, rootClass string) (*filters.Loc
 		return nil, nil
 	} else {
 		whereMap := where.(map[string]interface{}) // guaranteed by GraphQL to be a map.
-		rootClause, err := parseClause(whereMap, rootClass)
+		filter, err := filterMapToModel(whereMap)
 		if err != nil {
-			return nil, err
-		} else {
-			return &filters.LocalFilter{Root: rootClause}, nil
+			return nil, fmt.Errorf("failed to extract filters: %s", err)
 		}
+
+		return filterext.Parse(filter, rootClass)
 	}
 }
 
-// Parse a single clause
-func parseClause(args map[string]interface{}, rootClass string) (*filters.Clause, error) {
-	operator, operatorOk := args["operator"]
-	if !operatorOk {
-		return nil, fmt.Errorf("operand is missing in clause %s", jsonify(args))
-	}
-
-	var clause *filters.Clause
-	var err error
-
-	switch operator {
-	case "And":
-		clause, err = parseOperandsOp(args, filters.OperatorAnd, rootClass)
-	case "Or":
-		clause, err = parseOperandsOp(args, filters.OperatorOr, rootClass)
-	case "Not":
-		clause, err = parseOperandsOp(args, filters.OperatorOr, rootClass)
-	case "Equal":
-		clause, err = parseCompareOp(args, filters.OperatorEqual, rootClass)
-	case "Like":
-		clause, err = parseCompareOp(args, filters.OperatorLike, rootClass)
-	case "NotEqual":
-		clause, err = parseCompareOp(args, filters.OperatorNotEqual, rootClass)
-	case "GreaterThan":
-		clause, err = parseCompareOp(args, filters.OperatorGreaterThan, rootClass)
-	case "GreaterThanEqual":
-		clause, err = parseCompareOp(args, filters.OperatorGreaterThanEqual, rootClass)
-	case "LessThan":
-		clause, err = parseCompareOp(args, filters.OperatorLessThan, rootClass)
-	case "LessThanEqual":
-		clause, err = parseCompareOp(args, filters.OperatorLessThanEqual, rootClass)
-	case "WithinGeoRange":
-		clause, err = parseCompareOp(args, filters.OperatorWithinGeoRange, rootClass)
-	default:
-		err = fmt.Errorf("Unknown operator '%s' in clause %s", operator, jsonify(args))
-	}
-
-	return clause, err
-}
-
-// Parses a 'comperator' filter
-// Each of those has:
-// 1. The operator applied (e.g. Equal, LessThanEqual)
-// 2. A value (valueString, valueDate)
-// 3. The path ["SomeAction", "color"]
-func parseCompareOp(args map[string]interface{}, operator filters.Operator, rootClass string) (*filters.Clause, error) {
-	_, operandsPresent := args["operands"]
-
-	if operandsPresent {
-		return nil, fmt.Errorf("a 'operands' is given in clause '%s'; this is not allowed for a %s clause", jsonify(args), operator.Name())
-	}
-
-	path, err := parsePathFromArgs(args, rootClass)
+func filterMapToModel(m map[string]interface{}) (*models.WhereFilter, error) {
+	b, err := json.Marshal(m)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("failed convert map to models.WhereFilter: %s", err)
 	}
 
-	value, err := ParseValue(args)
+	var filter models.WhereFilter
+	err = json.Unmarshal(b, &filter)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("failed convert map to models.WhereFilter: %s", err)
 	}
 
-	return &filters.Clause{
-		Operator: operator,
-		On:       path,
-		Value:    value,
-	}, nil
-}
-
-// Parse an 'operand' filter.
-// One of those has:
-// 1. The operator appied (e.g. And, Or)
-// 2. The operands (e.g. a list of operands)
-//    Each operand will be parsed as a new clause.
-func parseOperandsOp(args map[string]interface{}, operator filters.Operator, rootClass string) (*filters.Clause, error) {
-	_, pathPresent := args["path"]
-
-	if pathPresent {
-		return nil, fmt.Errorf("a 'path' is given in clause '%s'; this is not allowed for a %s clause", jsonify(args), operator.Name())
-	}
-
-	rawOperands, ok := args["operands"]
-	if !ok {
-		return nil, fmt.Errorf("No operands given in clause '%s'", jsonify(args))
-	}
-
-	rawOperandsList, ok := rawOperands.([]interface{})
-	if !ok {
-		return nil, fmt.Errorf("The operands in clause '%s' are not a list", jsonify(args))
-	}
-
-	var operands []filters.Clause
-
-	for _, rawOperand := range rawOperandsList {
-		rawOperandMap, ok := rawOperand.(map[string]interface{})
-		if !ok {
-			return nil, fmt.Errorf("The operand '%s' is not valid", jsonify(rawOperand))
-		}
-
-		operand, err := parseClause(rawOperandMap, rootClass)
-		if err != nil {
-			return nil, err
-		}
-
-		operands = append(operands, *operand)
-	}
-
-	if len(operands) == 0 {
-		return nil, fmt.Errorf("Empty clause given")
-	}
-
-	return &filters.Clause{
-		Operator: operator,
-		Operands: operands,
-	}, nil
-}
-
-func parsePathFromArgs(args map[string]interface{}, rootClass string) (*filters.Path, error) {
-	rawPath, ok := args["path"]
-	if !ok {
-		return nil, fmt.Errorf("Missing the 'path' field for the filter '%s'", jsonify(args))
-	}
-
-	pathElements, ok := rawPath.([]interface{})
-	if !ok {
-		return nil, fmt.Errorf("The 'path' field for the filter '%s' is not a list of strings", jsonify(args))
-	}
-
-	path, err := filters.ParsePath(pathElements, rootClass)
-	if err != nil {
-		return nil, fmt.Errorf("invalid 'path' field for filter '%s': %s", jsonify(args), err)
-	}
-
-	return path, nil
-}
-
-// ParseValue used in a comparator operator.
-func ParseValue(args map[string]interface{}) (*filters.Value, error) {
-	// Split into this two parts:
-	// 1. This function that loops over the extractors and ensures exactly one value is found
-	// 2. A list of extractors that test if any of them matches (valueExtractors)
-
-	var value *filters.Value
-
-	for _, extractor := range valueExtractors {
-		foundValue, err := extractor(args)
-		// Abort if we found a value, but it's for being passed a string to an int value.
-		if err != nil {
-			return nil, err
-		}
-
-		if foundValue != nil {
-			if value != nil {
-				return nil, fmt.Errorf("Found two values the clause '%s'", jsonify(args))
-			} else {
-				value = foundValue
-			}
-		}
-	}
-
-	if value == nil {
-		return nil, fmt.Errorf("No value given in filter '%s'", jsonify(args))
-	}
-
-	return value, nil
-}
-
-// List of functions that can potentially extract a Value from the various valueXXXX fields in a clause.
-var valueExtractors [](func(args map[string]interface{}) (*filters.Value, error)) = [](func(args map[string]interface{}) (*filters.Value, error)){
-	// Ints
-	func(args map[string]interface{}) (*filters.Value, error) {
-		rawVal, ok := args["valueInt"]
-		if !ok {
-			return nil, nil
-		}
-
-		val, ok := rawVal.(int)
-		if !ok {
-			return nil, fmt.Errorf("the provided valueInt is not an int")
-		} else {
-			return &filters.Value{
-				Type:  schema.DataTypeInt,
-				Value: val,
-			}, nil
-		}
-	},
-	// Number
-	func(args map[string]interface{}) (*filters.Value, error) {
-		rawVal, ok := args["valueNumber"]
-		if !ok {
-			return nil, nil
-		}
-
-		val, ok := rawVal.(float64)
-		if !ok {
-			return nil, fmt.Errorf("the provided valueNumber is not a float")
-		}
-
-		return &filters.Value{
-			Type:  schema.DataTypeNumber,
-			Value: val,
-		}, nil
-	},
-	// Boolean
-	func(args map[string]interface{}) (*filters.Value, error) {
-		rawVal, ok := args["valueBoolean"]
-		if !ok {
-			return nil, nil
-		}
-
-		val, ok := rawVal.(bool)
-		if !ok {
-			return nil, fmt.Errorf("the provided valueBool is not a boolean")
-		}
-
-		return &filters.Value{
-			Type:  schema.DataTypeBoolean,
-			Value: val,
-		}, nil
-	},
-	// Strings
-	func(args map[string]interface{}) (*filters.Value, error) {
-		rawVal, ok := args["valueString"]
-		if !ok {
-			return nil, nil
-		}
-
-		val, ok := rawVal.(string)
-		if !ok {
-			return nil, fmt.Errorf("the provided valueString is not a string")
-		}
-
-		return &filters.Value{
-			Type:  schema.DataTypeString,
-			Value: val,
-		}, nil
-	},
-	// Strings as Text
-	func(args map[string]interface{}) (*filters.Value, error) {
-		rawVal, ok := args["valueText"]
-		if !ok {
-			return nil, nil
-		}
-
-		val, ok := rawVal.(string)
-		if !ok {
-			return nil, fmt.Errorf("the provided valueText is not a string")
-		}
-
-		return &filters.Value{
-			Type:  schema.DataTypeText,
-			Value: val,
-		}, nil
-	},
-	func(args map[string]interface{}) (*filters.Value, error) {
-		rawVal, ok := args["valueGeoRange"]
-		if !ok {
-			return nil, nil
-		}
-
-		geoMap, ok := rawVal.(map[string]interface{})
-		if !ok {
-			return nil, fmt.Errorf("the provided valueString is not a map")
-		}
-
-		c9s := geoMap["geoCoordinates"].(map[string]interface{})
-		lat := c9s["latitude"].(float64)
-		lon := c9s["longitude"].(float64)
-		distance := geoMap["distance"].(map[string]interface{})
-		maxDist := distance["max"].(float64)
-
-		return &filters.Value{
-			Type: schema.DataTypeGeoCoordinates,
-			Value: filters.GeoRange{
-				GeoCoordinates: &models.GeoCoordinates{
-					Latitude:  ptFloat32(float32(lat)),
-					Longitude: ptFloat32(float32(lon)),
-				},
-				Distance: float32(maxDist),
-			},
-		}, nil
-	},
-	// Dates
-	func(args map[string]interface{}) (*filters.Value, error) {
-		rawVal, ok := args["valueDate"]
-		if !ok {
-			return nil, nil
-		}
-
-		stringVal, ok := rawVal.(string)
-		if !ok {
-			return nil, fmt.Errorf("the provided valueDate is not a date string")
-		}
-
-		date, err := time.Parse(time.RFC3339, stringVal)
-		if err != nil {
-			return nil, fmt.Errorf("failed to parse the value '%s' as a date in valueDate", stringVal)
-		}
-
-		return &filters.Value{
-			Type:  schema.DataTypeDate,
-			Value: date,
-		}, nil
-	},
-}
-
-func ptFloat32(in float32) *float32 {
-	return &in
-}
-
-// Small utility function used in printing error messages.
-func jsonify(stuff interface{}) string {
-	j, _ := json.Marshal(stuff)
-	return string(j)
+	return &filter, nil
 }

--- a/adapters/handlers/graphql/local/common_filters/parse_test.go
+++ b/adapters/handlers/graphql/local/common_filters/parse_test.go
@@ -272,3 +272,7 @@ func TestExtractOperandFailsIfPathPresent(t *testing.T) {
 	query := `{ SomeAction(where: { path:["should", "not", "be", "present"], operator: And  })}`
 	resolver.AssertFailToResolve(t, query)
 }
+
+func ptFloat32(in float32) *float32 {
+	return &in
+}

--- a/adapters/handlers/rest/filterext/parse.go
+++ b/adapters/handlers/rest/filterext/parse.go
@@ -19,7 +19,7 @@ import (
 )
 
 // Parse Filter from REST construct to entities filter
-func Parse(in *models.WhereFilter) (*filters.LocalFilter, error) {
+func Parse(in *models.WhereFilter, rootClass string) (*filters.LocalFilter, error) {
 	if in == nil {
 		return nil, nil
 	}
@@ -30,14 +30,14 @@ func Parse(in *models.WhereFilter) (*filters.LocalFilter, error) {
 	}
 
 	if operator.OnValue() {
-		filter, err := parseValueFilter(in, operator)
+		filter, err := parseValueFilter(in, operator, rootClass)
 		if err != nil {
 			return nil, fmt.Errorf("invalid where filter: %v", err)
 		}
 		return filter, nil
 	}
 
-	filter, err := parseNestedFilter(in, operator)
+	filter, err := parseNestedFilter(in, operator, rootClass)
 	if err != nil {
 		return nil, fmt.Errorf("invalid where filter: %v", err)
 	}
@@ -45,13 +45,13 @@ func Parse(in *models.WhereFilter) (*filters.LocalFilter, error) {
 }
 
 func parseValueFilter(in *models.WhereFilter,
-	operator filters.Operator) (*filters.LocalFilter, error) {
+	operator filters.Operator, rootClass string) (*filters.LocalFilter, error) {
 	value, err := parseValue(in)
 	if err != nil {
 		return nil, err
 	}
 
-	path, err := parsePath(in.Path)
+	path, err := parsePath(in.Path, rootClass)
 	if err != nil {
 		return nil, err
 	}
@@ -66,7 +66,7 @@ func parseValueFilter(in *models.WhereFilter,
 }
 
 func parseNestedFilter(in *models.WhereFilter,
-	operator filters.Operator) (*filters.LocalFilter, error) {
+	operator filters.Operator, rootClass string) (*filters.LocalFilter, error) {
 	if in.Path != nil {
 		return nil, fmt.Errorf(
 			"operator '%s' not compatible with field 'path', remove 'path' "+
@@ -88,7 +88,7 @@ func parseNestedFilter(in *models.WhereFilter,
 			operator.Name())
 	}
 
-	operands, err := parseOperands(in.Operands)
+	operands, err := parseOperands(in.Operands, rootClass)
 	if err != nil {
 		return nil, err
 	}
@@ -101,10 +101,10 @@ func parseNestedFilter(in *models.WhereFilter,
 	}, nil
 }
 
-func parseOperands(ops []*models.WhereFilter) ([]filters.Clause, error) {
+func parseOperands(ops []*models.WhereFilter, rootClass string) ([]filters.Clause, error) {
 	out := make([]filters.Clause, len(ops))
 	for i, operand := range ops {
-		res, err := Parse(operand)
+		res, err := Parse(operand, rootClass)
 		if err != nil {
 			return nil, fmt.Errorf("operand %d: %v", i, err)
 		}
@@ -145,17 +145,17 @@ func parseOperator(in string) (filters.Operator, error) {
 	}
 }
 
-func parsePath(in []string) (*filters.Path, error) {
+func parsePath(in []string, rootClass string) (*filters.Path, error) {
 	if len(in) == 0 {
 		return nil, fmt.Errorf("field 'path': must have at least one element")
 	}
 
-	asInterface := make([]interface{}, len(in))
+	pathElements := make([]interface{}, len(in))
 	for i, elem := range in {
-		asInterface[i] = elem
+		pathElements[i] = elem
 	}
 
-	return filters.ParsePath(asInterface, "Todo") // TODO: do we need to set a root class?
+	return filters.ParsePath(pathElements, rootClass)
 }
 
 func allValuesNil(in *models.WhereFilter) bool {

--- a/adapters/handlers/rest/filterext/parse_test.go
+++ b/adapters/handlers/rest/filterext/parse_test.go
@@ -179,7 +179,7 @@ func Test_ExtractFlatFilters(t *testing.T) {
 
 		for _, test := range tests {
 			t.Run(test.name, func(t *testing.T) {
-				filter, err := Parse(test.input)
+				filter, err := Parse(test.input, "Todo")
 				assert.Equal(t, test.expectedErr, err)
 				assert.Equal(t, test.expectedFilter, filter)
 			})
@@ -285,7 +285,7 @@ func Test_ExtractFlatFilters(t *testing.T) {
 
 		for _, test := range tests {
 			t.Run(test.name, func(t *testing.T) {
-				filter, err := Parse(test.input)
+				filter, err := Parse(test.input, "Todo")
 				assert.Equal(t, test.expectedErr, err)
 				assert.Equal(t, test.expectedFilter, filter)
 			})
@@ -334,7 +334,7 @@ func Test_ExtractFlatFilters(t *testing.T) {
 
 		for _, test := range tests {
 			t.Run(test.name, func(t *testing.T) {
-				filter, err := Parse(test.input)
+				filter, err := Parse(test.input, "Todo")
 				assert.Equal(t, test.expectedErr, err)
 				assert.Equal(t, test.expectedFilter, filter)
 			})
@@ -436,7 +436,7 @@ func Test_ExtractFlatFilters(t *testing.T) {
 
 		for _, test := range tests {
 			t.Run(test.name, func(t *testing.T) {
-				filter, err := Parse(test.input)
+				filter, err := Parse(test.input, "Todo")
 				assert.Equal(t, test.expectedErr, err)
 				assert.Equal(t, test.expectedFilter, filter)
 			})

--- a/entities/filters/filters_validator.go
+++ b/entities/filters/filters_validator.go
@@ -22,23 +22,16 @@ func ValidateFilters(sch schema.Schema, filters *LocalFilter) error {
 	if filters == nil {
 		return errors.New("empty where")
 	}
-	return validateClause(sch, "", filters.Root)
+	return validateClause(sch, filters.Root)
 }
 
-func ValidateFiltersWithClassName(sch schema.Schema, className string, filters *LocalFilter) error {
-	if filters == nil {
-		return errors.New("empty where")
-	}
-	return validateClause(sch, className, filters.Root)
-}
-
-func validateClause(sch schema.Schema, withClassName string, clause *Clause) error {
+func validateClause(sch schema.Schema, clause *Clause) error {
 	// check if nested
 	if clause.Operands != nil {
 		var errs []error
 
 		for i, child := range clause.Operands {
-			if err := validateClause(sch, withClassName, &child); err != nil {
+			if err := validateClause(sch, &child); err != nil {
 				errs = append(errs, errors.Wrapf(err, "child operand at position %d", i))
 			}
 		}
@@ -53,9 +46,6 @@ func validateClause(sch schema.Schema, withClassName string, clause *Clause) err
 	// validate current
 
 	className := clause.On.GetInnerMost().Class
-	if len(withClassName) > 0 {
-		className = schema.ClassName(withClassName)
-	}
 	propName := clause.On.GetInnerMost().Property
 
 	if IsInternalProperty(propName) {

--- a/test/acceptance/batch_request_endpoints/batch_delete_test.go
+++ b/test/acceptance/batch_request_endpoints/batch_delete_test.go
@@ -12,8 +12,10 @@
 package batch_request_endpoints
 
 import (
+	"fmt"
 	"testing"
 
+	"github.com/go-openapi/strfmt"
 	"github.com/semi-technologies/weaviate/client/batch"
 	"github.com/semi-technologies/weaviate/entities/models"
 	"github.com/semi-technologies/weaviate/test/acceptance/helper"
@@ -21,19 +23,19 @@ import (
 )
 
 func batchDeleteJourney(t *testing.T) {
-	sourcesSize := 20
+	maxObjects := 20
 	var sources []*models.Object
 	equalThisName := "equal-this-name"
 
-	getBatchDelete := func(dryRun bool) *batch.BatchObjectsDeleteParams {
+	getBatchDelete := func(className string, path []string, valueString string, dryRun bool) *batch.BatchObjectsDeleteParams {
 		output := "verbose"
 		params := batch.NewBatchObjectsDeleteParams().WithBody(&models.BatchDelete{
 			Match: &models.BatchDeleteMatch{
-				Class: "BulkTestSource",
+				Class: className,
 				Where: &models.WhereFilter{
 					Operator:    "Equal",
-					Path:        []string{"name"},
-					ValueString: &equalThisName,
+					Path:        path,
+					ValueString: &valueString,
 				},
 			},
 			DryRun: &dryRun,
@@ -42,20 +44,42 @@ func batchDeleteJourney(t *testing.T) {
 		return params
 	}
 
+	sourceUUIDs := make([]strfmt.UUID, maxObjects)
+	targetUUIDs := make([]strfmt.UUID, maxObjects)
+
 	t.Run("create some data", func(t *testing.T) {
-		sources = make([]*models.Object, sourcesSize)
+		sources = make([]*models.Object, maxObjects)
 		for i := range sources {
+			uuid := mustNewUUID()
+
 			sources[i] = &models.Object{
 				Class: "BulkTestSource",
-				ID:    mustNewUUID(),
+				ID:    uuid,
 				Properties: map[string]interface{}{
 					"name": equalThisName,
 				},
 			}
+
+			sourceUUIDs[i] = uuid
+		}
+
+		targets := make([]*models.Object, maxObjects)
+		for i := range targets {
+			uuid := mustNewUUID()
+
+			targets[i] = &models.Object{
+				Class: "BulkTestTarget",
+				ID:    uuid,
+				Properties: map[string]interface{}{
+					"intProp": i,
+				},
+			}
+
+			targetUUIDs[i] = uuid
 		}
 	})
 
-	t.Run("import all data in batch", func(t *testing.T) {
+	t.Run("import all batch objects", func(t *testing.T) {
 		params := batch.NewBatchObjectsCreateParams().WithBody(
 			batch.BatchObjectsCreateBody{
 				Objects: sources,
@@ -69,16 +93,67 @@ func batchDeleteJourney(t *testing.T) {
 		}
 	})
 
+	t.Run("import all batch refs", func(t *testing.T) {
+		batchRefs := make([]*models.BatchReference, len(sources))
+
+		for i := range batchRefs {
+			batchRefs[i] = &models.BatchReference{
+				From: strfmt.URI(fmt.Sprintf("weaviate://localhost/%s/%s/fromSource", "BulkTestTarget", targetUUIDs[i])),
+				To:   strfmt.URI(fmt.Sprintf("weaviate://localhost/%s", sourceUUIDs[i])),
+			}
+		}
+
+		params := batch.NewBatchReferencesCreateParams().WithBody(batchRefs)
+		res, err := helper.Client(t).Batch.BatchReferencesCreate(params, nil)
+		require.Nil(t, err)
+
+		for _, elem := range res.Payload {
+			require.Nil(t, elem.Result.Errors)
+		}
+	})
+
 	t.Run("verify using GraphQL", func(t *testing.T) {
+		// verify objects
 		result := AssertGraphQL(t, helper.RootAuth, `
 		{  Get { BulkTestSource(where:{operator:Equal path:["name"] valueString:"equal-this-name"}) { name } } }
 		`)
 		items := result.Get("Get", "BulkTestSource").AsSlice()
-		require.Len(t, items, sourcesSize)
+		require.Len(t, items, maxObjects)
+
+		// verify refs
+		result = AssertGraphQL(t, helper.RootAuth, `
+		{
+		  Get {
+			BulkTestTarget
+			(
+			  where: {
+				path: ["fromSource", "BulkTestSource", "name"]
+				operator: Equal
+				valueString: "equal-this-name"
+			  }
+			)
+			{
+			  fromSource {
+				... on BulkTestSource {
+				  _additional {
+					id
+				  }
+				}
+			  }
+			}
+		  }
+		}
+		`)
+		items = result.Get("Get", "BulkTestTarget").AsSlice()
+		for _, item := range items {
+			fromSource := item.(map[string]interface{})["fromSource"]
+			require.NotNil(t, fromSource)
+		}
+		require.Len(t, items, maxObjects)
 	})
 
-	t.Run("perform batch delete dry run", func(t *testing.T) {
-		params := getBatchDelete(true)
+	t.Run("perform batch delete by refs dry run", func(t *testing.T) {
+		params := getBatchDelete("BulkTestTarget", []string{"fromSource", "BulkTestSource", "name"}, equalThisName, true)
 		res, err := helper.Client(t).Batch.BatchObjectsDelete(params, nil)
 		require.Nil(t, err)
 
@@ -86,25 +161,45 @@ func batchDeleteJourney(t *testing.T) {
 		require.NotNil(t, response)
 		require.NotNil(t, response.Match)
 		require.NotNil(t, response.Results)
-		require.Equal(t, int64(sourcesSize), response.Results.Matches)
+		require.Equal(t, int64(maxObjects), response.Results.Matches)
 		require.Equal(t, int64(0), response.Results.Successful)
 		require.Equal(t, int64(0), response.Results.Failed)
-		require.Equal(t, sourcesSize, len(response.Results.Objects))
+		require.Equal(t, maxObjects, len(response.Results.Objects))
 		for _, elem := range response.Results.Objects {
 			require.Nil(t, elem.Errors)
 		}
 	})
 
-	t.Run("verify that batch delete dry run didn't delete data", func(t *testing.T) {
+	t.Run("verify that batch delete by refs dry run didn't delete data", func(t *testing.T) {
 		result := AssertGraphQL(t, helper.RootAuth, `
-		{  Get { BulkTestSource(where:{operator:Equal path:["name"] valueString:"equal-this-name"}) { name } } }
+		{
+		  Get {
+			BulkTestTarget
+			(
+			  where: {
+				path: ["fromSource", "BulkTestSource", "name"]
+				operator: Equal
+				valueString: "equal-this-name"
+			  }
+			)
+			{
+			  fromSource {
+				... on BulkTestSource {
+				  _additional {
+					id
+				  }
+				}
+			  }
+			}
+		  }
+		}
 		`)
-		items := result.Get("Get", "BulkTestSource").AsSlice()
-		require.Len(t, items, sourcesSize)
+		items := result.Get("Get", "BulkTestTarget").AsSlice()
+		require.Len(t, items, maxObjects)
 	})
 
-	t.Run("perform batch delete", func(t *testing.T) {
-		params := getBatchDelete(false)
+	t.Run("perform batch delete by prop dry run", func(t *testing.T) {
+		params := getBatchDelete("BulkTestSource", []string{"name"}, equalThisName, true)
 		res, err := helper.Client(t).Batch.BatchObjectsDelete(params, nil)
 		require.Nil(t, err)
 
@@ -112,16 +207,88 @@ func batchDeleteJourney(t *testing.T) {
 		require.NotNil(t, response)
 		require.NotNil(t, response.Match)
 		require.NotNil(t, response.Results)
-		require.Equal(t, int64(sourcesSize), response.Results.Matches)
-		require.Equal(t, int64(sourcesSize), response.Results.Successful)
+		require.Equal(t, int64(maxObjects), response.Results.Matches)
+		require.Equal(t, int64(0), response.Results.Successful)
 		require.Equal(t, int64(0), response.Results.Failed)
-		require.Equal(t, sourcesSize, len(response.Results.Objects))
+		require.Equal(t, maxObjects, len(response.Results.Objects))
 		for _, elem := range response.Results.Objects {
 			require.Nil(t, elem.Errors)
 		}
 	})
 
-	t.Run("verify that batch delete deleted everything", func(t *testing.T) {
+	t.Run("verify that batch delete by prop dry run didn't delete data", func(t *testing.T) {
+		result := AssertGraphQL(t, helper.RootAuth, `
+		{  Get { BulkTestSource(where:{operator:Equal path:["name"] valueString:"equal-this-name"}) { name } } }
+		`)
+		items := result.Get("Get", "BulkTestSource").AsSlice()
+		require.Len(t, items, maxObjects)
+	})
+
+	t.Run("perform batch delete by ref", func(t *testing.T) {
+		params := getBatchDelete("BulkTestTarget", []string{"fromSource", "BulkTestSource", "name"}, equalThisName, false)
+		res, err := helper.Client(t).Batch.BatchObjectsDelete(params, nil)
+		require.Nil(t, err)
+
+		response := res.Payload
+		require.NotNil(t, response)
+		require.NotNil(t, response.Match)
+		require.NotNil(t, response.Results)
+		require.Equal(t, int64(maxObjects), response.Results.Matches)
+		require.Equal(t, int64(maxObjects), response.Results.Successful)
+		require.Equal(t, int64(0), response.Results.Failed)
+		require.Equal(t, maxObjects, len(response.Results.Objects))
+		for _, elem := range response.Results.Objects {
+			require.Nil(t, elem.Errors)
+		}
+	})
+
+	t.Run("verify that batch delete by ref deleted everything", func(t *testing.T) {
+		result := AssertGraphQL(t, helper.RootAuth, `
+		{
+		  Get {
+			BulkTestTarget
+			(
+			  where: {
+				path: ["fromSource", "BulkTestSource", "name"]
+				operator: Equal
+				valueString: "equal-this-name"
+			  }
+			)
+			{
+			  fromSource {
+				... on BulkTestSource {
+				  _additional {
+					id
+				  }
+				}
+			  }
+			}
+		  }
+		}
+		`)
+		items := result.Get("Get", "BulkTestTarget").AsSlice()
+		require.Len(t, items, 0)
+	})
+
+	t.Run("perform batch delete by prop", func(t *testing.T) {
+		params := getBatchDelete("BulkTestSource", []string{"name"}, equalThisName, false)
+		res, err := helper.Client(t).Batch.BatchObjectsDelete(params, nil)
+		require.Nil(t, err)
+
+		response := res.Payload
+		require.NotNil(t, response)
+		require.NotNil(t, response.Match)
+		require.NotNil(t, response.Results)
+		require.Equal(t, int64(maxObjects), response.Results.Matches)
+		require.Equal(t, int64(maxObjects), response.Results.Successful)
+		require.Equal(t, int64(0), response.Results.Failed)
+		require.Equal(t, maxObjects, len(response.Results.Objects))
+		for _, elem := range response.Results.Objects {
+			require.Nil(t, elem.Errors)
+		}
+	})
+
+	t.Run("verify that batch delete by prop deleted everything", func(t *testing.T) {
 		result := AssertGraphQL(t, helper.RootAuth, `
 		{  Get { BulkTestSource(where:{operator:Equal path:["name"] valueString:"equal-this-name"}) { name } } }
 		`)

--- a/test/acceptance/batch_request_endpoints/setup_test.go
+++ b/test/acceptance/batch_request_endpoints/setup_test.go
@@ -46,6 +46,19 @@ func Test_Batch(t *testing.T) {
 				},
 			},
 		})
+		createObjectClass(t, &models.Class{
+			Class: "BulkTestTarget",
+			Properties: []*models.Property{
+				{
+					Name:     "intProp",
+					DataType: []string{"int"},
+				},
+				{
+					Name:     "fromSource",
+					DataType: []string{"BulkTestSource"},
+				},
+			},
+		})
 	})
 
 	time.Sleep(2000 * time.Millisecond)
@@ -56,6 +69,7 @@ func Test_Batch(t *testing.T) {
 
 	deleteObjectClass(t, "BulkTest")
 	deleteObjectClass(t, "BulkTestSource")
+	deleteObjectClass(t, "BulkTestTarget")
 }
 
 func createObjectClass(t *testing.T, class *models.Class) {

--- a/usecases/classification/classifier_test.go
+++ b/usecases/classification/classifier_test.go
@@ -16,6 +16,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"strings"
 	"testing"
 	"time"
 
@@ -69,7 +70,7 @@ func Test_Classifier_KNN(t *testing.T) {
 			id = class.ID
 		})
 
-		t.Run("retrieving the same classificiation by id", func(t *testing.T) {
+		t.Run("retrieving the same classification by id", func(t *testing.T) {
 			class, err := classifier.Get(context.Background(), nil, id)
 			require.Nil(t, err)
 			require.NotNil(t, class)
@@ -420,6 +421,103 @@ func Test_Classifier_Custom_Classifier(t *testing.T) {
 			expectedErr := "classification failed: " +
 				"no classes to be classified - did you run a previous classification already?"
 			assert.Equal(t, expectedErr, class.Error)
+		})
+	})
+}
+
+func Test_Classifier_WhereFilterValidation(t *testing.T) {
+	t.Run("when invalid whereFilters are received", func(t *testing.T) {
+		sg := &fakeSchemaGetter{testSchema()}
+		repo := newFakeClassificationRepo()
+		authorizer := &fakeAuthorizer{}
+		vectorRepo := newFakeVectorRepoKNN(testDataToBeClassified(), testDataAlreadyClassified())
+		classifier := New(sg, repo, vectorRepo, authorizer, newNullLogger(), nil)
+
+		t.Run("with invalid sourceFilter", func(t *testing.T) {
+			invalidSourceFilter := &models.WhereFilter{
+				Path:        []string{"description"},
+				Operator:    "Equal",
+				ValueString: ptString("should be valueText"),
+			}
+
+			params := models.Classification{
+				Class:              "Article",
+				BasedOnProperties:  []string{"description"},
+				ClassifyProperties: []string{"exactCategory", "mainCategory"},
+				Settings: map[string]interface{}{
+					"k": json.Number("1"),
+				},
+				Filters: &models.ClassificationFilters{
+					SourceWhere: invalidSourceFilter,
+				},
+				Type: TypeContextual,
+			}
+
+			_, err := classifier.Schedule(context.Background(), nil, params)
+			assert.EqualError(t, err, `invalid sourceWhere: data type filter cannot use "valueString" on type "text", use "valueText" instead`)
+		})
+
+		t.Run("with invalid targetFilter", func(t *testing.T) {
+			sourceFilter := &models.WhereFilter{
+				Path:      []string{"description"},
+				Operator:  "Equal",
+				ValueText: ptString("someValue"),
+			}
+
+			invalidTargetFilter := &models.WhereFilter{
+				Path:        []string{"description"},
+				Operator:    "Equal",
+				ValueString: ptString("someValue"),
+			}
+
+			params := models.Classification{
+				Class:              "Article",
+				BasedOnProperties:  []string{"description"},
+				ClassifyProperties: []string{"exactCategory", "mainCategory"},
+				Settings: map[string]interface{}{
+					"k": json.Number("1"),
+				},
+				Filters: &models.ClassificationFilters{
+					SourceWhere: sourceFilter,
+					TargetWhere: invalidTargetFilter,
+				},
+				Type: TypeContextual,
+			}
+
+			_, err := classifier.Schedule(context.Background(), nil, params)
+			assert.Error(t, err)
+			assert.True(t, strings.Contains(err.Error(), "invalid targetWhere"))
+		})
+
+		t.Run("with invalid trainingFilter", func(t *testing.T) {
+			sourceFilter := &models.WhereFilter{
+				Path:      []string{"description"},
+				Operator:  "Equal",
+				ValueText: ptString("someValue"),
+			}
+			invalidTrainingFilter := &models.WhereFilter{
+				Path:        []string{"description"},
+				Operator:    "Equal",
+				ValueString: ptString("someValue"),
+			}
+
+			params := models.Classification{
+				Class:              "Article",
+				BasedOnProperties:  []string{"description"},
+				ClassifyProperties: []string{"exactCategory", "mainCategory"},
+				Settings: map[string]interface{}{
+					"k": json.Number("1"),
+				},
+				Filters: &models.ClassificationFilters{
+					SourceWhere:      sourceFilter,
+					TrainingSetWhere: invalidTrainingFilter,
+				},
+				Type: TypeKNN,
+			}
+
+			_, err := classifier.Schedule(context.Background(), nil, params)
+			assert.Error(t, err)
+			assert.True(t, strings.Contains(err.Error(), "invalid trainingSetWhere"))
 		})
 	})
 }

--- a/usecases/classification/fakes_for_test.go
+++ b/usecases/classification/fakes_for_test.go
@@ -83,7 +83,7 @@ func newFakeVectorRepoKNN(unclassified, classified search.Results) *fakeVectorRe
 	}
 }
 
-// read requests are specified throuh unclassified and classified,
+// read requests are specified through unclassified and classified,
 // write requests (Put[Kind]) are stored in the db map
 type fakeVectorRepoKNN struct {
 	sync.Mutex
@@ -202,7 +202,7 @@ func newFakeVectorRepoContextual(unclassified, targets search.Results) *fakeVect
 	}
 }
 
-// read requests are specified throuh unclassified and classified,
+// read requests are specified through unclassified and classified,
 // write requests (Put[Kind]) are stored in the db map
 type fakeVectorRepoContextual struct {
 	sync.Mutex

--- a/usecases/classification/validation.go
+++ b/usecases/classification/validation.go
@@ -22,6 +22,11 @@ import (
 	schemaUC "github.com/semi-technologies/weaviate/usecases/schema"
 )
 
+const (
+	TypeKNN        = "knn"
+	TypeContextual = "text2vec-contextionary-contextual"
+)
+
 type Validator struct {
 	schema  schema.Schema
 	errors  *errorCompounder
@@ -180,7 +185,7 @@ func (v *Validator) typeText2vecContextionaryContextual() bool {
 		return false
 	}
 
-	return v.subject.Type == "text2vec-contextionary-contextual"
+	return v.subject.Type == TypeContextual
 }
 
 func (v *Validator) typeKNN() bool {
@@ -188,7 +193,7 @@ func (v *Validator) typeKNN() bool {
 		return true
 	}
 
-	return v.subject.Type == "knn"
+	return v.subject.Type == TypeKNN
 }
 
 type errorCompounder struct {

--- a/usecases/objects/batch_delete.go
+++ b/usecases/objects/batch_delete.go
@@ -99,16 +99,14 @@ func (b *BatchManager) validateBatchDelete(ctx context.Context, principal *model
 		return nil, fmt.Errorf("class: %v doesn't exist", match.Class)
 	}
 
-	ec := &errorCompounder{}
-
 	filter, err := filterext.Parse(match.Where, class.Class)
 	if err != nil {
-		ec.add(errors.Wrap(err, "failed to parse where filter"))
+		return nil, fmt.Errorf("failed to parse where filter: %s", err)
 	}
 
 	err = filters.ValidateFilters(s, filter)
 	if err != nil {
-		ec.add(errors.Wrap(err, "invalid where filter"))
+		return nil, fmt.Errorf("invalid where filter: %s", err)
 	}
 
 	dryRunParam := false
@@ -122,13 +120,9 @@ func (b *BatchManager) validateBatchDelete(ctx context.Context, principal *model
 		case OutputMinimal, OutputVerbose:
 			outputParam = *output
 		default:
-			ec.add(errors.Errorf(`invalid output: "%s", possible values are: "%s", "%s"`,
-				*output, OutputMinimal, OutputVerbose))
+			return nil, fmt.Errorf(`invalid output: "%s", possible values are: "%s", "%s"`,
+				*output, OutputMinimal, OutputVerbose)
 		}
-	}
-
-	if ec.toError() != nil {
-		return nil, ec.toError()
 	}
 
 	params := &BatchDeleteParams{

--- a/usecases/objects/batch_delete.go
+++ b/usecases/objects/batch_delete.go
@@ -98,13 +98,13 @@ func (b *BatchManager) validateBatchDelete(ctx context.Context, principal *model
 		ec.add(errors.Errorf("class: %v doesn't exist", match.Class))
 	}
 
-	filter, err := filterext.Parse(match.Where)
+	filter, err := filterext.Parse(match.Where, class.Class)
 	if err != nil {
 		ec.add(errors.Wrap(err, "invalid where"))
 	}
 
 	if class != nil {
-		err = filters.ValidateFiltersWithClassName(s, class.Class, filter)
+		err = filters.ValidateFilters(s, filter)
 		if err != nil {
 			ec.add(errors.Wrap(err, "invalid where"))
 		}

--- a/usecases/objects/batch_delete_test.go
+++ b/usecases/objects/batch_delete_test.go
@@ -1,0 +1,177 @@
+package objects
+
+import (
+	"context"
+	"testing"
+
+	"github.com/semi-technologies/weaviate/adapters/repos/db/vector/hnsw"
+	"github.com/semi-technologies/weaviate/entities/models"
+	"github.com/semi-technologies/weaviate/entities/schema"
+	"github.com/semi-technologies/weaviate/usecases/config"
+	"github.com/sirupsen/logrus/hooks/test"
+	"github.com/stretchr/testify/assert"
+)
+
+func Test_BatchDelete_RequestValidation(t *testing.T) {
+	var (
+		vectorRepo *fakeVectorRepo
+		manager    *BatchManager
+	)
+
+	schema := schema.Schema{
+		Objects: &models.Schema{
+			Classes: []*models.Class{
+				{
+					Class: "Foo",
+					Properties: []*models.Property{
+						{
+							Name:     "name",
+							DataType: []string{"string"},
+						},
+					},
+					VectorIndexConfig: hnsw.UserConfig{},
+					Vectorizer:        config.VectorizerModuleNone,
+				},
+			},
+		},
+	}
+
+	resetAutoSchema := func(autoSchema bool) {
+		vectorRepo = &fakeVectorRepo{}
+		config := &config.WeaviateConfig{
+			Config: config.Config{
+				AutoSchema: config.AutoSchema{
+					Enabled: autoSchema,
+				},
+			},
+		}
+		locks := &fakeLocks{}
+		schemaManager := &fakeSchemaManager{
+			GetSchemaResponse: schema,
+		}
+		logger, _ := test.NewNullLogger()
+		authorizer := &fakeAuthorizer{}
+		vectorizer := &fakeVectorizer{}
+		vecProvider := &fakeVectorizerProvider{vectorizer}
+		manager = NewBatchManager(vectorRepo, vecProvider, locks,
+			schemaManager, config, logger, authorizer)
+	}
+
+	reset := func() {
+		resetAutoSchema(false)
+	}
+	ctx := context.Background()
+
+	reset()
+
+	t.Run("with invalid input", func(t *testing.T) {
+		tests := []struct {
+			input         *models.BatchDelete
+			expectedError string
+		}{
+			{
+				input: &models.BatchDelete{
+					DryRun: ptBool(false),
+					Output: ptString(OutputVerbose),
+					Match: &models.BatchDeleteMatch{
+						Class: "SomeClass",
+						Where: &models.WhereFilter{
+							Path:        []string{"some", "path"},
+							Operator:    "Equal",
+							ValueString: ptString("value"),
+						},
+					},
+				},
+				expectedError: "validate: class: SomeClass doesn't exist",
+			},
+			{
+				input: &models.BatchDelete{
+					DryRun: ptBool(false),
+					Output: ptString(OutputVerbose),
+					Match: &models.BatchDeleteMatch{
+						Class: "Foo",
+						Where: &models.WhereFilter{
+							Path:        []string{"some"},
+							Operator:    "Equal",
+							ValueString: ptString("value"),
+						},
+					},
+				},
+				expectedError: "validate: invalid where filter: no such prop with name 'some' found in class 'Foo' " +
+					"in the schema. Check your schema files for which properties in this class are available",
+			},
+			{
+				input: &models.BatchDelete{
+					DryRun: ptBool(false),
+					Output: ptString(OutputVerbose),
+				},
+				expectedError: "validate: empty match clause",
+			},
+			{
+				input: &models.BatchDelete{
+					DryRun: ptBool(false),
+					Output: ptString(OutputVerbose),
+					Match: &models.BatchDeleteMatch{
+						Class: "",
+					},
+				},
+				expectedError: "validate: empty match.class clause",
+			},
+			{
+				input: &models.BatchDelete{
+					DryRun: ptBool(false),
+					Output: ptString(OutputVerbose),
+					Match: &models.BatchDeleteMatch{
+						Class: "Foo",
+					},
+				},
+				expectedError: "validate: empty match.where clause",
+			},
+			{
+				input: &models.BatchDelete{
+					DryRun: ptBool(false),
+					Output: ptString(OutputVerbose),
+					Match: &models.BatchDeleteMatch{
+						Class: "Foo",
+						Where: &models.WhereFilter{
+							Path:        []string{},
+							Operator:    "Equal",
+							ValueString: ptString("name"),
+						},
+					},
+				},
+				expectedError: "validate: failed to parse where filter: invalid where filter: field 'path': must have at least one element",
+			},
+			{
+				input: &models.BatchDelete{
+					DryRun: ptBool(false),
+					Output: ptString("Simplified Chinese"),
+					Match: &models.BatchDeleteMatch{
+						Class: "Foo",
+						Where: &models.WhereFilter{
+							Path:        []string{"name"},
+							Operator:    "Equal",
+							ValueString: ptString("value"),
+						},
+					},
+				},
+				expectedError: "validate: invalid output: \"Simplified Chinese\", possible values are: \"minimal\", \"verbose\"",
+			},
+		}
+
+		for _, test := range tests {
+			_, err := manager.DeleteObjects(ctx, nil, test.input.Match,
+				test.input.DryRun, test.input.Output)
+			assert.Equal(t, test.expectedError, err.Error())
+		}
+	})
+
+}
+
+func ptBool(b bool) *bool {
+	return &b
+}
+
+func ptString(s string) *string {
+	return &s
+}

--- a/usecases/objects/batch_delete_test.go
+++ b/usecases/objects/batch_delete_test.go
@@ -165,7 +165,6 @@ func Test_BatchDelete_RequestValidation(t *testing.T) {
 			assert.Equal(t, test.expectedError, err.Error())
 		}
 	})
-
 }
 
 func ptBool(b bool) *bool {


### PR DESCRIPTION
1. Fixes bug which prevented batch deletes by reference properties
2. Unifies whereFilter parsing across all use cases: classification, GQL queries, and batch deletion
3. Adds whereFilter parsing validation to the classification use case