### PR TITLE
Improve LSM Store Monitoring (Segment & Compaction Details)

### DIFF
--- a/adapters/repos/db/lsmkv/bucket.go
+++ b/adapters/repos/db/lsmkv/bucket.go
@@ -77,7 +77,7 @@ func NewBucket(ctx context.Context, dir string, logger logrus.FieldLogger,
 	}
 
 	sg, err := newSegmentGroup(dir, 3*time.Second, logger,
-		b.legacyMapSortingBeforeCompaction, metrics)
+		b.legacyMapSortingBeforeCompaction, metrics, b.strategy)
 	if err != nil {
 		return nil, errors.Wrap(err, "init disk segments")
 	}

--- a/adapters/repos/db/lsmkv/metrics.go
+++ b/adapters/repos/db/lsmkv/metrics.go
@@ -21,6 +21,7 @@ type Metrics struct {
 	CompactionSet     *prometheus.GaugeVec
 	CompactionMap     *prometheus.GaugeVec
 	ActiveSegments    *prometheus.GaugeVec
+	BloomFilters      prometheus.ObserverVec
 }
 
 func NewMetrics(promMetrics *monitoring.PrometheusMetrics, className,
@@ -48,6 +49,10 @@ func NewMetrics(promMetrics *monitoring.PrometheusMetrics, className,
 		CompactionSet:     set,
 		CompactionMap:     stratMap,
 		ActiveSegments: promMetrics.LSMSegmentCount.MustCurryWith(prometheus.Labels{
+			"class_name": className,
+			"shard_name": shardName,
+		}),
+		BloomFilters: promMetrics.LSMBloomFilters.MustCurryWith(prometheus.Labels{
 			"class_name": className,
 			"shard_name": shardName,
 		}),

--- a/adapters/repos/db/lsmkv/metrics.go
+++ b/adapters/repos/db/lsmkv/metrics.go
@@ -22,6 +22,9 @@ type Metrics struct {
 	CompactionMap     *prometheus.GaugeVec
 	ActiveSegments    *prometheus.GaugeVec
 	BloomFilters      prometheus.ObserverVec
+	SegmentObjects    *prometheus.GaugeVec
+	SegmentSize       *prometheus.GaugeVec
+	SegmentCount      *prometheus.GaugeVec
 }
 
 func NewMetrics(promMetrics *monitoring.PrometheusMetrics, className,
@@ -53,6 +56,18 @@ func NewMetrics(promMetrics *monitoring.PrometheusMetrics, className,
 			"shard_name": shardName,
 		}),
 		BloomFilters: promMetrics.LSMBloomFilters.MustCurryWith(prometheus.Labels{
+			"class_name": className,
+			"shard_name": shardName,
+		}),
+		SegmentObjects: promMetrics.LSMSegmentObjects.MustCurryWith(prometheus.Labels{
+			"class_name": className,
+			"shard_name": shardName,
+		}),
+		SegmentSize: promMetrics.LSMSegmentSize.MustCurryWith(prometheus.Labels{
+			"class_name": className,
+			"shard_name": shardName,
+		}),
+		SegmentCount: promMetrics.LSMSegmentCountByLevel.MustCurryWith(prometheus.Labels{
 			"class_name": className,
 			"shard_name": shardName,
 		}),

--- a/adapters/repos/db/lsmkv/segment.go
+++ b/adapters/repos/db/lsmkv/segment.go
@@ -61,6 +61,9 @@ type diskIndex interface {
 
 	// AllKeys in no specific order, e.g. for building a bloom filter
 	AllKeys() ([][]byte, error)
+
+	// Size of the index in bytes
+	Size() int
 }
 
 func newSegment(path string, logger logrus.FieldLogger, metrics *Metrics,
@@ -233,4 +236,15 @@ func (ind *segment) close() error {
 
 func (ind *segment) drop() error {
 	return os.Remove(ind.path)
+}
+
+// Size returns the total size of the segment in bytes, including the header
+// and index
+func (ind *segment) Size() int {
+	return len(ind.contents)
+}
+
+// Payload Size is only the payload of the index, excluding the index
+func (ind *segment) PayloadSize() int {
+	return int(ind.dataEndPos)
 }

--- a/adapters/repos/db/lsmkv/segment.go
+++ b/adapters/repos/db/lsmkv/segment.go
@@ -44,6 +44,7 @@ type segment struct {
 	index                 diskIndex
 	secondaryIndices      []diskIndex
 	logger                logrus.FieldLogger
+	metrics               *Metrics
 
 	// the net addition this segment adds with respect to all previous segments
 	countNetAdditions int
@@ -62,7 +63,7 @@ type diskIndex interface {
 	AllKeys() ([][]byte, error)
 }
 
-func newSegment(path string, logger logrus.FieldLogger,
+func newSegment(path string, logger logrus.FieldLogger, metrics *Metrics,
 	existsLower existsOnLowerSegmentsFn) (*segment, error) {
 	file, err := os.Open(path)
 	if err != nil {
@@ -111,6 +112,7 @@ func newSegment(path string, logger logrus.FieldLogger,
 		dataEndPos:          header.indexStart,
 		index:               primaryDiskIndex,
 		logger:              logger,
+		metrics:             metrics,
 	}
 
 	if ind.secondaryIndexCount > 0 {

--- a/adapters/repos/db/lsmkv/segment_group.go
+++ b/adapters/repos/db/lsmkv/segment_group.go
@@ -104,7 +104,7 @@ func newSegmentGroup(dir string,
 		}
 
 		segment, err := newSegment(filepath.Join(dir, fileInfo.Name()), logger,
-			out.makeExistsOnLower(segmentIndex))
+			metrics, out.makeExistsOnLower(segmentIndex))
 		if err != nil {
 			return nil, errors.Wrapf(err, "init segment %s", fileInfo.Name())
 		}
@@ -142,7 +142,8 @@ func (ig *SegmentGroup) add(path string) error {
 	defer ig.maintenanceLock.Unlock()
 
 	newSegmentIndex := len(ig.segments)
-	segment, err := newSegment(path, ig.logger, ig.makeExistsOnLower(newSegmentIndex))
+	segment, err := newSegment(path, ig.logger, ig.metrics,
+		ig.makeExistsOnLower(newSegmentIndex))
 	if err != nil {
 		return errors.Wrapf(err, "init segment %s", path)
 	}

--- a/adapters/repos/db/lsmkv/segment_group.go
+++ b/adapters/repos/db/lsmkv/segment_group.go
@@ -52,7 +52,7 @@ type SegmentGroup struct {
 
 func newSegmentGroup(dir string,
 	compactionCycle time.Duration, logger logrus.FieldLogger,
-	mapRequiresSorting bool, metrics *Metrics) (*SegmentGroup, error) {
+	mapRequiresSorting bool, metrics *Metrics, strategy string) (*SegmentGroup, error) {
 	list, err := ioutil.ReadDir(dir)
 	if err != nil {
 		return nil, err
@@ -65,6 +65,7 @@ func newSegmentGroup(dir string,
 		metrics:             metrics,
 		stopCompactionCycle: make(chan struct{}),
 		mapRequiresSorting:  mapRequiresSorting,
+		strategy:            strategy,
 	}
 
 	segmentIndex := 0

--- a/adapters/repos/db/lsmkv/segment_group_compaction.go
+++ b/adapters/repos/db/lsmkv/segment_group_compaction.go
@@ -323,6 +323,7 @@ func (ig *SegmentGroup) monitorSegments() {
 			"strategy": ig.strategy,
 			"unit":     "index",
 			"level":    level,
+			"path":     ig.dir,
 		}).Set(float64(size))
 	}
 
@@ -331,6 +332,7 @@ func (ig *SegmentGroup) monitorSegments() {
 			"strategy": ig.strategy,
 			"unit":     "payload",
 			"level":    level,
+			"path":     ig.dir,
 		}).Set(float64(size))
 	}
 
@@ -338,6 +340,7 @@ func (ig *SegmentGroup) monitorSegments() {
 		ig.metrics.SegmentCount.With(prometheus.Labels{
 			"strategy": ig.strategy,
 			"level":    level,
+			"path":     ig.dir,
 		}).Set(float64(count))
 	}
 }

--- a/adapters/repos/db/lsmkv/segment_group_compaction.go
+++ b/adapters/repos/db/lsmkv/segment_group_compaction.go
@@ -222,7 +222,7 @@ func (ig *SegmentGroup) replaceCompactedSegments(old1, old2 int,
 	}
 
 	exists := ig.makeExistsOnLower(old1)
-	seg, err := newSegment(newPath, ig.logger, exists)
+	seg, err := newSegment(newPath, ig.logger, ig.metrics, exists)
 	if err != nil {
 		return errors.Wrap(err, "create new segment")
 	}

--- a/adapters/repos/db/lsmkv/segmentindex/disk_tree.go
+++ b/adapters/repos/db/lsmkv/segmentindex/disk_tree.go
@@ -187,3 +187,7 @@ func (t *DiskTree) AllKeys() ([][]byte, error) {
 
 	return out, nil
 }
+
+func (t *DiskTree) Size() int {
+	return len(t.data)
+}

--- a/adapters/repos/db/metrics.go
+++ b/adapters/repos/db/metrics.go
@@ -23,6 +23,7 @@ type Metrics struct {
 	logger     logrus.FieldLogger
 	monitoring bool
 	batchTime  prometheus.ObserverVec
+	objectTime prometheus.ObserverVec
 }
 
 func NewMetrics(logger logrus.FieldLogger, prom *monitoring.PrometheusMetrics,
@@ -33,14 +34,14 @@ func NewMetrics(logger logrus.FieldLogger, prom *monitoring.PrometheusMetrics,
 
 	if prom != nil {
 		m.monitoring = true
-		batchTime, err := prom.BatchTime.CurryWith(prometheus.Labels{
+		m.batchTime = prom.BatchTime.MustCurryWith(prometheus.Labels{
 			"class_name": className,
 			"shard_name": shardName,
 		})
-		if err != nil {
-			panic(err)
-		}
-		m.batchTime = batchTime
+		m.objectTime = prom.ObjectsTime.MustCurryWith(prometheus.Labels{
+			"class_name": className,
+			"shard_name": shardName,
+		})
 	}
 
 	return m
@@ -60,10 +61,12 @@ func (m *Metrics) ObjectStore(start time.Time) {
 		WithField("took", took).
 		Tracef("storing objects in KV/inverted store took %s", took)
 
-	if m.monitoring {
-		m.batchTime.With(prometheus.Labels{"operation": "object_storage"}).
-			Observe(float64(took / time.Millisecond))
+	if !m.monitoring {
+		return
 	}
+
+	m.batchTime.With(prometheus.Labels{"operation": "object_storage"}).
+		Observe(float64(took / time.Millisecond))
 }
 
 func (m *Metrics) VectorIndex(start time.Time) {
@@ -72,10 +75,12 @@ func (m *Metrics) VectorIndex(start time.Time) {
 		WithField("took", took).
 		Tracef("storing objects vector index took %s", took)
 
-	if m.monitoring {
-		m.batchTime.With(prometheus.Labels{"operation": "vector_storage"}).
-			Observe(float64(took / time.Millisecond))
+	if !m.monitoring {
+		return
 	}
+
+	m.batchTime.With(prometheus.Labels{"operation": "vector_storage"}).
+		Observe(float64(took / time.Millisecond))
 }
 
 func (m *Metrics) PutObject(start time.Time) {
@@ -83,6 +88,31 @@ func (m *Metrics) PutObject(start time.Time) {
 	m.logger.WithField("action", "store_object_store_single_object_in_tx").
 		WithField("took", took).
 		Tracef("storing single object (complete) in KV/inverted took %s", took)
+
+	if !m.monitoring {
+		return
+	}
+
+	m.objectTime.With(prometheus.Labels{
+		"operation": "put",
+		"step":      "total",
+	}).Observe(float64(took) / float64(time.Millisecond))
+}
+
+func (m *Metrics) PutObjectDetermineStatus(start time.Time) {
+	took := time.Since(start)
+	m.logger.WithField("action", "store_object_store_determine_status").
+		WithField("took", took).
+		Tracef("retrieving previous and determining status in KV took %s", took)
+
+	if !m.monitoring {
+		return
+	}
+
+	m.objectTime.With(prometheus.Labels{
+		"operation": "put",
+		"step":      "retrieve_previous_determine_status",
+	}).Observe(float64(took) / float64(time.Millisecond))
 }
 
 func (m *Metrics) PutObjectUpsertObject(start time.Time) {
@@ -90,13 +120,15 @@ func (m *Metrics) PutObjectUpsertObject(start time.Time) {
 	m.logger.WithField("action", "store_object_store_upsert_object_data").
 		WithField("took", took).
 		Tracef("storing object data in KV took %s", took)
-}
 
-func (m *Metrics) PutObjectUpdateDocID(start time.Time) {
-	took := time.Since(start)
-	m.logger.WithField("action", "store_object_store_update_index_id").
-		WithField("took", took).
-		Tracef("updating doc id in KV/inverted took %s", took)
+	if !m.monitoring {
+		return
+	}
+
+	m.objectTime.With(prometheus.Labels{
+		"operation": "put",
+		"step":      "upsert_object_store",
+	}).Observe(float64(took) / float64(time.Millisecond))
 }
 
 func (m *Metrics) PutObjectUpdateInverted(start time.Time) {
@@ -104,6 +136,15 @@ func (m *Metrics) PutObjectUpdateInverted(start time.Time) {
 	m.logger.WithField("action", "store_object_store_update_inverted").
 		WithField("took", took).
 		Tracef("updating inverted index for single object took %s", took)
+
+	if !m.monitoring {
+		return
+	}
+
+	m.objectTime.With(prometheus.Labels{
+		"operation": "put",
+		"step":      "inverted_total",
+	}).Observe(float64(took) / float64(time.Millisecond))
 }
 
 func (m *Metrics) InvertedDeleteOld(start time.Time) {
@@ -111,6 +152,14 @@ func (m *Metrics) InvertedDeleteOld(start time.Time) {
 	m.logger.WithField("action", "inverted_delete_old").
 		WithField("took", took).
 		Tracef("deleting old entries from inverted index %s", took)
+	if !m.monitoring {
+		return
+	}
+
+	m.objectTime.With(prometheus.Labels{
+		"operation": "put",
+		"step":      "inverted_delete",
+	}).Observe(float64(took) / float64(time.Millisecond))
 }
 
 func (m *Metrics) InvertedDeleteDelta(start time.Time) {
@@ -126,4 +175,13 @@ func (m *Metrics) InvertedExtend(start time.Time, propCount int) {
 		WithField("took", took).
 		WithField("prop_count", propCount).
 		Tracef("extending inverted index took %s", took)
+
+	if !m.monitoring {
+		return
+	}
+
+	m.objectTime.With(prometheus.Labels{
+		"operation": "put",
+		"step":      "inverted_extend",
+	}).Observe(float64(took) / float64(time.Millisecond))
 }

--- a/adapters/repos/db/shard.go
+++ b/adapters/repos/db/shard.go
@@ -192,7 +192,7 @@ func (s *Shard) initDBFile(ctx context.Context) error {
 	})
 	var metrics *lsmkv.Metrics
 	if s.promMetrics != nil {
-		lsmkv.NewMetrics(s.promMetrics, string(s.index.Config.ClassName), s.name)
+		metrics = lsmkv.NewMetrics(s.promMetrics, string(s.index.Config.ClassName), s.name)
 	}
 
 	store, err := lsmkv.New(s.DBPathLSM(), annotatedLogger, metrics)

--- a/adapters/repos/db/shard_write_put.go
+++ b/adapters/repos/db/shard_write_put.go
@@ -109,6 +109,7 @@ func (s *Shard) putObjectLSM(object *storobj.Object,
 	if err != nil {
 		return status, errors.Wrap(err, "check insert/update status")
 	}
+	s.metrics.PutObjectDetermineStatus(before)
 
 	object.SetDocID(status.docID)
 	data, err := object.MarshalBinary()

--- a/tools/dev/grafana/dashboards/lsm.json
+++ b/tools/dev/grafana/dashboards/lsm.json
@@ -73,7 +73,7 @@
         },
         "textMode": "auto"
       },
-      "pluginVersion": "9.0.0-beta2",
+      "pluginVersion": "8.3.3",
       "targets": [
         {
           "datasource": {
@@ -136,7 +136,7 @@
         },
         "textMode": "auto"
       },
-      "pluginVersion": "9.0.0-beta2",
+      "pluginVersion": "8.3.3",
       "targets": [
         {
           "datasource": {
@@ -158,7 +158,7 @@
         "type": "prometheus",
         "uid": "Prometheus"
       },
-      "description": "SetCollections are used in the inverted index for anything that does not have a frequency, e.g. numbers, bools, etc.",
+      "description": "MapCollections are used in the inverted index for anything that has a frequency, which is mainly text and string props. Those need a frequency for BM25 calculations.",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -199,7 +199,7 @@
         },
         "textMode": "auto"
       },
-      "pluginVersion": "9.0.0-beta2",
+      "pluginVersion": "8.3.3",
       "targets": [
         {
           "datasource": {
@@ -213,7 +213,7 @@
           "refId": "A"
         }
       ],
-      "title": "LSM Strategy SetCollection by Level (Inverted without frequency)",
+      "title": "LSM Strategy MapCollection by Level (Inverted with frequency)",
       "type": "stat"
     },
     {
@@ -354,7 +354,7 @@
         "showThresholdLabels": false,
         "showThresholdMarkers": true
       },
-      "pluginVersion": "9.0.0-beta2",
+      "pluginVersion": "8.3.3",
       "targets": [
         {
           "datasource": {
@@ -415,7 +415,7 @@
         "text": {},
         "textMode": "auto"
       },
-      "pluginVersion": "9.0.0-beta2",
+      "pluginVersion": "8.3.3",
       "targets": [
         {
           "datasource": {
@@ -503,7 +503,7 @@
         },
         "showUnfilled": true
       },
-      "pluginVersion": "9.0.0-beta2",
+      "pluginVersion": "8.3.3",
       "targets": [
         {
           "datasource": {
@@ -534,14 +534,14 @@
     }
   ],
   "refresh": false,
-  "schemaVersion": 36,
+  "schemaVersion": 34,
   "style": "dark",
   "tags": [],
   "templating": {
     "list": []
   },
   "time": {
-    "from": "now-5m",
+    "from": "now-15m",
     "to": "now"
   },
   "timepicker": {},

--- a/tools/dev/grafana/dashboards/lsm.json
+++ b/tools/dev/grafana/dashboards/lsm.json
@@ -32,6 +32,195 @@
         "type": "prometheus",
         "uid": "Prometheus"
       },
+      "description": "Replace is used primarly for object storage, but also for inverted index hash buckets.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "text",
+                "value": null
+              }
+            ]
+          },
+          "unit": "decbytes"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 10,
+        "w": 8,
+        "x": 0,
+        "y": 0
+      },
+      "id": 8,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "pluginVersion": "9.0.0-beta2",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "Prometheus"
+          },
+          "editorMode": "code",
+          "expr": "sum by (level, unit) (lsm_segment_size{strategy=\"replace\"})",
+          "legendFormat": "Level {{level}} / {{unit}} ",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "LSM Strategy Replace by Level (Object Storage)",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "Prometheus"
+      },
+      "description": "SetCollections are used in the inverted index for anything that does not have a frequency, e.g. numbers, bools, etc.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "text",
+                "value": null
+              }
+            ]
+          },
+          "unit": "decbytes"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 10,
+        "w": 8,
+        "x": 8,
+        "y": 0
+      },
+      "id": 9,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "pluginVersion": "9.0.0-beta2",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "Prometheus"
+          },
+          "editorMode": "code",
+          "expr": "sum by (level, unit) (lsm_segment_size{strategy=\"setcollection\"})",
+          "legendFormat": "Level {{level}} / {{unit}} ",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "LSM Strategy SetCollection by Level (Inverted without frequency)",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "Prometheus"
+      },
+      "description": "SetCollections are used in the inverted index for anything that does not have a frequency, e.g. numbers, bools, etc.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "text",
+                "value": null
+              }
+            ]
+          },
+          "unit": "decbytes"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 10,
+        "w": 8,
+        "x": 16,
+        "y": 0
+      },
+      "id": 10,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "pluginVersion": "9.0.0-beta2",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "Prometheus"
+          },
+          "editorMode": "code",
+          "expr": "sum by (level, unit) (lsm_segment_size{strategy=\"mapcollection\"})",
+          "legendFormat": "Level {{level}} / {{unit}} ",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "LSM Strategy SetCollection by Level (Inverted without frequency)",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "Prometheus"
+      },
       "description": "The bloom filters are designed to quickly produce true negatives, but sometimes they have false positive which require an actual disk lookup.",
       "fieldConfig": {
         "defaults": {
@@ -85,9 +274,9 @@
       },
       "gridPos": {
         "h": 8,
-        "w": 10,
+        "w": 8,
         "x": 0,
-        "y": 0
+        "y": 10
       },
       "id": 2,
       "options": {
@@ -149,8 +338,8 @@
       "gridPos": {
         "h": 8,
         "w": 3,
-        "x": 10,
-        "y": 0
+        "x": 8,
+        "y": 10
       },
       "id": 4,
       "options": {
@@ -206,9 +395,9 @@
       },
       "gridPos": {
         "h": 8,
-        "w": 11,
-        "x": 13,
-        "y": 0
+        "w": 7,
+        "x": 11,
+        "y": 10
       },
       "id": 6,
       "options": {
@@ -266,6 +455,82 @@
       ],
       "title": "Bloom Filter Access",
       "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "Prometheus"
+      },
+      "description": "The grouping is done by strategy which means the reported Object storage value is slightly too high, as all inverted index hash buckets are also of type replace.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "min": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "text",
+                "value": null
+              }
+            ]
+          },
+          "unit": "decbytes"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 6,
+        "x": 18,
+        "y": 10
+      },
+      "id": 12,
+      "options": {
+        "displayMode": "gradient",
+        "minVizHeight": 10,
+        "minVizWidth": 0,
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showUnfilled": true
+      },
+      "pluginVersion": "9.0.0-beta2",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "Prometheus"
+          },
+          "editorMode": "code",
+          "expr": "sum(lsm_segment_size{strategy=\"replace\"})",
+          "legendFormat": "Object Storage",
+          "range": true,
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "Prometheus"
+          },
+          "editorMode": "code",
+          "expr": "sum(lsm_segment_size{strategy=\"mapcollection\"}) + ignoring(strategy) sum(lsm_segment_size{strategy=\"setcollection\"})",
+          "hide": false,
+          "legendFormat": "Inverted Index",
+          "range": true,
+          "refId": "B"
+        }
+      ],
+      "title": "Estimated Sizes LSM stores",
+      "type": "bargauge"
     }
   ],
   "refresh": false,
