### PR TITLE
Improve HNSW Index Growth Operations, Monitor HNSW inserts & deletes

### DIFF
--- a/adapters/repos/db/vector/hnsw/index_test.go
+++ b/adapters/repos/db/vector/hnsw/index_test.go
@@ -87,38 +87,38 @@ func TestHnswIndexGrow(t *testing.T) {
 		err := index.Add(id, vector)
 		require.Nil(t, err)
 		// index should grow to 150001
-		assert.Equal(t, int(id)+defaultIndexGrowthDelta, len(index.nodes))
-		assert.Equal(t, int32(id+2*defaultIndexGrowthDelta), index.cache.len())
+		assert.Equal(t, int(id)+minimumIndexGrowthDelta, len(index.nodes))
+		assert.Equal(t, int32(id+2*minimumIndexGrowthDelta), index.cache.len())
 		// try to add a vector with id: 170001
-		id = uint64(6*initialSize + defaultIndexGrowthDelta + 1)
+		id = uint64(6*initialSize + minimumIndexGrowthDelta + 1)
 		err = index.Add(id, vector)
 		require.Nil(t, err)
-		// index should grow 170001 + defaultIndexGrowthDelta
-		assert.Equal(t, int(id)+defaultIndexGrowthDelta, len(index.nodes))
-		assert.Equal(t, int32(id+2*defaultIndexGrowthDelta), index.cache.len())
+		// index should grow to at least 170001
+		assert.GreaterOrEqual(t, len(index.nodes), 17001)
+		assert.GreaterOrEqual(t, index.cache.len(), int32(17001))
 	})
 
 	t.Run("should grow index", func(t *testing.T) {
-		// should grow index to fit the id: 5*initialSize+1
-		currentSize := uint64(7*initialSize + 1)
 		// should not increase the nodes size
+		sizeBefore := len(index.nodes)
+		cacheBefore := index.cache.len()
 		idDontGrowIndex := uint64(6*initialSize - 1)
 		err := index.Add(idDontGrowIndex, vector)
 		require.Nil(t, err)
-		assert.Equal(t, int(currentSize)+defaultIndexGrowthDelta, len(index.nodes))
-		assert.Equal(t, int32(currentSize+2*defaultIndexGrowthDelta), index.cache.len())
+		assert.Equal(t, sizeBefore, len(index.nodes))
+		assert.Equal(t, cacheBefore, index.cache.len())
 		// should increase nodes
 		id := uint64(8*initialSize + 1)
 		err = index.Add(id, vector)
 		require.Nil(t, err)
-		assert.Equal(t, int(id)+defaultIndexGrowthDelta, len(index.nodes))
-		assert.Equal(t, int32(id+2*defaultIndexGrowthDelta), index.cache.len())
+		assert.GreaterOrEqual(t, len(index.nodes), int(id))
+		assert.GreaterOrEqual(t, index.cache.len(), int32(id))
 		// should increase nodes when a much greater id is passed
 		id = uint64(20*initialSize + 22)
 		err = index.Add(id, vector)
 		require.Nil(t, err)
-		assert.Equal(t, int(id)+defaultIndexGrowthDelta, len(index.nodes))
-		assert.Equal(t, int32(id+2*defaultIndexGrowthDelta), index.cache.len())
+		assert.Equal(t, int(id)+minimumIndexGrowthDelta, len(index.nodes))
+		assert.Equal(t, int32(id+2*minimumIndexGrowthDelta), index.cache.len())
 	})
 }
 

