### PR TITLE
Monitor number of imported objects 

### DIFF
--- a/adapters/repos/db/lsmkv/bucket_options.go
+++ b/adapters/repos/db/lsmkv/bucket_options.go
@@ -83,3 +83,13 @@ func WithSecondaryKey(pos int, key []byte) SecondaryKeyOption {
 		return nil
 	}
 }
+
+func WithMonitorCount() BucketOption {
+	return func(b *Bucket) error {
+		if b.strategy != StrategyReplace {
+			return errors.Errorf("count monitoring only supported on 'replace' buckets")
+		}
+		b.monitorCount = true
+		return nil
+	}
+}

--- a/adapters/repos/db/lsmkv/metrics.go
+++ b/adapters/repos/db/lsmkv/metrics.go
@@ -29,6 +29,7 @@ type Metrics struct {
 	SegmentCount      *prometheus.GaugeVec
 	startupDurations  prometheus.ObserverVec
 	startupDiskIO     prometheus.ObserverVec
+	objectCount       prometheus.Gauge
 }
 
 func NewMetrics(promMetrics *monitoring.PrometheusMetrics, className,
@@ -83,6 +84,10 @@ func NewMetrics(promMetrics *monitoring.PrometheusMetrics, className,
 			"class_name": className,
 			"shard_name": shardName,
 		}),
+		objectCount: promMetrics.ObjectCount.With(prometheus.Labels{
+			"class_name": className,
+			"shard_name": shardName,
+		}),
 	}
 }
 
@@ -112,4 +117,12 @@ func (m *Metrics) TrackStartupBucketRecovery(start time.Time) {
 
 	took := float64(time.Since(start)) / float64(time.Millisecond)
 	m.startupDurations.With(prometheus.Labels{"operation": "lsm_startup_bucket_recovery"}).Observe(took)
+}
+
+func (m *Metrics) ObjectCount(count int) {
+	if m == nil {
+		return
+	}
+
+	m.objectCount.Set(float64(count))
 }

--- a/adapters/repos/db/shard.go
+++ b/adapters/repos/db/shard.go
@@ -205,7 +205,9 @@ func (s *Shard) initDBFile(ctx context.Context) error {
 
 	err = store.CreateOrLoadBucket(ctx, helpers.ObjectsBucketLSM,
 		lsmkv.WithStrategy(lsmkv.StrategyReplace),
-		lsmkv.WithSecondaryIndicies(1))
+		lsmkv.WithSecondaryIndicies(1),
+		lsmkv.WithMonitorCount(),
+	)
 	if err != nil {
 		return errors.Wrap(err, "create objects bucket")
 	}

--- a/usecases/monitoring/prometheus.go
+++ b/usecases/monitoring/prometheus.go
@@ -33,6 +33,7 @@ type PrometheusMetrics struct {
 	VectorIndexDurations               *prometheus.HistogramVec
 	VectorIndexSize                    *prometheus.GaugeVec
 	VectorIndexMaintenanceDurations    *prometheus.HistogramVec
+	ObjectCount                        *prometheus.GaugeVec
 
 	StartupProgress  *prometheus.GaugeVec
 	StartupDurations *prometheus.HistogramVec
@@ -57,6 +58,10 @@ func NewPrometheusMetrics() *PrometheusMetrics { // TODO don't rely on global st
 			Help:    "Duration of an individual object operation. Also as part of batches.",
 			Buckets: prometheus.ExponentialBuckets(10, 1.25, 25),
 		}, []string{"operation", "step", "class_name", "shard_name"}),
+		ObjectCount: promauto.NewGaugeVec(prometheus.GaugeOpts{
+			Name: "object_count",
+			Help: "Number of currently ongoing async operations",
+		}, []string{"class_name", "shard_name"}),
 
 		AsyncOperations: promauto.NewGaugeVec(prometheus.GaugeOpts{
 			Name: "async_operations_running",


### PR DESCRIPTION
# Public Info

This feature introduces metrics to count objects anytime a bucket is initialized or a memtable is flushed. As a result, with the work completed in #2001 which makes sure that a memtable is idle at most for 60s, we can have an up-to-date object count with at most a 60s delay.

# Internal Info

* Merge this PR only after #2001 is merged, as it is built on the same branch. Might require some rebasing after other PR is merged
* Adds a usage dashboard: 
<img width="1189" alt="image" src="https://user-images.githubusercontent.com/8974479/176124692-6bf7574b-2d73-4dac-9444-a117c55b331f.png">