@@ -276,7 +541,7 @@
     "list": []
   },
   "time": {
-    "from": "now-15m",
+    "from": "now-5m",
     "to": "now"
   },
   "timepicker": {},

--- a/tools/dev/grafana/dashboards/lsm.json
+++ b/tools/dev/grafana/dashboards/lsm.json
@@ -1,0 +1,288 @@
+{
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": {
+          "type": "grafana",
+          "uid": "-- Grafana --"
+        },
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "target": {
+          "limit": 100,
+          "matchAny": false,
+          "tags": [],
+          "type": "dashboard"
+        },
+        "type": "dashboard"
+      }
+    ]
+  },
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 0,
+  "links": [],
+  "liveNow": false,
+  "panels": [
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "Prometheus"
+      },
+      "description": "The bloom filters are designed to quickly produce true negatives, but sometimes they have false positive which require an actual disk lookup.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 10,
+        "x": 0,
+        "y": 0
+      },
+      "id": 2,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "Prometheus"
+          },
+          "editorMode": "code",
+          "expr": "rate(lsm_bloom_filters_duration_ms_sum{strategy=\"replace\"}[5s])/rate(lsm_bloom_filters_duration_ms_count{strategy=\"replace\"}[5s])",
+          "legendFormat": "{{operation}} ({{class_name}}/{{shard_name}})",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Bloom Filter Hits and Misses Duration",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "Prometheus"
+      },
+      "description": "Ratio of false-positive to all requests to the bloom filter, i.e. those that required an unnecessary disk lookup.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "percentunit"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 3,
+        "x": 10,
+        "y": 0
+      },
+      "id": 4,
+      "options": {
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showThresholdLabels": false,
+        "showThresholdMarkers": true
+      },
+      "pluginVersion": "9.0.0-beta2",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "Prometheus"
+          },
+          "expr": "sum(lsm_bloom_filters_duration_ms_count{operation=\"get_false_positive\"})/(sum(lsm_bloom_filters_duration_ms_count{operation=\"get_true_negative\"})+sum(lsm_bloom_filters_duration_ms_count{operation=\"get_true_positive\"})+sum(lsm_bloom_filters_duration_ms_count{operation=\"get_false_positive\"}))",
+          "refId": "A"
+        }
+      ],
+      "title": "Bloom Filter False Positive Ratio",
+      "type": "gauge"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "Prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "decimals": 0,
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "text",
+                "value": null
+              }
+            ]
+          },
+          "unit": "none"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 11,
+        "x": 13,
+        "y": 0
+      },
+      "id": 6,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "text": {},
+        "textMode": "auto"
+      },
+      "pluginVersion": "9.0.0-beta2",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "Prometheus"
+          },
+          "editorMode": "code",
+          "expr": "sum(lsm_bloom_filters_duration_ms_count{operation=\"get_true_positive\"})",
+          "legendFormat": "True Positives",
+          "range": true,
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "Prometheus"
+          },
+          "editorMode": "code",
+          "expr": "sum(lsm_bloom_filters_duration_ms_count{operation=\"get_true_negative\"})",
+          "hide": false,
+          "legendFormat": "True Negatives",
+          "range": true,
+          "refId": "B"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "Prometheus"
+          },
+          "editorMode": "code",
+          "expr": "sum(lsm_bloom_filters_duration_ms_count{operation=\"get_false_positive\"})",
+          "hide": false,
+          "legendFormat": "False Positives",
+          "range": true,
+          "refId": "C"
+        }
+      ],
+      "title": "Bloom Filter Access",
+      "type": "stat"
+    }
+  ],
+  "refresh": false,
+  "schemaVersion": 36,
+  "style": "dark",
+  "tags": [],
+  "templating": {
+    "list": []
+  },
+  "time": {
+    "from": "now-15m",
+    "to": "now"
+  },
+  "timepicker": {},
+  "timezone": "",
+  "title": "LSM Store",
+  "uid": "hPd0sernz",
+  "version": 1,
+  "weekStart": ""
+}