--- a/adapters/repos/db/vector/hnsw/insert.go
+++ b/adapters/repos/db/vector/hnsw/insert.go
@@ -14,17 +14,20 @@ package hnsw
 import (
 	"math"
 	"math/rand"
+	"time"
 
 	"github.com/pkg/errors"
 	"github.com/semi-technologies/weaviate/adapters/repos/db/vector/hnsw/distancer"
 )
 
 func (h *hnsw) Add(id uint64, vector []float32) error {
+	before := time.Now()
 	if len(vector) == 0 {
 		return errors.Errorf("insert called with nil-vector")
 	}
 
 	h.metrics.InsertVector()
+	defer h.metrics.TrackInsert(before, "total")
 
 	node := &vertex{
 		id: id,
@@ -69,6 +72,8 @@ func (h *hnsw) insertInitialElement(node *vertex, nodeVec []float32) error {
 }
 
 func (h *hnsw) insert(node *vertex, nodeVec []float32) error {
+	before := time.Now()
+
 	wasFirst := false
 	var firstInsertError error
 	h.initialInsertOnce.Do(func() {
@@ -132,16 +137,26 @@ func (h *hnsw) insert(node *vertex, nodeVec []float32) error {
 	h.nodes[nodeId] = node
 	h.Unlock()
 
+	h.metrics.TrackInsert(before, "prepare_and_insert_node")
+	before = time.Now()
+
 	entryPointID, err = h.findBestEntrypointForNode(currentMaximumLayer, targetLevel,
 		entryPointID, nodeVec)
 	if err != nil {
 		return errors.Wrap(err, "find best entrypoint")
 	}
 
+	h.metrics.TrackInsert(before, "find_entrypoint")
+	before = time.Now()
+
 	if err := h.findAndConnectNeighbors(node, entryPointID, nodeVec,
 		targetLevel, currentMaximumLayer, nil); err != nil {
 		return errors.Wrap(err, "find and connect neighbors")
 	}
+
+	h.metrics.TrackInsert(before, "find_and_connect_total")
+	before = time.Now()
+	defer h.metrics.TrackInsert(before, "update_global_entrypoint")
 
 	// go h.insertHook(nodeId, targetLevel, neighborsAtLevel)
 	node.unmarkAsMaintenance()

--- a/adapters/repos/db/vector/hnsw/maintainance.go
+++ b/adapters/repos/db/vector/hnsw/maintainance.go
@@ -28,14 +28,19 @@ const (
 // its own, make sure that this function is called from a single-thread or
 // locked situation
 func (h *hnsw) growIndexToAccomodateNode(id uint64, logger logrus.FieldLogger) error {
+	before := time.Now()
 	newIndex, changed, err := growIndexToAccomodateNode(h.nodes, id, logger)
 	if err != nil {
 		return err
 	}
 
+	h.metrics.SetSize(len(h.nodes))
+
 	if !changed {
 		return nil
 	}
+
+	defer h.metrics.GrowDuration(before)
 
 	h.cache.grow(uint64(len(newIndex)))
 

--- a/adapters/repos/db/vector/hnsw/maintainance_test.go
+++ b/adapters/repos/db/vector/hnsw/maintainance_test.go
@@ -53,7 +53,7 @@ func Test_growIndexToAccomodateNode(t *testing.T) {
 				id:    initialSize,
 				index: createVertexSlice(initialSize),
 			},
-			wantIndexSize: initialSize + defaultIndexGrowthDelta,
+			wantIndexSize: initialSize + minimumIndexGrowthDelta,
 			changed:       true,
 		},
 		{
@@ -62,7 +62,7 @@ func Test_growIndexToAccomodateNode(t *testing.T) {
 				id:    initialSize + 1,
 				index: createVertexSlice(initialSize),
 			},
-			wantIndexSize: initialSize + defaultIndexGrowthDelta,
+			wantIndexSize: initialSize + minimumIndexGrowthDelta,
 			changed:       true,
 		},
 		{
@@ -71,7 +71,7 @@ func Test_growIndexToAccomodateNode(t *testing.T) {
 				id:    4*initialSize - 1,
 				index: createVertexSlice(initialSize),
 			},
-			wantIndexSize: 4*initialSize - 1 + defaultIndexGrowthDelta,
+			wantIndexSize: 4*initialSize - 1 + minimumIndexGrowthDelta,
 			changed:       true,
 		},
 		{
@@ -80,7 +80,7 @@ func Test_growIndexToAccomodateNode(t *testing.T) {
 				id:    4 * initialSize,
 				index: createVertexSlice(initialSize),
 			},
-			wantIndexSize: 4*initialSize + defaultIndexGrowthDelta,
+			wantIndexSize: 4*initialSize + minimumIndexGrowthDelta,
 			changed:       true,
 		},
 		{
@@ -89,7 +89,7 @@ func Test_growIndexToAccomodateNode(t *testing.T) {
 				id:    4*initialSize + 1,
 				index: createVertexSlice(initialSize),
 			},
-			wantIndexSize: 4*initialSize + 1 + defaultIndexGrowthDelta,
+			wantIndexSize: 4*initialSize + 1 + minimumIndexGrowthDelta,
 			changed:       true,
 		},
 		{
@@ -98,7 +98,7 @@ func Test_growIndexToAccomodateNode(t *testing.T) {
 				id:    uint64(14160016),
 				index: createVertexSlice(14160016),
 			},
-			wantIndexSize: 14160016 + defaultIndexGrowthDelta,
+			wantIndexSize: int(14160016 * indexGrowthRate),
 			changed:       true,
 		},
 		{
@@ -107,7 +107,7 @@ func Test_growIndexToAccomodateNode(t *testing.T) {
 				id:    uint64(2*initialSize + 1),
 				index: createVertexSlice(initialSize + 1),
 			},
-			wantIndexSize: 2*initialSize + 1 + defaultIndexGrowthDelta,
+			wantIndexSize: 2*initialSize + 1 + minimumIndexGrowthDelta,
 			changed:       true,
 		},
 	}

--- a/adapters/repos/db/vector/hnsw/vector_cache.go
+++ b/adapters/repos/db/vector/hnsw/vector_cache.go
@@ -136,7 +136,7 @@ func (n *shardedLockCache) grow(node uint64) {
 	n.obtainAllLocks()
 	defer n.releaseAllLocks()
 
-	newSize := node + defaultIndexGrowthDelta
+	newSize := node + minimumIndexGrowthDelta
 	newCache := make([][]float32, newSize)
 	copy(newCache, n.cache)
 	n.cache = newCache

--- a/tools/dev/grafana/dashboards/vectorindex.json
+++ b/tools/dev/grafana/dashboards/vectorindex.json
@@ -21,7 +21,6 @@
   "editable": true,
   "fiscalYearStartMonth": 0,
   "graphTooltip": 0,
-  "id": 4,
   "links": [],
   "liveNow": false,
   "panels": [
@@ -171,6 +170,182 @@
         "show": true
       },
       "yBucketBound": "auto"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "Prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 8
+      },
+      "id": 6,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "single"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "Prometheus"
+          },
+          "exemplar": true,
+          "expr": "rate(vector_index_durations_ms_sum{operation=\"create\"}[5s])/rate(vector_index_durations_ms_count{operation=\"create\"}[5s])",
+          "interval": "",
+          "legendFormat": "{{step}} ({{class_name}}/{{shard_name}})",
+          "refId": "A"
+        }
+      ],
+      "title": "Insert Operations",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "Prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 8
+      },
+      "id": 7,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "single"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "Prometheus"
+          },
+          "exemplar": true,
+          "expr": "rate(vector_index_durations_ms_sum{operation=\"delete\"}[5s])/rate(vector_index_durations_ms_count{operation=\"delete\"}[5s])",
+          "interval": "",
+          "legendFormat": "{{step}} ({{class_name}}/{{shard_name}})",
+          "refId": "A"
+        }
+      ],
+      "title": "Delete Operations",
+      "type": "timeseries"
     }
   ],
   "schemaVersion": 34,
