### PR TITLE
Standardize SegmentGroup receiver name

### DIFF
--- a/adapters/repos/db/lsmkv/cursor_segment_collection.go
+++ b/adapters/repos/db/lsmkv/cursor_segment_collection.go
@@ -26,15 +26,15 @@ func (s *segment) newCollectionCursor() *segmentCursorCollection {
 	}
 }
 
-func (s *SegmentGroup) newCollectionCursors() ([]innerCursorCollection, func()) {
-	s.maintenanceLock.RLock()
-	out := make([]innerCursorCollection, len(s.segments))
+func (sg *SegmentGroup) newCollectionCursors() ([]innerCursorCollection, func()) {
+	sg.maintenanceLock.RLock()
+	out := make([]innerCursorCollection, len(sg.segments))
 
-	for i, segment := range s.segments {
+	for i, segment := range sg.segments {
 		out[i] = segment.newCollectionCursor()
 	}
 
-	return out, s.maintenanceLock.RUnlock
+	return out, sg.maintenanceLock.RUnlock
 }
 
 func (s *segmentCursorCollection) seek(key []byte) ([]byte, []value, error) {

--- a/adapters/repos/db/lsmkv/cursor_segment_map.go
+++ b/adapters/repos/db/lsmkv/cursor_segment_map.go
@@ -26,15 +26,15 @@ func (s *segment) newMapCursor() *segmentCursorMap {
 	}
 }
 
-func (s *SegmentGroup) newMapCursors() ([]innerCursorMap, func()) {
-	s.maintenanceLock.RLock()
-	out := make([]innerCursorMap, len(s.segments))
+func (sg *SegmentGroup) newMapCursors() ([]innerCursorMap, func()) {
+	sg.maintenanceLock.RLock()
+	out := make([]innerCursorMap, len(sg.segments))
 
-	for i, segment := range s.segments {
+	for i, segment := range sg.segments {
 		out[i] = segment.newMapCursor()
 	}
 
-	return out, s.maintenanceLock.RUnlock
+	return out, sg.maintenanceLock.RUnlock
 }
 
 func (s *segmentCursorMap) seek(key []byte) ([]byte, []MapPair, error) {

--- a/adapters/repos/db/lsmkv/cursor_segment_replace.go
+++ b/adapters/repos/db/lsmkv/cursor_segment_replace.go
@@ -28,15 +28,15 @@ func (s *segment) newCursor() *segmentCursorReplace {
 	}
 }
 
-func (s *SegmentGroup) newCursors() ([]innerCursorReplace, func()) {
-	s.maintenanceLock.RLock()
-	out := make([]innerCursorReplace, len(s.segments))
+func (sg *SegmentGroup) newCursors() ([]innerCursorReplace, func()) {
+	sg.maintenanceLock.RLock()
+	out := make([]innerCursorReplace, len(sg.segments))
 
-	for i, segment := range s.segments {
+	for i, segment := range sg.segments {
 		out[i] = segment.newCursor()
 	}
 
-	return out, s.maintenanceLock.RUnlock
+	return out, sg.maintenanceLock.RUnlock
 }
 
 func (s *segmentCursorReplace) seek(key []byte) ([]byte, []byte, error) {


### PR DESCRIPTION
`SegmentGroup` method receiver names were different across all methods for that type. Also, I believe that the `ig` receiver  name is not as readable as `sg`, which this PR introduces.