--- a/tools/dev/grafana/dashboards/objects.json
+++ b/tools/dev/grafana/dashboards/objects.json
@@ -24,7 +24,6 @@
   "editable": true,
   "fiscalYearStartMonth": 0,
   "graphTooltip": 0,
-  "id": 3,
   "links": [],
   "liveNow": false,
   "panels": [
@@ -118,9 +117,193 @@
       ],
       "title": "PUT (individual operations)",
       "type": "timeseries"
+    },
+    {
+      "cards": {},
+      "color": {
+        "cardColor": "#b4ff00",
+        "colorScale": "sqrt",
+        "colorScheme": "interpolateGreens",
+        "exponent": 0.5,
+        "mode": "spectrum"
+      },
+      "dataFormat": "tsbuckets",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "Prometheus"
+      },
+      "description": "",
+      "gridPos": {
+        "h": 7,
+        "w": 12,
+        "x": 12,
+        "y": 0
+      },
+      "heatmap": {},
+      "hideZeroBuckets": false,
+      "highlightCards": true,
+      "id": 4,
+      "legend": {
+        "show": false
+      },
+      "maxDataPoints": 25,
+      "reverseYBuckets": false,
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "Prometheus"
+          },
+          "exemplar": true,
+          "expr": "sum(increase(objects_durations_ms_bucket{step=\"total\"}[$__interval])) by (le)",
+          "format": "heatmap",
+          "interval": "",
+          "legendFormat": "{{le}}",
+          "refId": "A"
+        }
+      ],
+      "title": "PUT Object (Total)",
+      "tooltip": {
+        "show": true,
+        "showHistogram": false
+      },
+      "type": "heatmap",
+      "xAxis": {
+        "show": true
+      },
+      "yAxis": {
+        "decimals": 2,
+        "format": "ms",
+        "logBase": 1,
+        "show": true
+      },
+      "yBucketBound": "auto"
+    },
+    {
+      "cards": {},
+      "color": {
+        "cardColor": "#b4ff00",
+        "colorScale": "sqrt",
+        "colorScheme": "interpolateBlues",
+        "exponent": 0.5,
+        "mode": "spectrum"
+      },
+      "dataFormat": "tsbuckets",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "Prometheus"
+      },
+      "description": "",
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 7
+      },
+      "heatmap": {},
+      "hideZeroBuckets": false,
+      "highlightCards": true,
+      "id": 5,
+      "legend": {
+        "show": false
+      },
+      "maxDataPoints": 25,
+      "reverseYBuckets": false,
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "Prometheus"
+          },
+          "exemplar": true,
+          "expr": "sum(increase(objects_durations_ms_bucket{step=\"upsert_object_store\"}[$__interval])) by (le)",
+          "format": "heatmap",
+          "interval": "",
+          "legendFormat": "{{le}}",
+          "refId": "A"
+        }
+      ],
+      "title": "PUT Object (Upsert Object)",
+      "tooltip": {
+        "show": true,
+        "showHistogram": false
+      },
+      "type": "heatmap",
+      "xAxis": {
+        "show": true
+      },
+      "yAxis": {
+        "decimals": 2,
+        "format": "ms",
+        "logBase": 1,
+        "show": true
+      },
+      "yBucketBound": "auto"
+    },
+    {
+      "cards": {},
+      "color": {
+        "cardColor": "#b4ff00",
+        "colorScale": "sqrt",
+        "colorScheme": "interpolateOranges",
+        "exponent": 0.5,
+        "mode": "spectrum"
+      },
+      "dataFormat": "tsbuckets",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "Prometheus"
+      },
+      "description": "",
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 15
+      },
+      "heatmap": {},
+      "hideZeroBuckets": false,
+      "highlightCards": true,
+      "id": 6,
+      "legend": {
+        "show": false
+      },
+      "maxDataPoints": 25,
+      "reverseYBuckets": false,
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "Prometheus"
+          },
+          "exemplar": true,
+          "expr": "sum(increase(objects_durations_ms_bucket{step=\"inverted_total\"}[$__interval])) by (le)",
+          "format": "heatmap",
+          "interval": "",
+          "legendFormat": "{{le}}",
+          "refId": "A"
+        }
+      ],
+      "title": "PUT Object (Inverted Index)",
+      "tooltip": {
+        "show": true,
+        "showHistogram": false
+      },
+      "type": "heatmap",
+      "xAxis": {
+        "show": true
+      },
+      "yAxis": {
+        "decimals": 2,
+        "format": "ms",
+        "logBase": 1,
+        "show": true
+      },
+      "yBucketBound": "auto"
     }
   ],
