### PR TITLE
Optimize MTTR for Object and Hash buckets (LSM Store)

### DIFF
--- a/adapters/repos/db/lsmkv/commitlogger_parser.go
+++ b/adapters/repos/db/lsmkv/commitlogger_parser.go
@@ -89,20 +89,17 @@ func (p *commitloggerParser) doReplace() error {
 		}
 	}
 
-	if p.strategy == StrategyReplace {
-		for _, node := range p.replaceCache {
-			var opts []SecondaryKeyOption
-			if p.memtable.secondaryIndices > 0 {
-				for i, secKey := range node.secondaryKeys {
-					opts = append(opts, WithSecondaryKey(i, secKey))
-				}
+	for _, node := range p.replaceCache {
+		var opts []SecondaryKeyOption
+		if p.memtable.secondaryIndices > 0 {
+			for i, secKey := range node.secondaryKeys {
+				opts = append(opts, WithSecondaryKey(i, secKey))
 			}
-			if node.tombstone {
-				p.memtable.setTombstone(node.primaryKey, opts...)
-			} else {
-				p.memtable.put(node.primaryKey, node.value, opts...)
-			}
-
+		}
+		if node.tombstone {
+			p.memtable.setTombstone(node.primaryKey, opts...)
+		} else {
+			p.memtable.put(node.primaryKey, node.value, opts...)
 		}
 	}
 

--- a/adapters/repos/db/lsmkv/commitlogger_parser.go
+++ b/adapters/repos/db/lsmkv/commitlogger_parser.go
@@ -14,7 +14,6 @@ package lsmkv
 import (
 	"bufio"
 	"encoding/binary"
-	"fmt"
 	"io"
 	"os"
 
@@ -23,26 +22,36 @@ import (
 )
 
 type commitloggerParser struct {
-	path     string
-	strategy string
-	memtable *Memtable
-	reader   io.Reader
-	metrics  *Metrics
-	unique   map[string]segmentReplaceNode
+	path         string
+	strategy     string
+	memtable     *Memtable
+	reader       io.Reader
+	metrics      *Metrics
+	replaceCache map[string]segmentReplaceNode
 }
 
 func newCommitLoggerParser(path string, activeMemtable *Memtable,
 	strategy string, metrics *Metrics) *commitloggerParser {
 	return &commitloggerParser{
-		path:     path,
-		memtable: activeMemtable,
-		strategy: strategy,
-		metrics:  metrics,
-		unique:   map[string]segmentReplaceNode{},
+		path:         path,
+		memtable:     activeMemtable,
+		strategy:     strategy,
+		metrics:      metrics,
+		replaceCache: map[string]segmentReplaceNode{},
 	}
 }
 
 func (p *commitloggerParser) Do() error {
+	if p.strategy == StrategyReplace {
+		return p.doReplace()
+	}
+
+	return p.doCollection()
+}
+
+// doReplace parsers all entries into a cache for deduplication first and only
+// imports unique entries into the actual memtable as a final step.
+func (p *commitloggerParser) doReplace() error {
 	f, err := os.Open(p.path)
 	if err != nil {
 		return err
@@ -51,10 +60,11 @@ func (p *commitloggerParser) Do() error {
 	metered := diskio.NewMeteredReader(f, p.metrics.TrackStartupReadWALDiskIO)
 	p.reader = bufio.NewReaderSize(metered, 1*1024*1024)
 
-	count := 0
+	// errUnexpectedLength indicates that we could not read the commit log to the
+	// end, for example because the last element on the log was corrupt.
+	var errUnexpectedLength error
+
 	for {
-		fmt.Printf("read commit %d\n", count)
-		count++
 		var commitType CommitType
 
 		err := binary.Read(p.reader, binary.LittleEndian, &commitType)
@@ -63,24 +73,24 @@ func (p *commitloggerParser) Do() error {
 		}
 
 		if err != nil {
-			return errors.Wrap(err, "read commit type")
+			errUnexpectedLength = errors.Wrap(err, "read commit type")
+			break
 		}
 
 		switch commitType {
+		case CommitTypeCollection:
+			f.Close()
+			return errors.Errorf("found a collection commit on a replace bucket")
 		case CommitTypeReplace:
 			if err := p.parseReplaceNode(); err != nil {
-				return errors.Wrap(err, "read replace node")
-			}
-		case CommitTypeCollection:
-			if err := p.parseCollectionNode(); err != nil {
-				return errors.Wrap(err, "read collection node")
+				errUnexpectedLength = errors.Wrap(err, "read replace node")
+				break
 			}
 		}
 	}
 
-	count = 0
 	if p.strategy == StrategyReplace {
-		for _, node := range p.unique {
+		for _, node := range p.replaceCache {
 			var opts []SecondaryKeyOption
 			if p.memtable.secondaryIndices > 0 {
 				for i, secKey := range node.secondaryKeys {
@@ -93,62 +103,34 @@ func (p *commitloggerParser) Do() error {
 				p.memtable.put(node.primaryKey, node.value, opts...)
 			}
 
-			fmt.Printf("inserted %d elements\n", count)
 		}
+	}
+
+	if errUnexpectedLength != nil {
+		f.Close()
+		return errUnexpectedLength
 	}
 
 	return f.Close()
 }
 
+// parseReplaceNode only parses into the deduplication cache, not into the
+// final memtable yet. A second step is required to parse from the cache into
+// the actual memtable.
 func (p *commitloggerParser) parseReplaceNode() error {
 	n, err := ParseReplaceNode(p.reader, p.memtable.secondaryIndices)
 	if err != nil {
 		return err
 	}
 
-	// var opts []SecondaryKeyOption
-	// if p.memtable.secondaryIndices > 0 {
-	// 	for i, secKey := range n.secondaryKeys {
-	// 		opts = append(opts, WithSecondaryKey(i, secKey))
-	// 	}
-	// }
-
 	if !n.tombstone {
-		p.unique[string(n.primaryKey)] = n
+		p.replaceCache[string(n.primaryKey)] = n
 	} else {
-		if existing, ok := p.unique[string(n.primaryKey)]; ok {
+		if existing, ok := p.replaceCache[string(n.primaryKey)]; ok {
 			existing.tombstone = true
-			p.unique[string(n.primaryKey)] = existing
+			p.replaceCache[string(n.primaryKey)] = existing
 		} else {
-			p.unique[string(n.primaryKey)] = n
-		}
-	}
-
-	return nil
-}
-
-func (p *commitloggerParser) parseCollectionNode() error {
-	n, err := ParseCollectionNode(p.reader)
-	if err != nil {
-		return err
-	}
-
-	if p.strategy == StrategyMapCollection {
-		return p.parseMapNode(n)
-	}
-	return p.memtable.append(n.primaryKey, n.values)
-}
-
-func (p *commitloggerParser) parseMapNode(n segmentCollectionNode) error {
-	for _, val := range n.values {
-		mp := MapPair{}
-		if err := mp.FromBytes(val.value, false); err != nil {
-			return err
-		}
-		mp.Tombstone = val.tombstone
-
-		if err := p.memtable.appendMapSorted(n.primaryKey, mp); err != nil {
-			return err
+			p.replaceCache[string(n.primaryKey)] = n
 		}
 	}
 

--- a/adapters/repos/db/lsmkv/commitlogger_parser_collection.go
+++ b/adapters/repos/db/lsmkv/commitlogger_parser_collection.go
@@ -1,0 +1,76 @@
+package lsmkv
+
+import (
+	"bufio"
+	"encoding/binary"
+	"io"
+	"os"
+
+	"github.com/pkg/errors"
+	"github.com/semi-technologies/weaviate/entities/diskio"
+)
+
+func (p *commitloggerParser) doCollection() error {
+	f, err := os.Open(p.path)
+	if err != nil {
+		return err
+	}
+
+	metered := diskio.NewMeteredReader(f, p.metrics.TrackStartupReadWALDiskIO)
+	p.reader = bufio.NewReaderSize(metered, 1*1024*1024)
+
+	for {
+		var commitType CommitType
+
+		err := binary.Read(p.reader, binary.LittleEndian, &commitType)
+		if err == io.EOF {
+			break
+		}
+
+		if err != nil {
+			f.Close()
+			return errors.Wrap(err, "read commit type")
+		}
+
+		switch commitType {
+		case CommitTypeReplace:
+			f.Close()
+			return errors.Errorf("found a replace commit on collection bucket")
+		case CommitTypeCollection:
+			if err := p.parseCollectionNode(); err != nil {
+				f.Close()
+				return errors.Wrap(err, "read collection node")
+			}
+		}
+	}
+
+	return f.Close()
+}
+
+func (p *commitloggerParser) parseCollectionNode() error {
+	n, err := ParseCollectionNode(p.reader)
+	if err != nil {
+		return err
+	}
+
+	if p.strategy == StrategyMapCollection {
+		return p.parseMapNode(n)
+	}
+	return p.memtable.append(n.primaryKey, n.values)
+}
+
+func (p *commitloggerParser) parseMapNode(n segmentCollectionNode) error {
+	for _, val := range n.values {
+		mp := MapPair{}
+		if err := mp.FromBytes(val.value, false); err != nil {
+			return err
+		}
+		mp.Tombstone = val.tombstone
+
+		if err := p.memtable.appendMapSorted(n.primaryKey, mp); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}

--- a/adapters/repos/db/lsmkv/recover_from_wal_integration_test.go
+++ b/adapters/repos/db/lsmkv/recover_from_wal_integration_test.go
@@ -43,7 +43,7 @@ func TestReplaceStrategy_RecoverFromWAL(t *testing.T) {
 		fmt.Println(err)
 	}()
 
-	t.Run("without some previous state", func(t *testing.T) {
+	t.Run("with some previous state", func(t *testing.T) {
 		b, err := NewBucket(testCtx(), dirNameOriginal, nullLogger(), nil,
 			WithStrategy(StrategyReplace))
 		require.Nil(t, err)
@@ -53,7 +53,7 @@ func TestReplaceStrategy_RecoverFromWAL(t *testing.T) {
 
 		t.Run("set one key that will be flushed orderly", func(t *testing.T) {
 			// the motivation behind flushing this initial segment is to check that
-			// deletion as part of the recvoery also works correclty. If we would
+			// deletion as part of the recovery also works correctly. If we would
 			// just delete something that was created as part of the same memtable,
 			// the tests would still pass, even with removing the logic that recovers
 			// tombstones.
@@ -65,7 +65,7 @@ func TestReplaceStrategy_RecoverFromWAL(t *testing.T) {
 			//
 			// You can test this by commenting the "p.memtable.setTombstone()" line
 			// in p.doReplace(). This will fail the tests suite, but prior to this
-			// adddition it would have passed.
+			// addition it would have passed.
 			key2 := []byte("key-2")
 			orig2 := []byte("delete me later - you should never find me again")
 

--- a/adapters/repos/db/lsmkv/recover_from_wal_integration_test.go
+++ b/adapters/repos/db/lsmkv/recover_from_wal_integration_test.go
@@ -16,6 +16,7 @@ package lsmkv
 
 import (
 	"bytes"
+	"context"
 	"fmt"
 	"io"
 	"math/rand"
@@ -42,13 +43,45 @@ func TestReplaceStrategy_RecoverFromWAL(t *testing.T) {
 		fmt.Println(err)
 	}()
 
-	t.Run("without previous state", func(t *testing.T) {
+	t.Run("without some previous state", func(t *testing.T) {
 		b, err := NewBucket(testCtx(), dirNameOriginal, nullLogger(), nil,
 			WithStrategy(StrategyReplace))
 		require.Nil(t, err)
 
 		// so big it effectively never triggers as part of this test
 		b.SetMemtableThreshold(1e9)
+
+		t.Run("set one key that will be flushed orderly", func(t *testing.T) {
+			// the motivation behind flushing this initial segment is to check that
+			// deletion as part of the recvoery also works correclty. If we would
+			// just delete something that was created as part of the same memtable,
+			// the tests would still pass, even with removing the logic that recovers
+			// tombstones.
+			//
+			// To make sure they fail in this case, this prior state was introduced.
+			// An entry with key "key-2" is introduced in a previous segment, so if
+			// the deletion fails as part of the recovery this key would still be
+			// present later on. With the deletion working correctly it will be gone.
+			//
+			// You can test this by commenting the "p.memtable.setTombstone()" line
+			// in p.doReplace(). This will fail the tests suite, but prior to this
+			// adddition it would have passed.
+			key2 := []byte("key-2")
+			orig2 := []byte("delete me later - you should never find me again")
+
+			err = b.Put(key2, orig2)
+			require.Nil(t, err)
+		})
+
+		t.Run("shutdown (orderly) bucket to create first segment", func(t *testing.T) {
+			b.Shutdown(context.Background())
+
+			// then recreate bucket
+			var err error
+			b, err = NewBucket(testCtx(), dirNameOriginal, nullLogger(), nil,
+				WithStrategy(StrategyReplace))
+			require.Nil(t, err)
+		})
 
 		t.Run("set original values", func(t *testing.T) {
 			key1 := []byte("key-1")
@@ -100,15 +133,29 @@ func TestReplaceStrategy_RecoverFromWAL(t *testing.T) {
 		})
 
 		t.Run("copy state into recovery folder and destroy original", func(t *testing.T) {
-			cmd := exec.Command("/bin/bash", "-c", fmt.Sprintf("cp -r %s/*.wal %s",
-				dirNameOriginal, dirNameRecovered))
-			var out bytes.Buffer
-			cmd.Stderr = &out
-			err := cmd.Run()
-			if err != nil {
-				fmt.Println(out.String())
-				t.Fatal(err)
-			}
+			t.Run("copy over wals", func(t *testing.T) {
+				cmd := exec.Command("/bin/bash", "-c", fmt.Sprintf("cp -r %s/*.wal %s",
+					dirNameOriginal, dirNameRecovered))
+				var out bytes.Buffer
+				cmd.Stderr = &out
+				err := cmd.Run()
+				if err != nil {
+					fmt.Println(out.String())
+					t.Fatal(err)
+				}
+			})
+
+			t.Run("copy over segments", func(t *testing.T) {
+				cmd := exec.Command("/bin/bash", "-c", fmt.Sprintf("cp -r %s/*.db %s",
+					dirNameOriginal, dirNameRecovered))
+				var out bytes.Buffer
+				cmd.Stderr = &out
+				err := cmd.Run()
+				if err != nil {
+					fmt.Println(out.String())
+					t.Fatal(err)
+				}
+			})
 			b = nil
 			require.Nil(t, os.RemoveAll(dirNameOriginal))
 		})


### PR DESCRIPTION
## Public Info

Prior to this change, a very large WAL (Write-Ahead-Log) would lead to a very slow recovery, as the memtable used as part of the recovery is not intended to hold so many values. This change introduces a first step to deduplicate entries which makes the recovery considerably faster.

## Internal Info

This build has passed our stress test pipeline:

<img width="1386" alt="image" src="https://user-images.githubusercontent.com/8974479/176995385-b722eb2a-a69a-426d-a38f-00225ab191f5.png">
