### PR TITLE
Prevent a potential "startup race" leading to nil-pointer panics

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -87,7 +87,7 @@ before_script:
   # Verify that the code is properly formatted.
   - if [[ -n "$(gofmt -l .)" ]]; then echo "The following files were not formatted properly!"; gofmt -l .; exit 1; fi
 script: 
-  - travis_wait 30 ./test/run.sh || travis_terminate 1
+  - travis_wait 20 ./test/run.sh || travis_terminate 1
 services: 
   - docker
 sudo: required

--- a/.travis.yml
+++ b/.travis.yml
@@ -87,7 +87,7 @@ before_script:
   # Verify that the code is properly formatted.
   - if [[ -n "$(gofmt -l .)" ]]; then echo "The following files were not formatted properly!"; gofmt -l .; exit 1; fi
 script: 
-  - travis_wait 20 ./test/run.sh || travis_terminate 1
+  - travis_wait 30 ./test/run.sh || travis_terminate 1
 services: 
   - docker
 sudo: required

--- a/adapters/repos/db/shard_geo_props.go
+++ b/adapters/repos/db/shard_geo_props.go
@@ -42,6 +42,8 @@ func (s *Shard) initGeoProp(prop *models.Property) error {
 		Name:     prop.Name,
 	}
 
+	idx.PostStartup()
+
 	return nil
 }
 

--- a/adapters/repos/db/vector/geo/geo.go
+++ b/adapters/repos/db/vector/geo/geo.go
@@ -44,6 +44,7 @@ type vectorIndex interface {
 	Delete(id uint64) error
 	Dump(...string)
 	Drop() error
+	PostStartup()
 }
 
 // Config is passed to the GeoIndex when its created
@@ -86,6 +87,10 @@ func (i *Index) Drop() error {
 
 	i.vectorIndex = nil
 	return nil
+}
+
+func (i *Index) PostStartup() {
+	i.vectorIndex.PostStartup()
 }
 
 func makeCommitLoggerFromConfig(config Config) hnsw.MakeCommitLogger {

--- a/adapters/repos/db/vector/hnsw/index_too_many_links_bug_integration_test.go
+++ b/adapters/repos/db/vector/hnsw/index_too_many_links_bug_integration_test.go
@@ -90,6 +90,7 @@ func Test_NoRace_ManySmallCommitlogs(t *testing.T) {
 			VectorCacheMaxObjects: 2 * n,
 		})
 		require.Nil(t, err)
+		idx.PostStartup()
 		index = idx
 	})
 
@@ -172,6 +173,7 @@ func Test_NoRace_ManySmallCommitlogs(t *testing.T) {
 			VectorCacheMaxObjects: 2 * n,
 		})
 		require.Nil(t, err)
+		idx.PostStartup()
 		index = idx
 	})
 

--- a/adapters/repos/db/vector/hnsw/periodic_tombstone_removal_test.go
+++ b/adapters/repos/db/vector/hnsw/periodic_tombstone_removal_test.go
@@ -32,6 +32,9 @@ func TestPeriodicTombstoneRemoval(t *testing.T) {
 		MaxConnections:         30,
 		EFConstruction:         128,
 	})
+	index.PostStartup()
+
+	defer index.Shutdown()
 	require.Nil(t, err)
 
 	for i, vec := range testVectors {

--- a/adapters/repos/db/vector/hnsw/startup.go
+++ b/adapters/repos/db/vector/hnsw/startup.go
@@ -157,8 +157,8 @@ func (h *hnsw) registerTombstoneCleanup() {
 // vector cache, however, depend on the shard being ready as they will call
 // getVectorForID.
 func (h *hnsw) PostStartup() {
-	h.prefillCache()
 	h.registerMaintainence()
+	h.prefillCache()
 }
 
 func (h *hnsw) prefillCache() {

--- a/adapters/repos/db/vector/hnsw/startup.go
+++ b/adapters/repos/db/vector/hnsw/startup.go
@@ -37,7 +37,6 @@ func (h *hnsw) init(cfg Config) error {
 	}
 
 	h.commitLog = cl
-	h.registerMaintainence()
 
 	return nil
 }
@@ -159,6 +158,7 @@ func (h *hnsw) registerTombstoneCleanup() {
 // getVectorForID.
 func (h *hnsw) PostStartup() {
 	h.prefillCache()
+	h.registerMaintainence()
 }
 
 func (h *hnsw) prefillCache() {


### PR DESCRIPTION
Prior to this fix, it was possible for the HNSW index to start its delete cycle before the LSM store was ready. If this ever occurred, the result would be a nil-pointer panic as the HNSW delete cycle would try to access vectors from the LSM store which may not have existed. This fix makes sure that the delete cycle is only initiated as part of the `PostStartup()` routine which guarantees that the LSM store is fully up and running.