-  "schemaVersion": 36,
+  "refresh": "5s",
+  "schemaVersion": 34,
   "style": "dark",
   "tags": [],
   "templating": {
@@ -134,6 +317,6 @@
   "timezone": "",
   "title": "Object Operations",
   "uid": "X48CZzj7k",
-  "version": 2,
+  "version": 1,
   "weekStart": ""
 }

--- a/tools/dev/grafana/dashboards/objects.json
+++ b/tools/dev/grafana/dashboards/objects.json
@@ -1,0 +1,139 @@
+{
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": {
+          "type": "grafana",
+          "uid": "-- Grafana --"
+        },
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "target": {
+          "limit": 100,
+          "matchAny": false,
+          "tags": [],
+          "type": "dashboard"
+        },
+        "type": "dashboard"
+      }
+    ]
+  },
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 0,
+  "id": 3,
+  "links": [],
+  "liveNow": false,
+  "panels": [
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "Prometheus"
+      },
+      "description": "Operations typically happen highly concurrently, so the per object time is often close to the overall batch time. Use this data to draw conclusions about relative changes over time, not for interpreting absolute values.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "ms"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 0
+      },
+      "id": 2,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "Prometheus"
+          },
+          "editorMode": "code",
+          "expr": "rate(objects_durations_ms_sum{operation=\"put\"}[5s])/rate(objects_durations_ms_count{operation=\"put\"}[5s])",
+          "legendFormat": "{{step}} ({{class_name}}/{{shard_name}})",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "PUT (individual operations)",
+      "type": "timeseries"
+    }
+  ],
+  "schemaVersion": 36,
+  "style": "dark",
+  "tags": [],
+  "templating": {
+    "list": []
+  },
+  "time": {
+    "from": "now-15m",
+    "to": "now"
+  },
+  "timepicker": {},
+  "timezone": "",
+  "title": "Object Operations",
+  "uid": "X48CZzj7k",
+  "version": 2,
+  "weekStart": ""
+}

