### PR TITLE
Extend Prometheus Monitoring to include Metrics for Startup & Crash Recovery

### DIFF
--- a/adapters/repos/db/lsmkv/bucket.go
+++ b/adapters/repos/db/lsmkv/bucket.go
@@ -49,10 +49,13 @@ type Bucket struct {
 
 	status     storagestate.Status
 	statusLock sync.RWMutex
+
+	metrics *Metrics
 }
 
 func NewBucket(ctx context.Context, dir string, logger logrus.FieldLogger,
 	metrics *Metrics, opts ...BucketOption) (*Bucket, error) {
+	beforeAll := time.Now()
 	defaultMemTableThreshold := uint64(10 * 1024 * 1024)
 	defaultWalThreshold := uint64(1024 * 1024 * 1024)
 	defaultStrategy := StrategyReplace
@@ -68,6 +71,7 @@ func NewBucket(ctx context.Context, dir string, logger logrus.FieldLogger,
 		strategy:          defaultStrategy,
 		stopFlushCycle:    make(chan struct{}),
 		logger:            logger,
+		metrics:           metrics,
 	}
 
 	for _, opt := range opts {
@@ -93,6 +97,7 @@ func NewBucket(ctx context.Context, dir string, logger logrus.FieldLogger,
 	}
 
 	b.initFlushCycle()
+	b.metrics.TrackStartupBucket(beforeAll)
 
 	return b, nil
 }

--- a/adapters/repos/db/lsmkv/commitlogger_parser.go
+++ b/adapters/repos/db/lsmkv/commitlogger_parser.go
@@ -18,6 +18,7 @@ import (
 	"os"
 
 	"github.com/pkg/errors"
+	"github.com/semi-technologies/weaviate/entities/diskio"
 )
 
 type commitloggerParser struct {
@@ -25,14 +26,16 @@ type commitloggerParser struct {
 	strategy string
 	memtable *Memtable
 	reader   io.Reader
+	metrics  *Metrics
 }
 
 func newCommitLoggerParser(path string, activeMemtable *Memtable,
-	strategy string) *commitloggerParser {
+	strategy string, metrics *Metrics) *commitloggerParser {
 	return &commitloggerParser{
 		path:     path,
 		memtable: activeMemtable,
 		strategy: strategy,
+		metrics:  metrics,
 	}
 }
 
@@ -42,7 +45,8 @@ func (p *commitloggerParser) Do() error {
 		return err
 	}
 
-	p.reader = bufio.NewReader(f)
+	metered := diskio.NewMeteredReader(f, p.metrics.TrackStartupReadWALDiskIO)
+	p.reader = bufio.NewReader(metered)
 
 	for {
 		var commitType CommitType

--- a/adapters/repos/db/lsmkv/metrics.go
+++ b/adapters/repos/db/lsmkv/metrics.go
@@ -105,11 +105,6 @@ func (m *Metrics) TrackStartupBucket(start time.Time) {
 	m.startupDurations.With(prometheus.Labels{"operation": "lsm_startup_bucket"}).Observe(took)
 }
 
-// func (m *Metrics) TrackStartupBucketBloomFilter(start time.Time) {
-// 	took := float64(time.Since(start)) / float64(time.Millisecond)
-// 	m.startupDurations.With(prometheus.Labels{"operation": "lsm_startup_bucket_bloomfilter"}).Observe(took)
-// }
-
 func (m *Metrics) TrackStartupBucketRecovery(start time.Time) {
 	if m == nil {
 		return

--- a/adapters/repos/db/lsmkv/metrics.go
+++ b/adapters/repos/db/lsmkv/metrics.go
@@ -12,6 +12,8 @@
 package lsmkv
 
 import (
+	"time"
+
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/semi-technologies/weaviate/usecases/monitoring"
 )
@@ -25,6 +27,8 @@ type Metrics struct {
 	SegmentObjects    *prometheus.GaugeVec
 	SegmentSize       *prometheus.GaugeVec
 	SegmentCount      *prometheus.GaugeVec
+	startupDurations  prometheus.ObserverVec
+	startupDiskIO     prometheus.ObserverVec
 }
 
 func NewMetrics(promMetrics *monitoring.PrometheusMetrics, className,
@@ -71,5 +75,46 @@ func NewMetrics(promMetrics *monitoring.PrometheusMetrics, className,
 			"class_name": className,
 			"shard_name": shardName,
 		}),
+		startupDiskIO: promMetrics.StartupDiskIO.MustCurryWith(prometheus.Labels{
+			"class_name": className,
+			"shard_name": shardName,
+		}),
+		startupDurations: promMetrics.StartupDurations.MustCurryWith(prometheus.Labels{
+			"class_name": className,
+			"shard_name": shardName,
+		}),
 	}
+}
+
+func (m *Metrics) TrackStartupReadWALDiskIO(read int64, nanoseconds int64) {
+	if m == nil {
+		return
+	}
+
+	seconds := float64(nanoseconds) / float64(time.Second)
+	throughput := float64(read) / float64(seconds)
+	m.startupDiskIO.With(prometheus.Labels{"operation": "lsm_recover_wal"}).Observe(throughput)
+}
+
+func (m *Metrics) TrackStartupBucket(start time.Time) {
+	if m == nil {
+		return
+	}
+
+	took := float64(time.Since(start)) / float64(time.Millisecond)
+	m.startupDurations.With(prometheus.Labels{"operation": "lsm_startup_bucket"}).Observe(took)
+}
+
+// func (m *Metrics) TrackStartupBucketBloomFilter(start time.Time) {
+// 	took := float64(time.Since(start)) / float64(time.Millisecond)
+// 	m.startupDurations.With(prometheus.Labels{"operation": "lsm_startup_bucket_bloomfilter"}).Observe(took)
+// }
+
+func (m *Metrics) TrackStartupBucketRecovery(start time.Time) {
+	if m == nil {
+		return
+	}
+
+	took := float64(time.Since(start)) / float64(time.Millisecond)
+	m.startupDurations.With(prometheus.Labels{"operation": "lsm_startup_bucket_recovery"}).Observe(took)
 }

--- a/adapters/repos/db/vector/hnsw/metrics.go
+++ b/adapters/repos/db/vector/hnsw/metrics.go
@@ -8,16 +8,19 @@ import (
 )
 
 type Metrics struct {
-	enabled    bool
-	tombstones prometheus.Gauge
-	threads    prometheus.Gauge
-	insert     prometheus.Gauge
-	insertTime prometheus.ObserverVec
-	delete     prometheus.Gauge
-	deleteTime prometheus.ObserverVec
-	cleaned    prometheus.Counter
-	size       prometheus.Gauge
-	grow       prometheus.Observer
+	enabled          bool
+	tombstones       prometheus.Gauge
+	threads          prometheus.Gauge
+	insert           prometheus.Gauge
+	insertTime       prometheus.ObserverVec
+	delete           prometheus.Gauge
+	deleteTime       prometheus.ObserverVec
+	cleaned          prometheus.Counter
+	size             prometheus.Gauge
+	grow             prometheus.Observer
+	startupProgress  prometheus.Gauge
+	startupDurations prometheus.ObserverVec
+	startupDiskIO    prometheus.ObserverVec
 }
 
 func NewMetrics(prom *monitoring.PrometheusMetrics,
@@ -76,17 +79,36 @@ func NewMetrics(prom *monitoring.PrometheusMetrics,
 		"operation":  "grow",
 	})
 
+	startupProgress := prom.StartupProgress.With(prometheus.Labels{
+		"class_name": className,
+		"shard_name": shardName,
+		"operation":  "hnsw_read_commitlogs",
+	})
+
+	startupDurations := prom.StartupDurations.MustCurryWith(prometheus.Labels{
+		"class_name": className,
+		"shard_name": shardName,
+	})
+
+	startupDiskIO := prom.StartupDiskIO.MustCurryWith(prometheus.Labels{
+		"class_name": className,
+		"shard_name": shardName,
+	})
+
 	return &Metrics{
-		enabled:    true,
-		tombstones: tombstones,
-		threads:    threads,
-		cleaned:    cleaned,
-		insert:     insert,
-		insertTime: insertTime,
-		delete:     del,
-		deleteTime: deleteTime,
-		size:       size,
-		grow:       grow,
+		enabled:          true,
+		tombstones:       tombstones,
+		threads:          threads,
+		cleaned:          cleaned,
+		insert:           insert,
+		insertTime:       insertTime,
+		delete:           del,
+		deleteTime:       deleteTime,
+		size:             size,
+		grow:             grow,
+		startupProgress:  startupProgress,
+		startupDurations: startupDurations,
+		startupDiskIO:    startupDiskIO,
 	}
 }
 
@@ -179,4 +201,40 @@ func (m *Metrics) TrackDelete(start time.Time, step string) {
 
 	took := float64(time.Since(start)) / float64(time.Millisecond)
 	m.deleteTime.With(prometheus.Labels{"step": step}).Observe(took)
+}
+
+func (m *Metrics) StartupProgress(ratio float64) {
+	if !m.enabled {
+		return
+	}
+
+	m.startupProgress.Set(ratio)
+}
+
+func (m *Metrics) TrackStartupTotal(start time.Time) {
+	if !m.enabled {
+		return
+	}
+
+	took := float64(time.Since(start)) / float64(time.Millisecond)
+	m.startupDurations.With(prometheus.Labels{"operation": "hnsw_read_all_commitlogs"}).Observe(took)
+}
+
+func (m *Metrics) TrackStartupIndividual(start time.Time) {
+	if !m.enabled {
+		return
+	}
+
+	took := float64(time.Since(start)) / float64(time.Millisecond)
+	m.startupDurations.With(prometheus.Labels{"operation": "hnsw_read_single_commitlog"}).Observe(took)
+}
+
+func (m *Metrics) TrackStartupReadCommitlogDiskIO(read int64, nanoseconds int64) {
+	if !m.enabled {
+		return
+	}
+
+	seconds := float64(nanoseconds) / float64(time.Second)
+	throughput := float64(read) / float64(seconds)
+	m.startupDiskIO.With(prometheus.Labels{"operation": "hnsw_read_commitlog"}).Observe(throughput)
 }

--- a/entities/diskio/metered_reader.go
+++ b/entities/diskio/metered_reader.go
@@ -1,0 +1,35 @@
+package diskio
+
+import (
+	"io"
+	"time"
+)
+
+type MeteredReaderCallback func(read int64, nanoseconds int64)
+
+type MeteredReader struct {
+	r  io.Reader
+	cb MeteredReaderCallback
+}
+
+// Read passes the read through to the underlying reader. On a succesful read,
+// it will trigger the attached callback and provide it with metrics. If no
+// callback is set, it will ignore it.
+func (m *MeteredReader) Read(p []byte) (n int, err error) {
+	start := time.Now()
+	n, err = m.r.Read(p)
+	took := time.Since(start).Nanoseconds()
+	if err != nil {
+		return
+	}
+
+	if m.cb != nil {
+		m.cb(int64(n), took)
+	}
+
+	return
+}
+
+func NewMeteredReader(r io.Reader, cb MeteredReaderCallback) *MeteredReader {
+	return &MeteredReader{r: r, cb: cb}
+}

--- a/entities/diskio/metered_reader.go
+++ b/entities/diskio/metered_reader.go
@@ -12,7 +12,7 @@ type MeteredReader struct {
 	cb MeteredReaderCallback
 }
 
-// Read passes the read through to the underlying reader. On a succesful read,
+// Read passes the read through to the underlying reader. On a successful read,
 // it will trigger the attached callback and provide it with metrics. If no
 // callback is set, it will ignore it.
 func (m *MeteredReader) Read(p []byte) (n int, err error) {

--- a/entities/diskio/metered_reader_test.go
+++ b/entities/diskio/metered_reader_test.go
@@ -1,0 +1,70 @@
+package diskio
+
+import (
+	"bytes"
+	"io"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestMeteredReader(t *testing.T) {
+	data := make([]byte, 128)
+
+	t.Run("happy path - with callback", func(t *testing.T) {
+		var (
+			read int64
+			took int64
+		)
+
+		cb := func(r int64, n int64) {
+			read = r
+			took = n
+		}
+
+		mr := NewMeteredReader(bytes.NewReader(data), cb)
+
+		target := make([]byte, 128)
+		n, err := mr.Read(target)
+
+		require.Nil(t, err)
+		assert.Equal(t, int64(n), read)
+		assert.Greater(t, took, int64(0))
+	})
+
+	t.Run("happy path - without callback", func(t *testing.T) {
+		mr := NewMeteredReader(bytes.NewReader(data), nil)
+
+		target := make([]byte, 128)
+		_, err := mr.Read(target)
+		require.Nil(t, err)
+	})
+
+	t.Run("with an error", func(t *testing.T) {
+		var (
+			read int64
+			took int64
+		)
+
+		cb := func(r int64, n int64) {
+			read = r
+			took = n
+		}
+
+		underlying := bytes.NewReader(data)
+		// provoke EOF error by seeking to end of data
+		underlying.Seek(128, 0)
+		mr := NewMeteredReader(underlying, cb)
+
+		target := make([]byte, 128)
+		_, err := mr.Read(target)
+
+		assert.Equal(t, io.EOF, err)
+
+		// callabck should not have been called in error cases, so we expect to
+		// read initial values
+		assert.Equal(t, int64(0), read)
+		assert.Equal(t, int64(0), took)
+	})
+}

--- a/tools/dev/grafana/dashboards/startup.json
+++ b/tools/dev/grafana/dashboards/startup.json
@@ -21,7 +21,6 @@
   "editable": true,
   "fiscalYearStartMonth": 0,
   "graphTooltip": 0,
-  "id": 5,
   "links": [],
   "liveNow": false,
   "panels": [
@@ -247,6 +246,95 @@
       ],
       "title": "Startup all HNSW indexes",
       "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "Prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "Bps"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 9
+      },
+      "id": 7,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "single"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "Prometheus"
+          },
+          "exemplar": true,
+          "expr": "rate(startup_diskio_throughput_sum[$__interval])/rate(startup_diskio_throughput_count[$__interval])",
+          "interval": "",
+          "legendFormat": "{{operation}} ({{class_name}}/{{shard_name}})",
+          "refId": "A"
+        }
+      ],
+      "title": "Startup Disk I/O ",
+      "type": "timeseries"
     }
   ],
   "schemaVersion": 34,
