### PR TITLE
Improve Dev-Server Script

### DIFF
--- a/tools/dev/run_dev_server.sh
+++ b/tools/dev/run_dev_server.sh
@@ -6,22 +6,22 @@ CONFIG=${1:-local-development}
 cd "$( dirname "${BASH_SOURCE[0]}" )"/../..
 
 export GO111MODULE=on
-export DEVELOPMENT_UI=on
-export LOG_LEVEL=debug
-export LOG_FORMAT=text
-export PROMETHEUS_MONITORING_ENABLED=true
-export ENABLE_EXPERIMENTAL_BM25=true
-export GO_BLOCK_PROFILE_RATE=20
-export GO_MUTEX_PROFILE_FRACTION=20
+export LOG_LEVEL=${LOG_LEVEL:-"debug"}
+export LOG_FORMAT=${LOG_FORMAT:-"text"}
+export PROMETHEUS_MONITORING_ENABLED=${PROMETHEUS_MONITORING_ENABLED:-"true"}
+export ENABLE_EXPERIMENTAL_BM25=${ENABLE_EXPERIMENTAL_BM25:-"true"}
+export GO_BLOCK_PROFILE_RATE=${GO_BLOCK_PROFILE_RATE:-"20"}
+export GO_MUTEX_PROFILE_FRACTION=${GO_MUTEX_PROFILE_FRACTION:-"20"}
+export PERSISTENCE_DATA_PATH=${PERSISTENCE_DATA_PATH:-"./data"}
+export ORIGIN=${ORIGIN:-"http://localhost:8080"}
+export QUERY_DEFAULTS_LIMIT=${QUERY_DEFAULTS_LIMIT:-"20"}
+export QUERY_MAXIMUM_RESULTS=${QUERY_MAXIMUM_RESULTS:-"10000"}
 
 case $CONFIG in
   debug)
       CONTEXTIONARY_URL=localhost:9999 \
-      QUERY_DEFAULTS_LIMIT=20 \
-      ORIGIN=http://localhost:8080 \
       AUTHENTICATION_ANONYMOUS_ACCESS_ENABLED=true \
       DEFAULT_VECTORIZER_MODULE=text2vec-contextionary \
-      PERSISTENCE_DATA_PATH="./data" \
       ENABLE_MODULES="text2vec-contextionary" \
       dlv debug ./cmd/weaviate-server -- \
         --scheme http \
@@ -33,12 +33,8 @@ case $CONFIG in
 
   local-development)
       CONTEXTIONARY_URL=localhost:9999 \
-      QUERY_DEFAULTS_LIMIT=20 \
-      QUERY_MAXIMUM_RESULTS=10000 \
-      ORIGIN=http://localhost:8080 \
       AUTHENTICATION_ANONYMOUS_ACCESS_ENABLED=true \
       DEFAULT_VECTORIZER_MODULE=text2vec-contextionary \
-      PERSISTENCE_DATA_PATH="./data" \
       STORAGE_FS_SNAPSHOTS_PATH="${PWD}/snapshots" \
       ENABLE_MODULES="text2vec-contextionary,storage-filesystem" \
       CLUSTER_HOSTNAME="node1" \
@@ -52,10 +48,8 @@ case $CONFIG in
         --write-timeout=600s
     ;;
   second-node)
-      QUERY_DEFAULTS_LIMIT=20 \
-      ORIGIN=http://localhost:8080 \
       AUTHENTICATION_ANONYMOUS_ACCESS_ENABLED=true \
-      PERSISTENCE_DATA_PATH="./data-node2" \
+      PERSISTENCE_DATA_PATH="${PERSISTENCE_DATA_PATH}-node2" \
       STORAGE_FS_SNAPSHOTS_PATH="${PWD}/snapshots-node2" \
       CLUSTER_HOSTNAME="node2" \
       CLUSTER_GOSSIP_BIND_PORT="7102" \
@@ -74,11 +68,8 @@ case $CONFIG in
 
   local-transformers)
       CONTEXTIONARY_URL=localhost:9999 \
-      QUERY_DEFAULTS_LIMIT=20 \
-      ORIGIN=http://localhost:8080 \
       AUTHENTICATION_ANONYMOUS_ACCESS_ENABLED=true \
       DEFAULT_VECTORIZER_MODULE=text2vec-transformers \
