### PR TITLE
Improve HNSW Monitoring Capabilities (Operations, Deletes, Cleanup)

### DIFF
--- a/adapters/repos/db/shard.go
+++ b/adapters/repos/db/shard.go
@@ -109,9 +109,12 @@ func NewShard(ctx context.Context, promMetrics *monitoring.PrometheusMetrics,
 		}
 
 		vi, err := hnsw.New(hnsw.Config{
-			Logger:   index.logger,
-			RootPath: s.index.Config.RootPath,
-			ID:       s.ID(),
+			Logger:            index.logger,
+			RootPath:          s.index.Config.RootPath,
+			ID:                s.ID(),
+			ShardName:         s.name,
+			ClassName:         s.index.Config.ClassName.String(),
+			PrometheusMetrics: s.promMetrics,
 			MakeCommitLoggerThunk: func() (hnsw.CommitLogger, error) {
 				// Previously we had an interval of 10s in here, which was changed to
 				// 0.5s as part of gh-1867. There's really no way to wait so long in

--- a/adapters/repos/db/vector/hnsw/config.go
+++ b/adapters/repos/db/vector/hnsw/config.go
@@ -19,6 +19,7 @@ import (
 	"github.com/pkg/errors"
 	"github.com/semi-technologies/weaviate/adapters/repos/db/vector/hnsw/distancer"
 	"github.com/semi-technologies/weaviate/entities/schema"
+	"github.com/semi-technologies/weaviate/usecases/monitoring"
 	"github.com/sirupsen/logrus"
 )
 
@@ -33,6 +34,11 @@ type Config struct {
 	VectorForIDThunk      VectorForID
 	Logger                logrus.FieldLogger
 	DistanceProvider      distancer.Provider
+	PrometheusMetrics     *monitoring.PrometheusMetrics
+
+	// metadata for monitoring
+	ShardName string
+	ClassName string
 }
 
 func (c Config) Validate() error {

--- a/adapters/repos/db/vector/hnsw/config.go
+++ b/adapters/repos/db/vector/hnsw/config.go
@@ -99,7 +99,7 @@ func (ec *errorCompounder) toError() error {
 }
 
 const (
-	DefaultCleanupIntervalSeconds = 5 * 60
+	DefaultCleanupIntervalSeconds = 1
 	DefaultMaxConnections         = 64
 	DefaultEFConstruction         = 128
 	DefaultEF                     = -1 // indicates "let Weaviate pick"

--- a/adapters/repos/db/vector/hnsw/config.go
+++ b/adapters/repos/db/vector/hnsw/config.go
@@ -99,7 +99,7 @@ func (ec *errorCompounder) toError() error {
 }
 
 const (
-	DefaultCleanupIntervalSeconds = 1
+	DefaultCleanupIntervalSeconds = 5 * 60
 	DefaultMaxConnections         = 64
 	DefaultEFConstruction         = 128
 	DefaultEF                     = -1 // indicates "let Weaviate pick"

--- a/adapters/repos/db/vector/hnsw/delete.go
+++ b/adapters/repos/db/vector/hnsw/delete.go
@@ -26,6 +26,7 @@ func (h *hnsw) Delete(id uint64) error {
 	h.deleteLock.Lock()
 	defer h.deleteLock.Unlock()
 
+	h.metrics.DeleteVector()
 	if err := h.addTombstone(id); err != nil {
 		return err
 	}

--- a/adapters/repos/db/vector/hnsw/delete.go
+++ b/adapters/repos/db/vector/hnsw/delete.go
@@ -116,6 +116,9 @@ func (h *hnsw) copyTombstonesToAllowList() helpers.AllowList {
 // CleanUpTombstonedNodes removes nodes with a tombstone and reassignes edges
 // that were previously pointing to the tombstoned nodes
 func (h *hnsw) CleanUpTombstonedNodes() error {
+	h.metrics.StartCleanup(1)
+	defer h.metrics.EndCleanup(1)
+
 	deleteList := h.copyTombstonesToAllowList()
 	if len(deleteList) == 0 {
 		return nil
@@ -240,6 +243,8 @@ func (h *hnsw) reassignNeighborsOf(deleteList helpers.AllowList) error {
 			return errors.Wrap(err, "find and connect neighbors")
 		}
 		neighborNode.unmarkAsMaintenance()
+
+		h.metrics.CleanedUp()
 	}
 
 	return nil

--- a/adapters/repos/db/vector/hnsw/index.go
+++ b/adapters/repos/db/vector/hnsw/index.go
@@ -107,6 +107,8 @@ type hnsw struct {
 	pools *pools
 
 	forbidFlat bool // mostly used in testing scenarios where we want to use the index even in scenarios where we typically wouldn't
+
+	metrics *Metrics
 }
 
 type CommitLogger interface {
@@ -192,6 +194,8 @@ func New(cfg Config, uc UserConfig) (*hnsw, error) {
 		efMin:    int64(uc.DynamicEFMin),
 		efMax:    int64(uc.DynamicEFMax),
 		efFactor: int64(uc.DynamicEFFactor),
+
+		metrics: NewMetrics(cfg.PrometheusMetrics, cfg.ClassName, cfg.ShardName),
 	}
 
 	if err := index.init(cfg); err != nil {

--- a/adapters/repos/db/vector/hnsw/insert.go
+++ b/adapters/repos/db/vector/hnsw/insert.go
@@ -24,6 +24,8 @@ func (h *hnsw) Add(id uint64, vector []float32) error {
 		return errors.Errorf("insert called with nil-vector")
 	}
 
+	h.metrics.InsertVector()
+
 	node := &vertex{
 		id: id,
 	}

--- a/adapters/repos/db/vector/hnsw/metrics.go
+++ b/adapters/repos/db/vector/hnsw/metrics.go
@@ -1,0 +1,82 @@
+package hnsw
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/semi-technologies/weaviate/usecases/monitoring"
+)
+
+type Metrics struct {
+	enabled    bool
+	tombstones prometheus.Gauge
+	threads    prometheus.Gauge
+	cleaned    prometheus.Counter
+}
+
+func NewMetrics(prom *monitoring.PrometheusMetrics,
+	className, shardName string) *Metrics {
+	if prom == nil {
+		return &Metrics{enabled: false}
+	}
+
+	tombstones := prom.VectorIndexTombstones.With(prometheus.Labels{
+		"class_name": className,
+		"shard_name": shardName,
+	})
+
+	threads := prom.VectorIndexTombstoneCleanupThreads.With(prometheus.Labels{
+		"class_name": className,
+		"shard_name": shardName,
+	})
+
+	cleaned := prom.VectorIndexTombstoneCleanedCount.With(prometheus.Labels{
+		"class_name": className,
+		"shard_name": shardName,
+	})
+
+	return &Metrics{
+		enabled:    true,
+		tombstones: tombstones,
+		threads:    threads,
+		cleaned:    cleaned,
+	}
+}
+
+func (m *Metrics) AddTombstone() {
+	if !m.enabled {
+		return
+	}
+
+	m.tombstones.Inc()
+}
+
+func (m *Metrics) RemoveTombstone() {
+	if !m.enabled {
+		return
+	}
+
+	m.tombstones.Dec()
+}
+
+func (m *Metrics) StartCleanup(threads int) {
+	if !m.enabled {
+		return
+	}
+
+	m.threads.Add(float64(threads))
+}
+
+func (m *Metrics) EndCleanup(threads int) {
+	if !m.enabled {
+		return
+	}
+
+	m.threads.Sub(float64(threads))
+}
+
+func (m *Metrics) CleanedUp() {
+	if !m.enabled {
+		return
+	}
+
+	m.cleaned.Inc()
+}

--- a/adapters/repos/db/vector/hnsw/metrics.go
+++ b/adapters/repos/db/vector/hnsw/metrics.go
@@ -9,6 +9,8 @@ type Metrics struct {
 	enabled    bool
 	tombstones prometheus.Gauge
 	threads    prometheus.Gauge
+	insert     prometheus.Gauge
+	delete     prometheus.Gauge
 	cleaned    prometheus.Counter
 }
 
@@ -33,11 +35,25 @@ func NewMetrics(prom *monitoring.PrometheusMetrics,
 		"shard_name": shardName,
 	})
 
+	insert := prom.VectorIndexOperations.With(prometheus.Labels{
+		"class_name": className,
+		"shard_name": shardName,
+		"operation":  "create",
+	})
+
+	del := prom.VectorIndexOperations.With(prometheus.Labels{
+		"class_name": className,
+		"shard_name": shardName,
+		"operation":  "delete",
+	})
+
 	return &Metrics{
 		enabled:    true,
 		tombstones: tombstones,
 		threads:    threads,
 		cleaned:    cleaned,
+		insert:     insert,
+		delete:     del,
 	}
 }
 
@@ -79,4 +95,20 @@ func (m *Metrics) CleanedUp() {
 	}
 
 	m.cleaned.Inc()
+}
+
+func (m *Metrics) InsertVector() {
+	if !m.enabled {
+		return
+	}
+
+	m.insert.Inc()
+}
+
+func (m *Metrics) DeleteVector() {
+	if !m.enabled {
+		return
+	}
+
+	m.delete.Inc()
 }

--- a/tools/dev/grafana/dashboards/importing.json
+++ b/tools/dev/grafana/dashboards/importing.json
@@ -527,6 +527,7 @@
         "type": "prometheus",
         "uid": "Prometheus"
       },
+      "description": "If a node had an outgoing connection to another node that received a tombstone it must be reassigned.",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -580,7 +581,7 @@
           "refId": "A"
         }
       ],
-      "title": "Total cleaned up tombstones",
+      "title": "Reassigned Nodes",
       "type": "stat"
     },
     {
@@ -643,8 +644,8 @@
         "overrides": []
       },
       "gridPos": {
-        "h": 8,
-        "w": 12,
+        "h": 7,
+        "w": 6,
         "x": 0,
         "y": 18
       },
@@ -708,6 +709,92 @@
       "fieldConfig": {
         "defaults": {
           "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "text",
+                "value": null
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 6,
+        "x": 6,
+        "y": 18
+      },
+      "id": 19,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "center",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "pluginVersion": "8.3.3",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "Prometheus"
+          },
+          "exemplar": true,
+          "expr": "vector_index_operations{operation=\"create\"}",
+          "interval": "",
+          "legendFormat": "Vectors Inserted",
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "Prometheus"
+          },
+          "exemplar": true,
+          "expr": "vector_index_operations{operation=\"delete\"}",
+          "hide": false,
+          "interval": "",
+          "legendFormat": "Vectors Deleted",
+          "refId": "B"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "Prometheus"
+          },
+          "exemplar": false,
+          "expr": "vector_index_operations{operation=\"create\"} - ignoring(operation) vector_index_operations{operation=\"delete\"} ",
+          "hide": false,
+          "instant": false,
+          "interval": "",
+          "legendFormat": "Net Vectors",
+          "refId": "C"
+        }
+      ],
+      "title": "Vector Index Statistics",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "Prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
             "mode": "palette-classic"
           },
           "custom": {
@@ -760,7 +847,7 @@
         "h": 8,
         "w": 12,
         "x": 0,
-        "y": 26
+        "y": 25
       },
       "id": 4,
       "options": {
@@ -790,7 +877,7 @@
       "type": "timeseries"
     }
   ],