@@ -256,13 +344,13 @@
     "list": []
   },
   "time": {
-    "from": "now-30m",
+    "from": "now-15m",
     "to": "now"
   },
   "timepicker": {},
   "timezone": "",
   "title": "Startup times",
   "uid": "oZZHUUC7k",
-  "version": 2,
+  "version": 1,
   "weekStart": ""
 }

--- a/tools/dev/grafana/dashboards/startup.json
+++ b/tools/dev/grafana/dashboards/startup.json
@@ -1,0 +1,268 @@
+{
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": "-- Grafana --",
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "target": {
+          "limit": 100,
+          "matchAny": false,
+          "tags": [],
+          "type": "dashboard"
+        },
+        "type": "dashboard"
+      }
+    ]
+  },
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 0,
+  "id": 5,
+  "links": [],
+  "liveNow": false,
+  "panels": [
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "Prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "ms"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 9,
+        "w": 12,
+        "x": 0,
+        "y": 0
+      },
+      "id": 2,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "single"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "Prometheus"
+          },
+          "exemplar": true,
+          "expr": "rate(startup_durations_ms_sum[$__interval])/rate(startup_durations_ms_count[$__interval])",
+          "interval": "",
+          "legendFormat": "{{operation}} ({{class_name}} / {{shard_name}})",
+          "refId": "A"
+        }
+      ],
+      "title": "Startup durations",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "Prometheus"
+      },
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "ms"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 9,
+        "w": 3,
+        "x": 12,
+        "y": 0
+      },
+      "id": 4,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "pluginVersion": "8.3.3",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "Prometheus"
+          },
+          "exemplar": true,
+          "expr": "sum(startup_durations_ms_sum{operation=\"lsm_startup_bucket\"})",
+          "interval": "",
+          "legendFormat": "",
+          "refId": "A"
+        }
+      ],
+      "title": "Startup all LSM buckets",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "Prometheus"
+      },
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "ms"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 9,
+        "w": 3,
+        "x": 15,
+        "y": 0
+      },
+      "id": 5,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "pluginVersion": "8.3.3",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "Prometheus"
+          },
+          "exemplar": true,
+          "expr": "sum(startup_durations_ms_sum{operation=\"hnsw_read_all_commitlogs\"})",
+          "interval": "",
+          "legendFormat": "",
+          "refId": "A"
+        }
+      ],
+      "title": "Startup all HNSW indexes",
+      "type": "stat"
+    }
+  ],
+  "schemaVersion": 34,
+  "style": "dark",
+  "tags": [],
+  "templating": {
+    "list": []
+  },
+  "time": {
+    "from": "now-30m",
+    "to": "now"
+  },
+  "timepicker": {},
+  "timezone": "",
+  "title": "Startup times",
+  "uid": "oZZHUUC7k",
+  "version": 2,
+  "weekStart": ""
+}