-      PERSISTENCE_DATA_PATH="./data" \
       TRANSFORMERS_INFERENCE_API="http://localhost:8000" \
       ENABLE_MODULES="text2vec-transformers" \
       go run ./cmd/weaviate-server \
@@ -90,11 +81,8 @@ case $CONFIG in
     ;;
   local-transformers-passage-query)
       CONTEXTIONARY_URL=localhost:9999 \
-      QUERY_DEFAULTS_LIMIT=20 \
-      ORIGIN=http://localhost:8080 \
       AUTHENTICATION_ANONYMOUS_ACCESS_ENABLED=true \
       DEFAULT_VECTORIZER_MODULE=text2vec-transformers \
-      PERSISTENCE_DATA_PATH="./data" \
       TRANSFORMERS_PASSAGE_INFERENCE_API="http://localhost:8006" \
       TRANSFORMERS_QUERY_INFERENCE_API="http://localhost:8007" \
       ENABLE_MODULES="text2vec-transformers" \
@@ -107,11 +95,8 @@ case $CONFIG in
     ;;  
   local-qna)
       CONTEXTIONARY_URL=localhost:9999 \
-      QUERY_DEFAULTS_LIMIT=20 \
-      ORIGIN=http://localhost:8080 \
       AUTHENTICATION_ANONYMOUS_ACCESS_ENABLED=true \
       DEFAULT_VECTORIZER_MODULE=text2vec-contextionary \
-      PERSISTENCE_DATA_PATH="./data" \
       QNA_INFERENCE_API="http://localhost:8001" \
       ENABLE_MODULES="text2vec-contextionary,qna-transformers" \
       go run ./cmd/weaviate-server \
@@ -123,11 +108,8 @@ case $CONFIG in
     ;;
   local-image)
       CONTEXTIONARY_URL=localhost:9999 \
-      QUERY_DEFAULTS_LIMIT=20 \
-      ORIGIN=http://localhost:8080 \
       AUTHENTICATION_ANONYMOUS_ACCESS_ENABLED=true \
       DEFAULT_VECTORIZER_MODULE=text2vec-contextionary \
-      PERSISTENCE_DATA_PATH="./data" \
       IMAGE_INFERENCE_API="http://localhost:8002" \
       ENABLE_MODULES="text2vec-contextionary,img2vec-neural" \
       go run ./cmd/weaviate-server \
@@ -139,11 +121,8 @@ case $CONFIG in
     ;;
   local-ner)
       CONTEXTIONARY_URL=localhost:9999 \
-      QUERY_DEFAULTS_LIMIT=20 \
-      ORIGIN=http://localhost:8080 \
       AUTHENTICATION_ANONYMOUS_ACCESS_ENABLED=true \
       DEFAULT_VECTORIZER_MODULE=text2vec-contextionary \
-      PERSISTENCE_DATA_PATH="./data" \
       NER_INFERENCE_API="http://localhost:8003" \
       ENABLE_MODULES="text2vec-contextionary,ner-transformers" \
       go run ./cmd/weaviate-server \
@@ -155,11 +134,8 @@ case $CONFIG in
     ;;
   local-spellcheck)
       CONTEXTIONARY_URL=localhost:9999 \
-      QUERY_DEFAULTS_LIMIT=20 \
-      ORIGIN=http://localhost:8080 \
       AUTHENTICATION_ANONYMOUS_ACCESS_ENABLED=true \
       DEFAULT_VECTORIZER_MODULE=text2vec-contextionary \
-      PERSISTENCE_DATA_PATH="./data" \
       SPELLCHECK_INFERENCE_API="http://localhost:8004" \
       ENABLE_MODULES="text2vec-contextionary,text-spellcheck" \
       go run ./cmd/weaviate-server \
@@ -171,11 +147,8 @@ case $CONFIG in
     ;;
   local-clip)
       CONTEXTIONARY_URL=localhost:9999 \
-      QUERY_DEFAULTS_LIMIT=20 \
-      ORIGIN=http://localhost:8080 \
       AUTHENTICATION_ANONYMOUS_ACCESS_ENABLED=true \
       DEFAULT_VECTORIZER_MODULE=multi2vec-clip \