-  "refresh": "10s",
+  "refresh": "5s",
   "schemaVersion": 34,
   "style": "dark",
   "tags": [],
@@ -798,7 +885,7 @@
     "list": []
   },
   "time": {
-    "from": "now-15m",
+    "from": "now-15min",
     "to": "now"
   },
   "timepicker": {},

--- a/tools/dev/grafana/dashboards/importing.json
+++ b/tools/dev/grafana/dashboards/importing.json
@@ -119,6 +119,161 @@
         "type": "prometheus",
         "uid": "Prometheus"
       },
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 9,
+        "w": 9,
+        "x": 12,
+        "y": 0
+      },
+      "id": 9,
+      "interval": "1",
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "single"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "Prometheus"
+          },
+          "exemplar": true,
+          "expr": "vector_index_tombstones",
+          "instant": false,
+          "interval": "",
+          "intervalFactor": 1,
+          "legendFormat": "{{class_name}} - {{shard_name}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Active Tombstones in HNSW index",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "Prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 100000
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 9,
+        "w": 3,
+        "x": 21,
+        "y": 0
+      },
+      "id": 11,
+      "options": {
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showThresholdLabels": false,
+        "showThresholdMarkers": true
+      },
+      "pluginVersion": "8.3.3",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "Prometheus"
+          },
+          "exemplar": true,
+          "expr": "sum(vector_index_tombstones)",
+          "interval": "",
+          "legendFormat": "",
+          "refId": "A"
+        }
+      ],
+      "title": "Currently active HNSW tombstones",
+      "type": "gauge"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "Prometheus"
+      },
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -215,6 +370,218 @@
       ],
       "title": "Persistence Tasks (Object, Vector)",
       "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "Prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 6,