--- a/usecases/monitoring/prometheus.go
+++ b/usecases/monitoring/prometheus.go
@@ -32,6 +32,10 @@ type PrometheusMetrics struct {
 	VectorIndexDurations               *prometheus.HistogramVec
 	VectorIndexSize                    *prometheus.GaugeVec
 	VectorIndexMaintenanceDurations    *prometheus.HistogramVec
+
+	StartupProgress  *prometheus.GaugeVec
+	StartupDurations *prometheus.HistogramVec
+	StartupDiskIO    *prometheus.HistogramVec
 }
 
 func NewPrometheusMetrics() *PrometheusMetrics { // TODO don't rely on global state for registration
@@ -105,5 +109,20 @@ func NewPrometheusMetrics() *PrometheusMetrics { // TODO don't rely on global st
 			Help:    "Duration of typical vector index operations (insert, delete)",
 			Buckets: prometheus.ExponentialBuckets(0.1, 1.5, 30),
 		}, []string{"operation", "step", "class_name", "shard_name"}),
+
+		StartupProgress: promauto.NewGaugeVec(prometheus.GaugeOpts{
+			Name: "startup_progress",
+			Help: "A ratio (percentage) of startup progress for a particular component in a shard",
+		}, []string{"operation", "class_name", "shard_name"}),
+		StartupDurations: promauto.NewHistogramVec(prometheus.HistogramOpts{
+			Name:    "startup_durations_ms",
+			Help:    "Duration of inidividual startup operations in ms",
+			Buckets: prometheus.ExponentialBuckets(100, 1.25, 40),
+		}, []string{"operation", "class_name", "shard_name"}),
+		StartupDiskIO: promauto.NewHistogramVec(prometheus.HistogramOpts{
+			Name:    "startup_diskio_throughput",
+			Help:    "Disk I/O throuhput in bytes per second",
+			Buckets: prometheus.ExponentialBuckets(1, 2, 40),
+		}, []string{"operation", "class_name", "shard_name"}),
 	}
 }


### PR DESCRIPTION
## Public Info

This introduces more metrics to measure startup times and disk i/o in startup scenarios, both for regular and crash-recovery startup scenarios.

## Internal Info
- This adds a new type called `MeteredReader` which implements `io.Reader`. It passes the reads through to the underlying reader, but also calls a callback with read data and passed time statistics. This allows for an easy disk throughput meassurement.
- This adds the following sample dashboard to our dev dashboards to track startup:
   <img width="2131" alt="Screenshot 2022-06-16 at 13 28 54" src="https://user-images.githubusercontent.com/8974479/174246245-f7164199-d79e-4636-afc9-ae1c52b71936.png">