--- a/usecases/monitoring/prometheus.go
+++ b/usecases/monitoring/prometheus.go
@@ -55,15 +55,15 @@ func NewPrometheusMetrics() *PrometheusMetrics { // TODO don't rely on global st
 		LSMSegmentObjects: promauto.NewGaugeVec(prometheus.GaugeOpts{
 			Name: "lsm_segment_objects",
 			Help: "Number of objects/entries of segment by level",
-		}, []string{"strategy", "class_name", "shard_name", "level"}),
+		}, []string{"strategy", "class_name", "shard_name", "path", "level"}),
 		LSMSegmentSize: promauto.NewGaugeVec(prometheus.GaugeOpts{
 			Name: "lsm_segment_size",
 			Help: "Size of segment by level and unit",
-		}, []string{"strategy", "class_name", "shard_name", "level", "unit"}),
+		}, []string{"strategy", "class_name", "shard_name", "path", "level", "unit"}),
 		LSMSegmentCountByLevel: promauto.NewGaugeVec(prometheus.GaugeOpts{
 			Name: "lsm_segment_count",
 			Help: "Number of segments by level",
-		}, []string{"strategy", "class_name", "shard_name", "level"}),
+		}, []string{"strategy", "class_name", "shard_name", "path", "level"}),
 
 		VectorIndexTombstones: promauto.NewGaugeVec(prometheus.GaugeOpts{
 			Name: "vector_index_tombstones",

--- a/usecases/monitoring/prometheus.go
+++ b/usecases/monitoring/prometheus.go
@@ -18,6 +18,7 @@ import (
 
 type PrometheusMetrics struct {
 	BatchTime                          *prometheus.HistogramVec
+	LSMBloomFilters                    *prometheus.HistogramVec
 	AsyncOperations                    *prometheus.GaugeVec
 	LSMSegmentCount                    *prometheus.GaugeVec
 	VectorIndexTombstones              *prometheus.GaugeVec
@@ -43,6 +44,11 @@ func NewPrometheusMetrics() *PrometheusMetrics { // TODO don't rely on global st
 			Name: "lsm_active_segments",
 			Help: "Number of currently ongoing async operations",
 		}, []string{"strategy", "class_name", "shard_name", "path"}),
+		LSMBloomFilters: promauto.NewHistogramVec(prometheus.HistogramOpts{
+			Name:    "lsm_bloom_filters_duration_ms",
+			Help:    "Duration of bloom filter operations",
+			Buckets: prometheus.ExponentialBuckets(0.001, 1.25, 60),
+		}, []string{"operation", "strategy", "class_name", "shard_name"}),
 
 		VectorIndexTombstones: promauto.NewGaugeVec(prometheus.GaugeOpts{
 			Name: "vector_index_tombstones",

--- a/usecases/monitoring/prometheus.go
+++ b/usecases/monitoring/prometheus.go
@@ -21,6 +21,9 @@ type PrometheusMetrics struct {
 	LSMBloomFilters                    *prometheus.HistogramVec
 	AsyncOperations                    *prometheus.GaugeVec
 	LSMSegmentCount                    *prometheus.GaugeVec
+	LSMSegmentCountByLevel             *prometheus.GaugeVec
+	LSMSegmentObjects                  *prometheus.GaugeVec
+	LSMSegmentSize                     *prometheus.GaugeVec
 	VectorIndexTombstones              *prometheus.GaugeVec
 	VectorIndexTombstoneCleanupThreads *prometheus.GaugeVec
 	VectorIndexTombstoneCleanedCount   *prometheus.CounterVec
@@ -42,13 +45,25 @@ func NewPrometheusMetrics() *PrometheusMetrics { // TODO don't rely on global st
 
 		LSMSegmentCount: promauto.NewGaugeVec(prometheus.GaugeOpts{
 			Name: "lsm_active_segments",
-			Help: "Number of currently ongoing async operations",
+			Help: "Number of currently present segments per shard",
 		}, []string{"strategy", "class_name", "shard_name", "path"}),
 		LSMBloomFilters: promauto.NewHistogramVec(prometheus.HistogramOpts{
 			Name:    "lsm_bloom_filters_duration_ms",
 			Help:    "Duration of bloom filter operations",
 			Buckets: prometheus.ExponentialBuckets(0.001, 1.25, 60),
 		}, []string{"operation", "strategy", "class_name", "shard_name"}),
+		LSMSegmentObjects: promauto.NewGaugeVec(prometheus.GaugeOpts{
+			Name: "lsm_segment_objects",
+			Help: "Number of objects/entries of segment by level",
+		}, []string{"strategy", "class_name", "shard_name", "level"}),
+		LSMSegmentSize: promauto.NewGaugeVec(prometheus.GaugeOpts{
+			Name: "lsm_segment_size",
+			Help: "Size of segment by level and unit",
+		}, []string{"strategy", "class_name", "shard_name", "level", "unit"}),
+		LSMSegmentCountByLevel: promauto.NewGaugeVec(prometheus.GaugeOpts{
+			Name: "lsm_segment_count",
+			Help: "Number of segments by level",
+		}, []string{"strategy", "class_name", "shard_name", "level"}),
 
 		VectorIndexTombstones: promauto.NewGaugeVec(prometheus.GaugeOpts{
 			Name: "vector_index_tombstones",

--- a/usecases/monitoring/prometheus.go
+++ b/usecases/monitoring/prometheus.go
@@ -42,7 +42,7 @@ func NewPrometheusMetrics() *PrometheusMetrics { // TODO don't rely on global st
 		ObjectsTime: promauto.NewHistogramVec(prometheus.HistogramOpts{
 			Name:    "objects_durations_ms",
 			Help:    "Duration of an individual object operation. Also as part of batches.",
-			Buckets: prometheus.ExponentialBuckets(0.1, 1.25, 40),
+			Buckets: prometheus.ExponentialBuckets(10, 1.25, 25),
 		}, []string{"operation", "step", "class_name", "shard_name"}),
 
 		AsyncOperations: promauto.NewGaugeVec(prometheus.GaugeOpts{

--- a/usecases/monitoring/prometheus.go
+++ b/usecases/monitoring/prometheus.go
@@ -18,6 +18,7 @@ import (
 
 type PrometheusMetrics struct {
 	BatchTime                          *prometheus.HistogramVec
+	ObjectsTime                        *prometheus.HistogramVec
 	LSMBloomFilters                    *prometheus.HistogramVec
 	AsyncOperations                    *prometheus.GaugeVec
 	LSMSegmentCount                    *prometheus.GaugeVec
@@ -37,6 +38,12 @@ func NewPrometheusMetrics() *PrometheusMetrics { // TODO don't rely on global st
 			Help:    "Duration in ms of a single batch",
 			Buckets: prometheus.ExponentialBuckets(10, 1.25, 40),
 		}, []string{"operation", "class_name", "shard_name"}),
+
+		ObjectsTime: promauto.NewHistogramVec(prometheus.HistogramOpts{
+			Name:    "objects_durations_ms",
+			Help:    "Duration of an individual object operation. Also as part of batches.",
+			Buckets: prometheus.ExponentialBuckets(0.1, 1.25, 40),
+		}, []string{"operation", "step", "class_name", "shard_name"}),
 
 		AsyncOperations: promauto.NewGaugeVec(prometheus.GaugeOpts{
 			Name: "async_operations_running",


### PR DESCRIPTION
## Public Info

This improves the monitoring capabilities of the LSM store. It tracks:
- Number of currently active segments
- Segment details size by level split into index and payload size
- Segment bloom filter statistics, including false-positive rate
- PUT Object durations split into total, object store, inverted store, etc. 

## Internal Info

This adds the following sample dashboard: 

<img width="1728" alt="image" src="https://user-images.githubusercontent.com/8974479/172257015-187d32d0-4f55-42af-9f34-8eeadf00bd80.png">