+        "x": 12,
+        "y": 9
+      },
+      "id": 13,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "single"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "Prometheus"
+          },
+          "exemplar": true,
+          "expr": "vector_index_tombstone_cleanup_threads",
+          "interval": "",
+          "legendFormat": "{{class_name}} - {{shard_name}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Active Tombstone Cleanup Threads",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "Prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 3,
+        "x": 18,
+        "y": 9
+      },
+      "id": 15,
+      "options": {
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showThresholdLabels": false,
+        "showThresholdMarkers": true
+      },
+      "pluginVersion": "8.3.3",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "Prometheus"
+          },
+          "exemplar": true,
+          "expr": "sum(vector_index_tombstone_cleanup_threads)",
+          "interval": "",
+          "legendFormat": "",
+          "refId": "A"
+        }
+      ],
+      "title": "Active Tombstone Cleanup Threads",
+      "type": "gauge"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "Prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 3,
+        "x": 21,
+        "y": 9
+      },
+      "id": 17,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "pluginVersion": "8.3.3",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "Prometheus"
+          },
+          "exemplar": true,
+          "expr": "sum(vector_index_tombstone_cleaned)",
+          "interval": "",
+          "legendFormat": "",
+          "refId": "A"
+        }
+      ],
+      "title": "Total cleaned up tombstones",
+      "type": "stat"
     },
     {
       "datasource": {
@@ -423,7 +790,7 @@
       "type": "timeseries"
     }
   ],