-      PERSISTENCE_DATA_PATH="./data" \
       CLIP_INFERENCE_API="http://localhost:8005" \
       ENABLE_MODULES="multi2vec-clip" \
       go run ./cmd/weaviate-server \
@@ -187,9 +160,6 @@ case $CONFIG in
     ;;
   local-oidc)
       CONTEXTIONARY_URL=localhost:9999 \
-      QUERY_DEFAULTS_LIMIT=20 \
-      ORIGIN=http://localhost:8080 \
-      PERSISTENCE_DATA_PATH="./data" \
       AUTHENTICATION_ANONYMOUS_ACCESS_ENABLED=false \
       AUTHENTICATION_OIDC_ENABLED=true \
       AUTHENTICATION_OIDC_ISSUER=http://localhost:9090/auth/realms/weaviate \
@@ -207,9 +177,6 @@ case $CONFIG in
 
   local-multi-text)
       CONTEXTIONARY_URL=localhost:9999 \
-      QUERY_DEFAULTS_LIMIT=20 \
-      ORIGIN=http://localhost:8080 \
-      PERSISTENCE_DATA_PATH="./data" \
       AUTHENTICATION_ANONYMOUS_ACCESS_ENABLED=true \
       DEFAULT_VECTORIZER_MODULE=text2vec-contextionary \
       TRANSFORMERS_INFERENCE_API=http://localhost:8000 \
@@ -223,11 +190,8 @@ case $CONFIG in
 
   local-openai)
       CONTEXTIONARY_URL=localhost:9999 \
-      QUERY_DEFAULTS_LIMIT=20 \
-      ORIGIN=http://localhost:8080 \
       AUTHENTICATION_ANONYMOUS_ACCESS_ENABLED=true \
       DEFAULT_VECTORIZER_MODULE=text2vec-openai \
-      PERSISTENCE_DATA_PATH="./data" \
       ENABLE_MODULES="text2vec-openai" \
       go run ./cmd/weaviate-server \
         --scheme http \
@@ -238,11 +202,8 @@ case $CONFIG in
     ;;
 
   local-no-modules)
-      QUERY_DEFAULTS_LIMIT=20 \
-      ORIGIN=http://localhost:8080 \
       AUTHENTICATION_ANONYMOUS_ACCESS_ENABLED=true \
       DEFAULT_VECTORIZER_MODULE=none \
-      PERSISTENCE_DATA_PATH="./data" \
       go run ./cmd/weaviate-server \
         --scheme http \
         --host "127.0.0.1" \

--- a/tools/dev/run_dev_server.sh
+++ b/tools/dev/run_dev_server.sh
@@ -23,6 +23,7 @@ case $CONFIG in
       AUTHENTICATION_ANONYMOUS_ACCESS_ENABLED=true \
       DEFAULT_VECTORIZER_MODULE=text2vec-contextionary \
       ENABLE_MODULES="text2vec-contextionary" \
+      CLUSTER_HOSTNAME="node1" \
       dlv debug ./cmd/weaviate-server -- \
         --scheme http \
         --host "127.0.0.1" \
@@ -71,6 +72,7 @@ case $CONFIG in
       AUTHENTICATION_ANONYMOUS_ACCESS_ENABLED=true \
       DEFAULT_VECTORIZER_MODULE=text2vec-transformers \
       TRANSFORMERS_INFERENCE_API="http://localhost:8000" \
+      CLUSTER_HOSTNAME="node1" \
       ENABLE_MODULES="text2vec-transformers" \
       go run ./cmd/weaviate-server \
         --scheme http \
@@ -85,6 +87,7 @@ case $CONFIG in
       DEFAULT_VECTORIZER_MODULE=text2vec-transformers \
       TRANSFORMERS_PASSAGE_INFERENCE_API="http://localhost:8006" \
       TRANSFORMERS_QUERY_INFERENCE_API="http://localhost:8007" \
+      CLUSTER_HOSTNAME="node1" \
       ENABLE_MODULES="text2vec-transformers" \
       go run ./cmd/weaviate-server \
         --scheme http \
@@ -98,6 +101,7 @@ case $CONFIG in
       AUTHENTICATION_ANONYMOUS_ACCESS_ENABLED=true \
       DEFAULT_VECTORIZER_MODULE=text2vec-contextionary \
       QNA_INFERENCE_API="http://localhost:8001" \
