### PR TITLE
Add Skeleton for backup/snapshot provider

### DIFF
--- a/entities/snapshots/snapshot.go
+++ b/entities/snapshots/snapshot.go
@@ -1,0 +1,20 @@
+package snapshots
+
+import "time"
+
+type Snapshot struct {
+	StartedAt   time.Time
+	CompletedAt time.Time
+
+	ID    string
+	Files []string
+}
+
+// type Backup struct {
+// 	Events []BackupEvent
+// }
+
+// type BackupEvent struct {
+// 	Time time.Time
+// 	Msg  string
+// }

--- a/usecases/backups/backups.go
+++ b/usecases/backups/backups.go
@@ -1,0 +1,95 @@
+package backups
+
+import (
+	"context"
+
+	"github.com/pkg/errors"
+	"github.com/semi-technologies/weaviate/entities/snapshots"
+)
+
+type modulesProvider interface {
+	BackupStorageProvider(providerID string) (StorageProvider, error)
+}
+
+type StorageProvider interface {
+	StoreSnapshot(ctx context.Context, snapshot snapshots.Snapshot) error
+	// TODO: expand to also be able to restore from snapshot
+}
+
+type Snapshotter interface { // implemented by the index
+	// Snapshot creates a snapshot which is metadata referencing files on disk.
+	// While the snapshot exists, the index makes sure that those files are never
+	// changed, for examle by stopping compactions.
+	//
+	// The index stays usable with a snapshot present, it can still accept
+	// reads+writes, as the index is built in an append-only-way.
+	//
+	// Snapshot() fails if another snapshot exists.
+	Snapshot(ctx context.Context) (snapshots.Snapshot, error)
+
+	// ReleaseSnapshot signals to the unederlyhing index that the files have been
+	// copied (or the operation aborted), and that it is safe for the index to
+	// change the files, such as start compactions.
+	ReleaseSnapshot(ctx context.Context, id string) error
+}
+
+type SnapshotProvider struct {
+	snapshotter     Snapshotter
+	storageProvider StorageProvider
+}
+
+func NewSnapshotProvider(snapshotter Snapshotter,
+	storageProvider StorageProvider) (*SnapshotProvider, error) {
+	return &SnapshotProvider{ /*TODO*/ }, nil
+}
+
+func (sm *SnapshotProvider) Backup(ctx context.Context) error {
+	snapshot, err := sm.snapshotter.Snapshot(ctx)
+	if err != nil {
+		return errors.Wrap(err, "create snapshot")
+	}
+
+	if err := sm.storageProvider.StoreSnapshot(ctx, snapshot); err != nil {
+		return errors.Wrap(err, "store snapshot")
+	}
+
+	// 3. if successful delete snapshot
+	if err := sm.snapshotter.ReleaseSnapshot(ctx, snapshot.ID); err != nil {
+		return errors.Wrap(err, "delete snapshot")
+	}
+
+	return nil
+}
+
+type BackupManager struct {
+	modules modulesProvider
+}
+
+// CreateBackup is called by the User
+func (bm *BackupManager) CreateBackup(ctx context.Context, className string,
+	storageProviderName string) error {
+	// get snapshotter from Index for className
+	var snapshotter Snapshotter
+
+	storageProvider, err := bm.modules.BackupStorageProvider(storageProviderName)
+	if err != nil {
+		return errors.Wrapf(err, "find backup provider %q", storageProviderName)
+	}
+
+	provider, err := NewSnapshotProvider(snapshotter, storageProvider)
+	if err != nil {
+		return errors.Wrap(err, "init snapshot provider")
+	}
+
+	err = provider.Backup(ctx)
+	if err != nil {
+		return errors.Wrap(err, "execute backup")
+	}
+
+	return nil
+}
+
+func (bm *BackupManager) RestoreBackup(ctx context.Context, className string,
+	storageProviderName string, backupID string) error {
+	panic("not implemented")
+}

--- a/usecases/modules/modules.go
+++ b/usecases/modules/modules.go
@@ -23,6 +23,7 @@ import (
 	"github.com/semi-technologies/weaviate/entities/moduletools"
 	"github.com/semi-technologies/weaviate/entities/schema"
 	"github.com/semi-technologies/weaviate/entities/search"
+	"github.com/semi-technologies/weaviate/usecases/backups"
 	"github.com/sirupsen/logrus"
 )
 
@@ -663,4 +664,9 @@ func (m *Provider) getClass(className string) (*models.Class, error) {
 
 func (m *Provider) HasMultipleVectorizers() bool {
 	return m.hasMultipleVectorizers
+}
+
+func (m *Provider) BackupStorageProvider(providerID string) backups.StorageProvider {
+	// TODO find the right module that exposes a backups.StorageProvider for the
+	// providerID, where providerID is something like "s3"
 }

--- a/usecases/modules/modules.go
+++ b/usecases/modules/modules.go
@@ -669,4 +669,5 @@ func (m *Provider) HasMultipleVectorizers() bool {
 func (m *Provider) BackupStorageProvider(providerID string) backups.StorageProvider {
 	// TODO find the right module that exposes a backups.StorageProvider for the
 	// providerID, where providerID is something like "s3"
+	panic("not implemented")
 }


### PR DESCRIPTION
This introduces a high-level API to coordinate snapshots and backups. This can be considered a draft and roughly allows splitting up the work into independent chunks such as the storage provider on the module side, the snapshotter on the index, etc. It is not functional yet, but entirely non-breaking as it only introduces new code that isn't called anywhere yet.