### PR TITLE
Prevent Caching of Filters in Batch Delete

### DIFF
--- a/adapters/repos/db/inverted/row_cacher.go
+++ b/adapters/repos/db/inverted/row_cacher.go
@@ -92,6 +92,10 @@ func (rc *RowCacher) deleteExistingEntries(sizeToDelete uint64) {
 	})
 }
 
+func (rc *RowCacher) Size() uint64 {
+	return atomic.LoadUint64(&rc.currentSize)
+}
+
 func (rc *RowCacher) Load(id []byte) (*CacheEntry, bool) {
 	retrieved, ok := rc.rowStore.Load(string(id))
 	if !ok {

--- a/adapters/repos/db/inverted/searcher.go
+++ b/adapters/repos/db/inverted/searcher.go
@@ -174,14 +174,29 @@ func (f *Searcher) objectsByDocID(ids []uint64,
 // had the shortest distance
 func (f *Searcher) DocIDs(ctx context.Context, filter *filters.LocalFilter,
 	additional additional.Properties, className schema.ClassName) (helpers.AllowList, error) {
+	return f.docIDs(ctx, filter, additional, className, true)
+}
+
+// DocIDsPreventCaching is the same as DocIDs, but makes sure that no filter
+// cache entries are written. This can be used when we can guarantee that the
+// filter is part of an operation that will lead to a state change, such as
+// batch delete. The state change would make the cached filter unusuable
+// anyway, so we don't need to unnecessarily populate the cache with an entry.
+func (f *Searcher) DocIDsPreventCaching(ctx context.Context, filter *filters.LocalFilter,
+	additional additional.Properties, className schema.ClassName) (helpers.AllowList, error) {
+	return f.docIDs(ctx, filter, additional, className, false)
+}
+
+func (f *Searcher) docIDs(ctx context.Context, filter *filters.LocalFilter,
+	additional additional.Properties, className schema.ClassName,
+	allowCaching bool) (helpers.AllowList, error) {
 	pv, err := f.extractPropValuePair(filter.Root, className)
 	if err != nil {
 		return nil, err
 	}
 
 	cacheable := pv.cacheable()
-	if !cacheable {
-	} else {
+	if cacheable && allowCaching {
 		if err := pv.fetchHashes(f); err != nil {
 			return nil, errors.Wrap(err, "fetch row hashes to check for cach eligibility")
 		}
@@ -208,7 +223,7 @@ func (f *Searcher) DocIDs(ctx context.Context, filter *filters.LocalFilter,
 		out.Insert(p)
 	}
 
-	if cacheable {
+	if cacheable && allowCaching {
 		f.rowCache.Store(pv.docIDs.checksum, &CacheEntry{
 			Type:      CacheTypeAllowList,
 			AllowList: out,

--- a/adapters/repos/db/inverted/searcher.go
+++ b/adapters/repos/db/inverted/searcher.go
@@ -180,7 +180,7 @@ func (f *Searcher) DocIDs(ctx context.Context, filter *filters.LocalFilter,
 // DocIDsPreventCaching is the same as DocIDs, but makes sure that no filter
 // cache entries are written. This can be used when we can guarantee that the
 // filter is part of an operation that will lead to a state change, such as
-// batch delete. The state change would make the cached filter unusuable
+// batch delete. The state change would make the cached filter unusable
 // anyway, so we don't need to unnecessarily populate the cache with an entry.
 func (f *Searcher) DocIDsPreventCaching(ctx context.Context, filter *filters.LocalFilter,
 	additional additional.Properties, className schema.ClassName) (helpers.AllowList, error) {

--- a/adapters/repos/db/shard_write_batch_delete.go
+++ b/adapters/repos/db/shard_write_batch_delete.go
@@ -129,10 +129,13 @@ func (b *deleteObjectsBatcher) setErrorAtIndex(err error, index int) {
 
 func (s *Shard) findDocIDs(ctx context.Context,
 	filters *filters.LocalFilter) ([]uint64, error) {
+	// This method is used exclusively for batch delete, so we can always
+	// prevent filter caching, as a Batch-Delete filter will lead to a state
+	// mutation, making the filter not reusable anyway.
 	allowList, err := inverted.NewSearcher(s.store, s.index.getSchema.GetSchemaSkipAuth(),
 		s.invertedRowCache, nil, s.index.classSearcher, s.deletedDocIDs,
 		s.index.stopwords, s.versioner.version).
-		DocIDs(ctx, filters, additional.Properties{}, s.index.Config.ClassName)
+		DocIDsPreventCaching(ctx, filters, additional.Properties{}, s.index.Config.ClassName)
 
 	var docIDs []uint64
 	for id := range allowList {


### PR DESCRIPTION
Batch Delete uses a filter to determine which objects should be deleted. Filters are generally cacheable for the duration that the state has not changed. Since a Batch Delete always leads to a state change, caching this filter is pointless and leads to increased heap usage and/or takes cacheable space away from more useful filters. This change makes sure that such a filter is never cached in the first place.

fixes #1996 