@@ -187,6 +362,6 @@
   "timezone": "",
   "title": "Vector Index",
   "uid": "03GWjZC7z",
-  "version": 2,
+  "version": 1,
   "weekStart": ""
 }

--- a/tools/dev/grafana/dashboards/vectorindex.json
+++ b/tools/dev/grafana/dashboards/vectorindex.json
@@ -1,0 +1,192 @@
+{
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": "-- Grafana --",
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "target": {
+          "limit": 100,
+          "matchAny": false,
+          "tags": [],
+          "type": "dashboard"
+        },
+        "type": "dashboard"
+      }
+    ]
+  },
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 0,
+  "id": 4,
+  "links": [],
+  "liveNow": false,
+  "panels": [
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "Prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 0
+      },
+      "id": 2,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "single"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "Prometheus"
+          },
+          "exemplar": true,
+          "expr": "vector_index_size",
+          "interval": "",
+          "legendFormat": "{{class_name}} / {{shard_name}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Vector Index Size",
+      "type": "timeseries"
+    },
+    {
+      "cards": {},
+      "color": {
+        "cardColor": "#b4ff00",
+        "colorScale": "sqrt",
+        "colorScheme": "interpolateInferno",
+        "exponent": 0.5,
+        "mode": "spectrum"
+      },
+      "dataFormat": "tsbuckets",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "Prometheus"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 0
+      },
+      "heatmap": {},
+      "hideZeroBuckets": false,
+      "highlightCards": true,
+      "id": 4,
+      "legend": {
+        "show": false
+      },
+      "maxDataPoints": 25,
+      "reverseYBuckets": false,
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "Prometheus"
+          },
+          "exemplar": true,
+          "expr": "sum(increase(vector_index_maintenance_durations_ms_bucket[$__interval])) by (le)",
+          "format": "heatmap",
+          "interval": "",
+          "legendFormat": "{{le}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Vector Index Maintenance Operations (Sync & Async)",
+      "tooltip": {
+        "show": true,
+        "showHistogram": false
+      },
+      "type": "heatmap",
+      "xAxis": {
+        "show": true
+      },
+      "yAxis": {
+        "format": "dtdurationms",
+        "logBase": 1,
+        "show": true
+      },
+      "yBucketBound": "auto"
+    }
+  ],
+  "schemaVersion": 34,
+  "style": "dark",
+  "tags": [],
+  "templating": {
+    "list": []
+  },
+  "time": {
+    "from": "now-15m",
+    "to": "now"
+  },
+  "timepicker": {},
+  "timezone": "",
+  "title": "Vector Index",
+  "uid": "03GWjZC7z",
+  "version": 2,
+  "weekStart": ""
+}

