### PR TITLE
Handle Common Request Errors that would otherwise be shown as panics

### DIFF
--- a/adapters/handlers/rest/middlewares.go
+++ b/adapters/handlers/rest/middlewares.go
@@ -100,6 +100,7 @@ func makeSetupGlobalMiddleware(appState *state.State) func(http.Handler) http.Ha
 		handler = addHandleRoot(handler)
 		handler = makeAddModuleHandlers(appState.Modules)(handler)
 		handler = addInjectHeadersIntoContext(handler)
+		handler = makeCatchPanics(appState.Logger)(handler)
 
 		return handler
 	}

--- a/adapters/handlers/rest/panics_middleware.go
+++ b/adapters/handlers/rest/panics_middleware.go
@@ -1,0 +1,47 @@
+package rest
+
+import (
+	"net/http"
+	"syscall"
+
+	"github.com/pkg/errors"
+	"github.com/sirupsen/logrus"
+)
+
+func makeCatchPanics(logger logrus.FieldLogger) func(http.Handler) http.Handler {
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			defer handlePanics(logger, r)
+			next.ServeHTTP(w, r)
+		})
+	}
+}
+
+func handlePanics(logger logrus.FieldLogger, r *http.Request) {
+	recovered := recover()
+	if recovered == nil {
+		return
+	}
+
+	err, ok := recovered.(error)
+	if !ok {
+		// not a typed error, we can not handle this error other returning it to
+		// the user
+		logger.WithField("error", recovered).Error()
+		return
+	}
+
+	if errors.Is(err, syscall.EPIPE) {
+		handleBrokenPipe(err, logger, r)
+		return
+	}
+}
+
+func handleBrokenPipe(err error, logger logrus.FieldLogger, r *http.Request) {
+	logger.WithError(err).WithFields(logrus.Fields{
+		"method":      r.Method,
+		"path":        r.URL,
+		"description": "A broken pipe error occurs when Weaviate tries to write a response onto a connection that has already been closed or reset by the client. Typically, this is the case when the server was not able to respond within the configured client-side timeout.",
+		"hint":        "Either try increasing the client-side timeout, or sending a computationally cheaper request, for example by reducing a batch size, reducing a limit, using less complex filters, etc.",
+	}).Errorf("broken pipe")
+}

--- a/adapters/handlers/rest/panics_middleware.go
+++ b/adapters/handlers/rest/panics_middleware.go
@@ -3,6 +3,7 @@ package rest
 import (
 	"net"
 	"net/http"
+	"runtime/debug"
 	"syscall"
 
 	"github.com/pkg/errors"
@@ -33,6 +34,10 @@ func handlePanics(logger logrus.FieldLogger, r *http.Request) {
 			"method": r.Method,
 			"path":   r.URL,
 		}).Errorf("%v", recovered)
+
+		// This was not expected, so we want to print the stack, this will help us
+		// find the source of the issue if the user sends their logs
+		debug.PrintStack()
 		return
 	}
 
@@ -54,6 +59,9 @@ func handlePanics(logger logrus.FieldLogger, r *http.Request) {
 		"method": r.Method,
 		"path":   r.URL,
 	}).Errorf(err.Error())
+	// This was not expected, so we want to print the stack, this will help us
+	// find the source of the issue if the user sends their logs
+	debug.PrintStack()
 }
 
 func handleBrokenPipe(err error, logger logrus.FieldLogger, r *http.Request) {

--- a/adapters/handlers/rest/panics_middleware.go
+++ b/adapters/handlers/rest/panics_middleware.go
@@ -28,7 +28,11 @@ func handlePanics(logger logrus.FieldLogger, r *http.Request) {
 	if !ok {
 		// not a typed error, we can not handle this error other returning it to
 		// the user
-		logger.WithField("error", recovered).Error()
+		logger.WithFields(logrus.Fields{
+			"error":  recovered,
+			"method": r.Method,
+			"path":   r.URL,
+		}).Errorf("%v", recovered)
 		return
 	}
 
@@ -44,6 +48,12 @@ func handlePanics(logger logrus.FieldLogger, r *http.Request) {
 			return
 		}
 	}
+
+	// typed as error, but none we are currently handling explicitly
+	logger.WithError(err).WithFields(logrus.Fields{
+		"method": r.Method,
+		"path":   r.URL,
+	}).Errorf(err.Error())
 }
 
 func handleBrokenPipe(err error, logger logrus.FieldLogger, r *http.Request) {


### PR DESCRIPTION
Prior to this change, a client-side timeout or a server-side timeout would lead to panics. Those were only handled by the panic handling loggers as part of the Go http server. However, they would have still been printed with an entire stack trace which gave the user the impression that they were completely unhandled. In addition to that, users who are not network experts, had a hard time understanding what "broken pipe" or "i/o timeout" really meant. These are now caught and redirected to proper errors with a description and a hint on how to solve them.

closes #2044 

## Example 1: "broken pipe"

### Before
<img width="1708" alt="Screen Shot 2022-07-23 at 2 15 29 PM" src="https://user-images.githubusercontent.com/8974479/180611680-e21687bf-f7ff-4e73-8965-52cd0d5a239e.png">

### After
<img width="1718" alt="Screen Shot 2022-07-23 at 2 16 14 PM" src="https://user-images.githubusercontent.com/8974479/180611686-fa3c5780-53d6-46fb-8720-0816dc729e21.png">

## Example 2: "i/o timeout"

### Before
<img width="1715" alt="Screen Shot 2022-07-23 at 4 21 09 PM" src="https://user-images.githubusercontent.com/8974479/180611698-650c6220-2701-4ba9-b2b7-abd50c9ea912.png">

### After
<img width="1718" alt="Screen Shot 2022-07-23 at 4 20 40 PM" src="https://user-images.githubusercontent.com/8974479/180611732-0455a113-3af5-4018-b97e-ca0fdcb683cc.png">