-  "refresh": false,
+  "refresh": "10s",
   "schemaVersion": 34,
   "style": "dark",
   "tags": [],
@@ -431,8 +798,8 @@
     "list": []
   },
   "time": {
-    "from": "2022-01-18T14:52:33.183Z",
-    "to": "2022-01-18T16:31:04.762Z"
+    "from": "now-15m",
+    "to": "now"
   },
   "timepicker": {},
   "timezone": "",

--- a/tools/dev/grafana/dashboards/importing.json
+++ b/tools/dev/grafana/dashboards/importing.json
@@ -753,7 +753,7 @@
             "uid": "Prometheus"
           },
           "exemplar": true,
-          "expr": "vector_index_operations{operation=\"create\"}",
+          "expr": "sum(vector_index_operations{operation=\"create\"})",
           "interval": "",
           "legendFormat": "Vectors Inserted",
           "refId": "A"
@@ -764,7 +764,7 @@
             "uid": "Prometheus"
           },
           "exemplar": true,
-          "expr": "vector_index_operations{operation=\"delete\"}",
+          "expr": "sum(vector_index_operations{operation=\"delete\"})",
           "hide": false,
           "interval": "",
           "legendFormat": "Vectors Deleted",
@@ -776,7 +776,7 @@
             "uid": "Prometheus"
           },
           "exemplar": false,
