### PR TITLE
Fix index out of range panic when trying to read links in hnsw index

### DIFF
--- a/adapters/repos/db/vector/hnsw/deserializer.go
+++ b/adapters/repos/db/vector/hnsw/deserializer.go
@@ -325,7 +325,7 @@ func (c *Deserializer) ReadClearLinks(r io.Reader, res *DeserializationResult,
 		return err
 	}
 
-	if int(id) > len(res.Nodes) {
+	if int(id) >= len(res.Nodes) {
 		// node is out of bounds, so it can't exist, nothing to do here
 		return nil
 	}
@@ -351,7 +351,7 @@ func (c *Deserializer) ReadClearLinksAtLevel(r io.Reader, res *DeserializationRe
 		return err
 	}
 
-	if int(id) > len(res.Nodes) {
+	if int(id) >= len(res.Nodes) {
 		// node is out of bounds, so it can't exist, nothing to do here
 		return nil
 	}

--- a/adapters/repos/db/vector/hnsw/deserializer_test.go
+++ b/adapters/repos/db/vector/hnsw/deserializer_test.go
@@ -147,3 +147,50 @@ func TestDeserializerReadDeleteNode(t *testing.T) {
 		}
 	}
 }
+
+func TestDeserializerReadClearLinks(t *testing.T) {
+	nodes := generateDummyVertices(4)
+	res := &DeserializationResult{
+		Nodes: nodes,
+	}
+	ids := []uint64{2, 3, 4, 5, 6}
+
+	for _, id := range ids {
+		val := make([]byte, 8)
+		binary.LittleEndian.PutUint64(val, id)
+		data := bytes.NewReader(val)
+		logger, _ := test.NewNullLogger()
+		d := NewDeserializer(logger)
+
+		reader := bufio.NewReader(data)
+
+		err := d.ReadClearLinks(reader, res, true)
+		if err != nil {
+			t.Errorf("Error reading links: %v", err)
+		}
+	}
+}
+
+func TestDeserializerReadClearLinksAtLevel(t *testing.T) {
+	nodes := generateDummyVertices(4)
+	res := &DeserializationResult{
+		Nodes: nodes,
+	}
+	ids := []uint64{2, 3, 4, 5, 6}
+
+	for _, id := range ids {
+		val := make([]byte, 10)
+		binary.LittleEndian.PutUint64(val, id)
+		binary.LittleEndian.PutUint16(val, uint16(id))
+		data := bytes.NewReader(val)
+		logger, _ := test.NewNullLogger()
+		d := NewDeserializer(logger)
+
+		reader := bufio.NewReader(data)
+
+		err := d.ReadClearLinksAtLevel(reader, res, false)
+		if err != nil {
+			t.Errorf("Error reading links at level: %v", err)
+		}
+	}
+}


### PR DESCRIPTION
This PR fixes a panic when we try to get a `node` from `nodes` array where it's index equals the length of the `nodes` array: `index == len(nodes)`:

```
panic: runtime error: index out of range [4] with length 4 [recovered]
	panic: runtime error: index out of range [4] with length 4
```