### PR TITLE
Fix object patch with nil vector failure occurring after restart

### DIFF
--- a/adapters/repos/db/shard_write_merge.go
+++ b/adapters/repos/db/shard_write_merge.go
@@ -82,7 +82,7 @@ func (s *Shard) mergeObjectInStorage(merge objects.MergeDocument,
 	}
 
 	if err := s.updateInvertedIndexLSM(nextObj, status, previous); err != nil {
-		return nil, status, errors.Wrap(err, "udpate inverted indices")
+		return nil, status, errors.Wrap(err, "update inverted indices")
 	}
 
 	return nextObj, status, nil

--- a/adapters/repos/db/shard_write_put.go
+++ b/adapters/repos/db/shard_write_put.go
@@ -45,12 +45,8 @@ func (s *Shard) putObject(ctx context.Context, object *storobj.Object) error {
 		return errors.Wrap(err, "store object in LSM store")
 	}
 
-	// vector is now optional as of
-	// https://github.com/semi-technologies/weaviate/issues/1800
-	if object.Vector != nil {
-		if err := s.updateVectorIndex(object.Vector, status); err != nil {
-			return errors.Wrap(err, "update vector index")
-		}
+	if err := s.updateVectorIndex(object.Vector, status); err != nil {
+		return errors.Wrap(err, "update vector index")
 	}
 
 	if err := s.updatePropertySpecificIndices(object, status); err != nil {
@@ -74,17 +70,20 @@ func (s *Shard) putObject(ctx context.Context, object *storobj.Object) error {
 
 func (s *Shard) updateVectorIndex(vector []float32,
 	status objectInsertStatus) error {
-	// on occasion, objects are updated which
-	// do not have vector embeddings. in this
-	// case, there is nothing to update here.
-	if len(vector) == 0 {
-		return nil
-	}
-
+	// even if no vector is provided in an update, we still need
+	// to delete the previous vector from the index, if it
+	// exists. otherwise, the associated doc id is left dangling,
+	// resulting in failed attempts to merge an object on restarts.
 	if status.docIDChanged {
 		if err := s.vectorIndex.Delete(status.oldDocID); err != nil {
 			return errors.Wrapf(err, "delete doc id %d from vector index", status.oldDocID)
 		}
+	}
+
+	// vector is now optional as of
+	// https://github.com/semi-technologies/weaviate/issues/1800
+	if len(vector) == 0 {
+		return nil
 	}
 
 	if err := s.vectorIndex.Add(status.docID, vector); err != nil {

--- a/adapters/repos/db/vector/hnsw/delete.go
+++ b/adapters/repos/db/vector/hnsw/delete.go
@@ -114,8 +114,8 @@ func (h *hnsw) copyTombstonesToAllowList() helpers.AllowList {
 	return deleteList
 }
 
-// CleanUpTombstonedNodes removes nodes with a tombstone and reassignes edges
-// that were previously pointing to the tombstoned nodes
+// CleanUpTombstonedNodes removes nodes with a tombstone and reassigns
+// edges that were previously pointing to the tombstoned nodes
 func (h *hnsw) CleanUpTombstonedNodes() error {
 	h.metrics.StartCleanup(1)
 	defer h.metrics.EndCleanup(1)
@@ -134,7 +134,7 @@ func (h *hnsw) CleanUpTombstonedNodes() error {
 			// this a special case because:
 			//
 			// 1. we need to find a new entrypoint, if this is the last point on this
-			// level, we need to find an entyrpoint on a lower level
+			// level, we need to find an entrypoint on a lower level
 			// 2. there is a risk that this is the only node in the entire graph. In
 			// this case we must reset the graph
 			h.Lock()


### PR DESCRIPTION
When an object's vector is removed during a replacement (PUT), and then the same object is subsequently merged (PATCH) to be updated with a vector, and then a restart of the server occurs, we see a failure resembling:

```
repo: merge into index <index-name>: shard <shard-name>: update vector index: insert doc id <doc-id> to vector index: find and connect neighbors: entrypoint was deleted in the object store, it has been flagged for cleanup and should be fixed in the next cleanup cycle
```

---

The reason for this failure was that when the object replacement removing the vector occurred, the vector index was not updated to remove the object's old doc id from the vector index ([see here](https://github.com/semi-technologies/weaviate/blob/1f2ac1e5f4963feb8978272593361c95f24ac0e4/adapters/repos/db/shard_write_put.go#L50)):

```go
// vector is now optional as of
// https://github.com/semi-technologies/weaviate/issues/1800
if object.Vector != nil {
	if err := s.updateVectorIndex(object.Vector, status); err != nil {
		return errors.Wrap(err, "update vector index")
	}
}
``` 

---

To fix this issue, we must move the nil-vector-check to inside `s.updateVectorIndex`, so we can see if a doc ID exists for a vector belonging to an object which no longer exists, even if the updating object does not contain a vector. If it does, we remove that doc ID:

```go
func (s *Shard) updateVectorIndex(vector []float32, status objectInsertStatus) error {
    // even if no vector is provided in an update, we still need
    // to delete the previous vector from the index, if it
    // exists. otherwise, the associated doc id is left dangling,
    // resulting in failed attempts to merge an object on restarts.
    if status.docIDChanged {
        if err := s.vectorIndex.Delete(status.oldDocID); err != nil {
	    return errors.Wrapf(err, "delete doc id %d from vector index", status.oldDocID)
	}
    }
    ...
```

Otherwise, we move on to the empty vector check and proceed as usual. This both fixes the bug, and allows for optional vectors in object creation/replacement.

```go
func (s *Shard) updateVectorIndex(vector []float32, status objectInsertStatus) error {
    // even if no vector is provided in an update, we still need
    // to delete the previous vector from the index, if it
    // exists. otherwise, the associated doc id is left dangling,
    // resulting in failed attempts to merge an object on restarts.
    if status.docIDChanged {
        if err := s.vectorIndex.Delete(status.oldDocID); err != nil {
            return errors.Wrapf(err, "delete doc id %d from vector index", status.oldDocID)
        }
    }

    // vector is now optional as of
    // https://github.com/semi-technologies/weaviate/issues/1800
    if len(vector) == 0 {
        return nil
    }

    if err := s.vectorIndex.Add(status.docID, vector); err != nil {
        return errors.Wrapf(err, "insert doc id %d to vector index", status.docID)
    }
    ...
```