-          "expr": "vector_index_operations{operation=\"create\"} - ignoring(operation) vector_index_operations{operation=\"delete\"} ",
+          "expr": "sum(vector_index_operations{operation=\"create\"}) - ignoring(operation) sum(vector_index_operations{operation=\"delete\"})",
           "hide": false,
           "instant": false,
           "interval": "",
@@ -885,7 +885,7 @@
     "list": []
   },
   "time": {
-    "from": "now-15min",
+    "from": "now-15m",
     "to": "now"
   },
   "timepicker": {},

--- a/tools/dev/run_dev_server.sh
+++ b/tools/dev/run_dev_server.sh
@@ -11,6 +11,8 @@ export LOG_LEVEL=debug
 export LOG_FORMAT=text
 export PROMETHEUS_MONITORING_ENABLED=true
 export ENABLE_EXPERIMENTAL_BM25=true
+export GO_BLOCK_PROFILE_RATE=20
+export GO_MUTEX_PROFILE_FRACTION=20
 
 case $CONFIG in
   debug)

--- a/usecases/config/config_handler.go
+++ b/usecases/config/config_handler.go
@@ -64,6 +64,7 @@ type Config struct {
 	AutoSchema              AutoSchema     `json:"auto_schema" yaml:"auto_schema"`
 	Cluster                 cluster.Config `json:"cluster" yaml:"cluster"`
 	Monitoring              Monitoring     `json:"monitoring" yaml:"monitoring"`
+	Profiling               Profiling      `json:"profiling" yaml:"profiling"`
 	DiskUse                 DiskUse        `json:"disk_use" yaml:"disk_use"`
 }
 
@@ -120,9 +121,14 @@ type Contextionary struct {
 }
 
 type Monitoring struct {
-	Enabled bool   `json:"enabled"`
-	Tool    string `json:"tool"`
-	Port    int    `json:"port"`
+	Enabled bool   `json:"enabled" yaml:"enabled"`
+	Tool    string `json:"tool" yaml:"tool"`
+	Port    int    `json:"port" yaml:"port"`
+}
+
+type Profiling struct {
+	BlockProfileRate     int `json:"blockProfileRate" yaml:"blockProfileRate"`
+	MutexProfileFraction int `json:"mutexProfileFraction" yaml:"mutexProfileFraction"`
 }
 
 type Persistence struct {

--- a/usecases/config/environment.go
+++ b/usecases/config/environment.go
@@ -181,6 +181,24 @@ func FromEnv(config *Config) error {
 		config.DiskUse.ReadOnlyPercentage = DefaultDiskUseReadonlyPercentage
 	}
 
+	if v := os.Getenv("GO_BLOCK_PROFILE_RATE"); v != "" {
+		asInt, err := strconv.Atoi(v)
+		if err != nil {
+			return errors.Wrapf(err, "parse GO_BLOCK_PROFILE_RATE as int")
+		}
+
+		config.Profiling.BlockProfileRate = asInt
+	}
+
+	if v := os.Getenv("GO_MUTEX_PROFILE_FRACTION"); v != "" {
+		asInt, err := strconv.Atoi(v)
+		if err != nil {
+			return errors.Wrapf(err, "parse GO_MUTEX_PROFILE_FRACTION as int")
+		}
+
+		config.Profiling.MutexProfileFraction = asInt
+	}
+
 	return nil
 }
 