+      CLUSTER_HOSTNAME="node1" \
       ENABLE_MODULES="text2vec-contextionary,qna-transformers" \
       go run ./cmd/weaviate-server \
         --scheme http \
@@ -111,6 +115,7 @@ case $CONFIG in
       AUTHENTICATION_ANONYMOUS_ACCESS_ENABLED=true \
       DEFAULT_VECTORIZER_MODULE=text2vec-contextionary \
       IMAGE_INFERENCE_API="http://localhost:8002" \
+      CLUSTER_HOSTNAME="node1" \
       ENABLE_MODULES="text2vec-contextionary,img2vec-neural" \
       go run ./cmd/weaviate-server \
         --scheme http \
@@ -125,6 +130,7 @@ case $CONFIG in
       DEFAULT_VECTORIZER_MODULE=text2vec-contextionary \
       NER_INFERENCE_API="http://localhost:8003" \
       ENABLE_MODULES="text2vec-contextionary,ner-transformers" \
+      CLUSTER_HOSTNAME="node1" \
       go run ./cmd/weaviate-server \
         --scheme http \
         --host "127.0.0.1" \
@@ -138,6 +144,7 @@ case $CONFIG in
       DEFAULT_VECTORIZER_MODULE=text2vec-contextionary \
       SPELLCHECK_INFERENCE_API="http://localhost:8004" \
       ENABLE_MODULES="text2vec-contextionary,text-spellcheck" \
+      CLUSTER_HOSTNAME="node1" \
       go run ./cmd/weaviate-server \
         --scheme http \
         --host "127.0.0.1" \
@@ -151,6 +158,7 @@ case $CONFIG in
       DEFAULT_VECTORIZER_MODULE=multi2vec-clip \
       CLIP_INFERENCE_API="http://localhost:8005" \
       ENABLE_MODULES="multi2vec-clip" \
+      CLUSTER_HOSTNAME="node1" \
       go run ./cmd/weaviate-server \
         --scheme http \
         --host "127.0.0.1" \
@@ -169,6 +177,7 @@ case $CONFIG in
       AUTHORIZATION_ADMINLIST_ENABLED=true \
       AUTHORIZATION_ADMINLIST_USERS=john@doe.com \
       DEFAULT_VECTORIZER_MODULE=text2vec-contextionary \
+      CLUSTER_HOSTNAME="node1" \
       go run ./cmd/weaviate-server \
         --scheme http \
         --host "127.0.0.1" \
@@ -182,6 +191,7 @@ case $CONFIG in
       TRANSFORMERS_INFERENCE_API=http://localhost:8000 \
       CLIP_INFERENCE_API=http://localhost:8005 \
       ENABLE_MODULES=text2vec-contextionary,text2vec-transformers,multi2vec-clip \
+      CLUSTER_HOSTNAME="node1" \
       go run ./cmd/weaviate-server \
         --scheme http \
         --host "127.0.0.1" \
@@ -193,6 +203,7 @@ case $CONFIG in
       AUTHENTICATION_ANONYMOUS_ACCESS_ENABLED=true \
       DEFAULT_VECTORIZER_MODULE=text2vec-openai \
       ENABLE_MODULES="text2vec-openai" \
+      CLUSTER_HOSTNAME="node1" \
       go run ./cmd/weaviate-server \
         --scheme http \
         --host "127.0.0.1" \
@@ -202,6 +213,7 @@ case $CONFIG in
     ;;
 
   local-no-modules)
+      CLUSTER_HOSTNAME="node1" \
       AUTHENTICATION_ANONYMOUS_ACCESS_ENABLED=true \
       DEFAULT_VECTORIZER_MODULE=none \
       go run ./cmd/weaviate-server \


### PR DESCRIPTION
This PR aims to improve the DX for the dev server script:

* global variables are no longer hard-coded, they are taken from the
  environment if not set. If not provided defaults are used.
* repetition is removed among the invidivual configurations by moving
  all variables that are the same for every config to the global level

This change is non-breaking and running the script without setting any
env vars has the same effects as before. However, you can now customize
it. For example to change the log format to JSON and to run with a
different data path you can simply run:

```
LOG_LEVEL=json DATA_PERSISTENCE_PATH=./some-other-path \
  tools/dev/run_dev_server.sh local-no-modules