--- a/usecases/monitoring/prometheus.go
+++ b/usecases/monitoring/prometheus.go
@@ -29,6 +29,8 @@ type PrometheusMetrics struct {
 	VectorIndexTombstoneCleanupThreads *prometheus.GaugeVec
 	VectorIndexTombstoneCleanedCount   *prometheus.CounterVec
 	VectorIndexOperations              *prometheus.GaugeVec
+	VectorIndexSize                    *prometheus.GaugeVec
+	VectorIndexMaintenanceDurations    *prometheus.HistogramVec
 }
 
 func NewPrometheusMetrics() *PrometheusMetrics { // TODO don't rely on global state for registration
@@ -87,6 +89,15 @@ func NewPrometheusMetrics() *PrometheusMetrics { // TODO don't rely on global st
 		VectorIndexOperations: promauto.NewGaugeVec(prometheus.GaugeOpts{
 			Name: "vector_index_operations",
 			Help: "Total number of mutating operations on the vector index",
+		}, []string{"operation", "class_name", "shard_name"}),
+		VectorIndexSize: promauto.NewGaugeVec(prometheus.GaugeOpts{
+			Name: "vector_index_size",
+			Help: "The size of the vector index. Typically larger than number of vectors, as it grows proactively.",
+		}, []string{"class_name", "shard_name"}),
+		VectorIndexMaintenanceDurations: promauto.NewHistogramVec(prometheus.HistogramOpts{
+			Name:    "vector_index_maintenance_durations_ms",
+			Help:    "Duration of a sync or async vector index maintenance operation",
+			Buckets: prometheus.ExponentialBuckets(1, 1.5, 30),
 		}, []string{"operation", "class_name", "shard_name"}),
 	}
 }

--- a/usecases/monitoring/prometheus.go
+++ b/usecases/monitoring/prometheus.go
@@ -29,6 +29,7 @@ type PrometheusMetrics struct {
 	VectorIndexTombstoneCleanupThreads *prometheus.GaugeVec
 	VectorIndexTombstoneCleanedCount   *prometheus.CounterVec
 	VectorIndexOperations              *prometheus.GaugeVec
+	VectorIndexDurations               *prometheus.HistogramVec
 	VectorIndexSize                    *prometheus.GaugeVec
 	VectorIndexMaintenanceDurations    *prometheus.HistogramVec
 }
@@ -99,5 +100,10 @@ func NewPrometheusMetrics() *PrometheusMetrics { // TODO don't rely on global st
 			Help:    "Duration of a sync or async vector index maintenance operation",
 			Buckets: prometheus.ExponentialBuckets(1, 1.5, 30),
 		}, []string{"operation", "class_name", "shard_name"}),
+		VectorIndexDurations: promauto.NewHistogramVec(prometheus.HistogramOpts{
+			Name:    "vector_index_durations_ms",
+			Help:    "Duration of typical vector index operations (insert, delete)",
+			Buckets: prometheus.ExponentialBuckets(0.1, 1.5, 30),
+		}, []string{"operation", "step", "class_name", "shard_name"}),
 	}
 }


### PR DESCRIPTION
## Public Info

This PR introduces two noticeable changes:
* Prior to this PR the HNSW index was grown in static intervals of 25,000 objects. This is fine for small-to-medium scale (<20M objects) cases. However, when growing above this threshold, the constant growth operations slow down importing considerably. This is made worse by the fact that some reusable structures (e.g. the HNSW visited list) are kept in pools that have a lifetime of one growth interval. So, in a situation where we are constantly growing, we are also allocating and deallocating a lot of visited lists. These additional allocations make the growing operation (which is essentially also a memory allocation + copy operation) much slower. Since growing the index requires a global lock, it acts like a stop-the-world event that pauses all ongoing insert or query operations. 

  As a fix, this change introduces a relative growth pattern, where if the index needs to be grown, it will grow by a factor of 1.25. Additionally, the previous growth interval is kept as a lower threshold, so the index now grows by 25,000 or by 25% whichever is larger. This simple fix fixes the growth-related slowdown issues - even at a considerably larger scale than before. 
    
  <img width="1380" alt="image" src="https://user-images.githubusercontent.com/8974479/172824206-095d0784-45ab-44dd-a802-71ec4fecb921.png">
* Extends the monitoring capabilities of the HNSW index
  * tracks size and growth related events
  * tracks insert and delete operations at a more granular level

## Internal Info

This PR adds a new sample dashboard to our dev scripts (`vectorindex.json`):

<img width="2856" alt="image" src="https://user-images.githubusercontent.com/8974479/172825084-efe780f5-037d-4469-b7f9-c03607119108.png">

