### PR TITLE
Improve Object/Inverted Store Startup Time in normal and recovery situations

### DIFF
--- a/adapters/repos/db/lsmkv/commitlogger_parser.go
+++ b/adapters/repos/db/lsmkv/commitlogger_parser.go
@@ -46,7 +46,7 @@ func (p *commitloggerParser) Do() error {
 	}
 
 	metered := diskio.NewMeteredReader(f, p.metrics.TrackStartupReadWALDiskIO)
-	p.reader = bufio.NewReader(metered)
+	p.reader = bufio.NewReaderSize(metered, 1*1024*1024)
 
 	for {
 		var commitType CommitType

--- a/adapters/repos/db/shard.go
+++ b/adapters/repos/db/shard.go
@@ -64,6 +64,8 @@ type Shard struct {
 
 func NewShard(ctx context.Context, promMetrics *monitoring.PrometheusMetrics,
 	shardName string, index *Index) (*Shard, error) {
+	before := time.Now()
+
 	rand, err := newBufferedRandomGen(64 * 1024)
 	if err != nil {
 		return nil, errors.Wrap(err, "init bufferend random generator")
@@ -85,6 +87,7 @@ func NewShard(ctx context.Context, promMetrics *monitoring.PrometheusMetrics,
 		randomSource:  rand,
 		diskScanState: newDiskScanState(),
 	}
+	defer s.metrics.ShardStartup(before)
 
 	hnswUserConfig, ok := index.vectorIndexUserConfig.(hnsw.UserConfig)
 	if !ok {

--- a/tools/dev/grafana/dashboards/startup.json
+++ b/tools/dev/grafana/dashboards/startup.json
@@ -118,7 +118,7 @@
         "type": "prometheus",
         "uid": "Prometheus"
       },
-      "description": "",
+      "description": "These times do not represent wall time. Some init processes are running in parallel, so this is CPU time. For a wall clock measurement look at total shard startup time.",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -245,6 +245,73 @@
         }
       ],
       "title": "Startup all HNSW indexes",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "Prometheus"
+      },
+      "description": "This represents the total wall time per shard.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "ms"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 9,
+        "w": 3,
+        "x": 18,
+        "y": 0
+      },
+      "id": 8,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "pluginVersion": "8.3.3",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "Prometheus"
+          },
+          "exemplar": true,
+          "expr": "startup_durations_ms_sum{operation=\"shard_total_init\"}",
+          "interval": "",
+          "legendFormat": "{{class_name}}/{{shard_name}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Total shard Startup",
       "type": "stat"
     },
     {


### PR DESCRIPTION
This change improves the startup times for the object/inverted (i.e. non-vector) stores by introducing two changes:

* Increase the size of the buffer used when reading from disk. Previously the buffer would default to `4096B`, it is now set to `1MB`. With the larger buffer we can sustain read speeds of around 2-3GB/s (tested on local machine) whereas the previous setting would only allow us to read at 300-400MB/s.
* Initialize Buckets concurrently. In the inverted index, each property leads to its own bucket (in some cases even two buckets per prop). Previously they would all startup (including recovery) sequentially. If there were many active WALs (e.g. after a crash) this could lead to a long duration where one CPU core was at 100% utilization, but all other cores were idle. 

Using an example crash recovery situation, the two changes above lead to a significant speed up of the MTTR:


<table>
<thead>
<tr><th>Before</th><th>After</th></tr>
</thead>
<tbody>
<tr><td><img width="345" alt="Screenshot 2022-06-17 at 11 20 54" src="https://user-images.githubusercontent.com/8974479/174270516-57ff4d63-533b-4260-8cbe-e174d2ed6af4.png"></td><td><img width="351" alt="Screenshot 2022-06-17 at 11 00 12" src="https://user-images.githubusercontent.com/8974479/174270519-c7e3b728-3c26-454e-899e-00bd0ea24948.png">
</td></tr>
</tbody>
</table>