### PR TITLE
Parallelize test pipelines

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,6 @@
 addons:
   hosts:
-    - db
-# after_success is only used for Dockerhub and should run last.
-  
+    - db  
 before_install: 
   # install a newer docker version which supports buildx
   - sudo rm -rf /var/lib/apt/lists/*
@@ -70,14 +68,12 @@ before_script:
         travis_terminate 0
       fi
     fi
-  # Verify that the code is properly formatted.
-  - if [[ -n "$(gofmt -l .)" ]]; then echo "The following files were not formatted properly!"; gofmt -l .; exit 1; fi
 jobs:
   include:
   - name: "Unit and integration tests"
     stage: test
     script: 
-    - travis_wait 20 ./test/run.sh --unit_and_integration_tests || travis_terminate 1
+    - ./test/run.sh --unit_and_integration_tests || travis_terminate 1
     - |
       if [ "$TRAVIS_PULL_REQUEST" != "false" ]; then
           # send to codecov.io
@@ -91,7 +87,7 @@ jobs:
   - name: "Acceptance tests (requiring docker to run)"
     stage: test
     script: 
-    - travis_wait 20 ./test/run.sh --acceptance_tests || travis_terminate 1
+    - ./test/run.sh --acceptance_tests || travis_terminate 1
   - name: "Push docker container"
     if: type != pull_request
     stage: deploy

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,21 +2,7 @@ addons:
   hosts:
     - db
 # after_success is only used for Dockerhub and should run last.
-after_success:
-  - |
-    if [ "$TRAVIS_PULL_REQUEST" != "false" ]; then
-      # send to codecov.io
-      # unit tests
-      rm -f coverage.txt || true; mv coverage-unit.txt coverage.txt
-      bash <(curl -s https://codecov.io/bash) -F unittests
-
-      # unit tests
-      rm -f coverage.txt || true; mv coverage-integration.txt coverage.txt
-      bash <(curl -s https://codecov.io/bash) -F integration
-
-      rm coverage.txt
-    fi
-  - travis_wait 30 ./ci/push_docker.sh
+  
 before_install: 
   # install a newer docker version which supports buildx
   - sudo rm -rf /var/lib/apt/lists/*
@@ -86,8 +72,31 @@ before_script:
     fi
   # Verify that the code is properly formatted.
   - if [[ -n "$(gofmt -l .)" ]]; then echo "The following files were not formatted properly!"; gofmt -l .; exit 1; fi
-script: 
-  - travis_wait 20 ./test/run.sh || travis_terminate 1
+jobs:
+  include:
+  - name: "Unit and integration tests"
+    stage: test
+    script: 
+    - travis_wait 20 ./test/run.sh unit_and_integration_tests || travis_terminate 1
+    - |
+      if [ "$TRAVIS_PULL_REQUEST" != "false" ]; then
+          # send to codecov.io
+          rm -f coverage.txt || true; mv coverage-unit.txt coverage.txt
+          bash <(curl -s https://codecov.io/bash) -F unittests
+
+          rm -f coverage.txt || true; mv coverage-integration.txt coverage.txt
+          bash <(curl -s https://codecov.io/bash) -F integration
+          rm -f coverage.txt
+      fi
+  - name: "Acceptance tests (requiring docker to run)"
+    stage: test
+    script: 
+    - travis_wait 20 ./test/run.sh acceptance_tests || travis_terminate 1
+  - name: "Push docker container"
+    stage: deploy
+    script:
+      - travis_wait 30 ./ci/push_docker.sh
+
 services: 
   - docker
 sudo: required

--- a/.travis.yml
+++ b/.travis.yml
@@ -93,6 +93,7 @@ jobs:
     script: 
     - travis_wait 20 ./test/run.sh acceptance_tests || travis_terminate 1
   - name: "Push docker container"
+    if: type != pull_request
     stage: deploy
     script:
       - travis_wait 30 ./ci/push_docker.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -77,7 +77,7 @@ jobs:
   - name: "Unit and integration tests"
     stage: test
     script: 
-    - travis_wait 20 ./test/run.sh unit_and_integration_tests || travis_terminate 1
+    - travis_wait 20 ./test/run.sh --unit_and_integration_tests || travis_terminate 1
     - |
       if [ "$TRAVIS_PULL_REQUEST" != "false" ]; then
           # send to codecov.io
@@ -91,7 +91,7 @@ jobs:
   - name: "Acceptance tests (requiring docker to run)"
     stage: test
     script: 
-    - travis_wait 20 ./test/run.sh acceptance_tests || travis_terminate 1
+    - travis_wait 20 ./test/run.sh --acceptance_tests || travis_terminate 1
   - name: "Push docker container"
     if: type != pull_request
     stage: deploy

--- a/test/run.sh
+++ b/test/run.sh
@@ -15,29 +15,36 @@ function main() {
   rm -rf data
   echo "Done!"
 
-  echo_green "Run all unit tests..."
-  run_unit_tests "$@"
-  echo_green "Unit tests successful"
+  if [ "$1" = "unit_and_integration_tests" ]
+  then
+    echo_green "Run all unit tests..."
+    run_unit_tests "$@"
+    echo_green "Unit tests successful"
+    echo_green "Run integration tests..."
+    run_integration_tests "$@"
+    echo_green "Integration tests successful"
+  elif [ "$1" = "acceptance_tests" ]
+  then
+    echo "In Acceptance test suite"
+    echo_green "Stop any running docker-compose containers..."
+    surpress_on_success docker-compose -f docker-compose-test.yml down --remove-orphans
 
-  echo_green "Run integration tests..."
-  run_integration_tests "$@"
-  echo_green "Integration tests successful"
+    echo_green "Start up weaviate and backing dbs in docker-compose..."
+    echo "This could take some time..."
+    tools/test/run_ci_server.sh
 
-  echo_green "Stop any running docker-compose containers..."
-  surpress_on_success docker-compose -f docker-compose-test.yml down --remove-orphans
+    # echo_green "Import required schema and test fixtures..."
+    # # Note: It's not best practice to do this as part of the test script
+    # # It would be better if each test independently prepared (and also 
+    # # cleaned up) the test fixtures it needs, but one step at a time ;)
+    # surpress_on_success import_test_fixtures
 
-  echo_green "Start up weaviate and backing dbs in docker-compose..."
-  echo "This could take some time..."
-  tools/test/run_ci_server.sh
-
-  # echo_green "Import required schema and test fixtures..."
-  # # Note: It's not best practice to do this as part of the test script
-  # # It would be better if each test independently prepared (and also 
-  # # cleaned up) the test fixtures it needs, but one step at a time ;)
-  # surpress_on_success import_test_fixtures
-
-  echo_green "Run acceptance tests..."
-  run_acceptance_tests "$@"
+    echo_green "Run acceptance tests..."
+    run_acceptance_tests "$@"
+  else
+    echo "Unknown test suite, exiting"
+    exit 1
+  fi
 
   echo "Done!"
 }

--- a/test/run.sh
+++ b/test/run.sh
@@ -3,6 +3,20 @@
 set -eou pipefail
 
 function main() {
+  # This script runs all tests if no CMD switch is given and the respective tests otherwise.
+  run_all_tests=true
+  run_acceptance_tests=false
+  run_unit_and_integration_tests=false
+
+  while [[ "$#" -gt 0 ]]; do
+      case $1 in
+          --acceptance_tests) run_all_tests=false; run_acceptance_tests=true; echo $run_acceptance_tests ;;
+          --unit_and_integration_tests) run_all_tests=false; run_unit_and_integration_tests=true; echo $run_all_tests;;
+          *) echo "Unknown parameter passed: $1"; exit 1 ;;
+      esac
+      shift
+  done
+
   # Jump to root directory
   cd "$( dirname "${BASH_SOURCE[0]}" )"/..
 
@@ -15,7 +29,7 @@ function main() {
   rm -rf data
   echo "Done!"
 
-  if [ "$1" = "unit_and_integration_tests" ]
+  if $run_unit_and_integration_tests || $run_all_tests
   then
     echo_green "Run all unit tests..."
     run_unit_tests "$@"
@@ -23,7 +37,9 @@ function main() {
     echo_green "Run integration tests..."
     run_integration_tests "$@"
     echo_green "Integration tests successful"
-  elif [ "$1" = "acceptance_tests" ]
+  fi 
+
+  if $run_acceptance_tests || $run_all_tests
   then
     echo "In Acceptance test suite"
     echo_green "Stop any running docker-compose containers..."
@@ -41,9 +57,6 @@ function main() {
 
     echo_green "Run acceptance tests..."
     run_acceptance_tests "$@"
-  else
-    echo "Unknown test suite, exiting"
-    exit 1
   fi
 
   echo "Done!"


### PR DESCRIPTION
This should speed up our pipelines by running different parts of the test suite in parallel.

It is organized the following:
- stage test: Unit, Integration and Acceptance tests do not depend on each other and can run on different containers in parallel. Due to problems with codecov (sending the coverage result file from different jobs does not produce a correct report) Unit and integration tests run in the same job.
- stage deploy: After all tests have passed, the container is build and uploaded. The deploy stage will only be started for [PR-tests](https://app.travis-ci.com/github/semi-technologies/weaviate/builds/253239024) and not the [branch-tests](https://app.travis-ci.com/github/semi-technologies/weaviate/builds/253240412). This saves starting up another container that only builds the docker image and then exists saving another ~1:30min.

Note that the codecov reports complains about a lower coverage. As this PR only contains changes to .travis-ci and run scripts, this seems not be caused by me and is probably due to the random nature of some tests.