--- a/usecases/monitoring/prometheus.go
+++ b/usecases/monitoring/prometheus.go
@@ -23,6 +23,7 @@ type PrometheusMetrics struct {
 	VectorIndexTombstones              *prometheus.GaugeVec
 	VectorIndexTombstoneCleanupThreads *prometheus.GaugeVec
 	VectorIndexTombstoneCleanedCount   *prometheus.CounterVec
+	VectorIndexOperations              *prometheus.GaugeVec
 }
 
 func NewPrometheusMetrics() *PrometheusMetrics { // TODO don't rely on global state for registration
@@ -55,5 +56,9 @@ func NewPrometheusMetrics() *PrometheusMetrics { // TODO don't rely on global st
 			Name: "vector_index_tombstone_cleaned",
 			Help: "Total number of deleted objects that have been cleaned up",
 		}, []string{"class_name", "shard_name"}),
+		VectorIndexOperations: promauto.NewGaugeVec(prometheus.GaugeOpts{
+			Name: "vector_index_operations",
+			Help: "Total number of mutating operations on the vector index",
+		}, []string{"operation", "class_name", "shard_name"}),
 	}
 }

--- a/usecases/monitoring/prometheus.go
+++ b/usecases/monitoring/prometheus.go
@@ -17,9 +17,12 @@ import (
 )
 
 type PrometheusMetrics struct {
-	BatchTime       *prometheus.HistogramVec
-	AsyncOperations *prometheus.GaugeVec
-	LSMSegmentCount *prometheus.GaugeVec
+	BatchTime                          *prometheus.HistogramVec
+	AsyncOperations                    *prometheus.GaugeVec
+	LSMSegmentCount                    *prometheus.GaugeVec
+	VectorIndexTombstones              *prometheus.GaugeVec
+	VectorIndexTombstoneCleanupThreads *prometheus.GaugeVec
+	VectorIndexTombstoneCleanedCount   *prometheus.CounterVec
 }
 
 func NewPrometheusMetrics() *PrometheusMetrics { // TODO don't rely on global state for registration
@@ -39,5 +42,18 @@ func NewPrometheusMetrics() *PrometheusMetrics { // TODO don't rely on global st
 			Name: "lsm_active_segments",
 			Help: "Number of currently ongoing async operations",
 		}, []string{"strategy", "class_name", "shard_name", "path"}),
+
+		VectorIndexTombstones: promauto.NewGaugeVec(prometheus.GaugeOpts{
+			Name: "vector_index_tombstones",
+			Help: "Number of active vector index tombstones",
+		}, []string{"class_name", "shard_name"}),
+		VectorIndexTombstoneCleanupThreads: promauto.NewGaugeVec(prometheus.GaugeOpts{
+			Name: "vector_index_tombstone_cleanup_threads",
+			Help: "Number of threads in use to clean up tombstones",
+		}, []string{"class_name", "shard_name"}),
+		VectorIndexTombstoneCleanedCount: promauto.NewCounterVec(prometheus.CounterOpts{
+			Name: "vector_index_tombstone_cleaned",
+			Help: "Total number of deleted objects that have been cleaned up",
+		}, []string{"class_name", "shard_name"}),
 	}
 }


### PR DESCRIPTION
## Public Info

This PR improves the monitoring capabilities for the HNSW vector index for the following points:
* Track number of active HNSW tombstones
* Track number of reassigned nodes (as part of tombstone cleanup)
* Track ongoing cleanup threads
* Track vector index high-level operations (insert, delete)
* Add ability to configure Golang block and mutex profiling through env vars (optional, off by default)

## Internal Info

This PR updates the internal Grafana sample dashboard to include all metrics that are currently obtained:

<img width="2803" alt="image" src="https://user-images.githubusercontent.com/8974479/172150856-509b6a1e-5b53-499f-9d7b-478f868fa133.png">
