### PR TITLE
Improve performance of memtable for sequential writes

### DIFF
--- a/adapters/repos/db/lsmkv/binary_search_tree.go
+++ b/adapters/repos/db/lsmkv/binary_search_tree.go
@@ -62,7 +62,11 @@ func (t *binarySearchTree) setTombstone(key []byte, secondaryKeys [][]byte) {
 		return
 	}
 
-	t.root.setTombstone(key, secondaryKeys)
+	new_root := t.root.setTombstone(key, secondaryKeys)
+	if new_root != nil {
+		t.root = new_root
+	}
+	t.root.colourIsred = false // Can be flipped in the process of balancing, but root is always black
 }
 
 func (t *binarySearchTree) flattenInOrder() []*binarySearchNode {
@@ -181,12 +185,12 @@ func (n *binarySearchNode) get(key []byte) ([]byte, error) {
 	}
 }
 
-func (n *binarySearchNode) setTombstone(key []byte, secondaryKeys [][]byte) {
+func (n *binarySearchNode) setTombstone(key []byte, secondaryKeys [][]byte) *binarySearchNode {
 	if bytes.Equal(n.key, key) {
 		n.value = nil
 		n.tombstone = true
 		n.secondaryKeys = secondaryKeys
-		return
+		return nil
 	}
 
 	if bytes.Compare(key, n.key) < 0 {
@@ -196,12 +200,13 @@ func (n *binarySearchNode) setTombstone(key []byte, secondaryKeys [][]byte) {
 				value:         nil,
 				tombstone:     true,
 				secondaryKeys: secondaryKeys,
+				parent:        n,
+				colourIsred:   true,
 			}
-			return
-		}
+			return rebalanceRedBlackTree(n.left)
 
-		n.left.setTombstone(key, secondaryKeys)
-		return
+		}
+		return n.left.setTombstone(key, secondaryKeys)
 	} else {
 		if n.right == nil {
 			n.right = &binarySearchNode{
@@ -209,12 +214,12 @@ func (n *binarySearchNode) setTombstone(key []byte, secondaryKeys [][]byte) {
 				value:         nil,
 				tombstone:     true,
 				secondaryKeys: secondaryKeys,
+				parent:        n,
+				colourIsred:   true,
 			}
-			return
+			return rebalanceRedBlackTree(n.right)
 		}
-
-		n.right.setTombstone(key, secondaryKeys)
-		return
+		return n.right.setTombstone(key, secondaryKeys)
 	}
 }
 

--- a/adapters/repos/db/lsmkv/binary_search_tree_test.go
+++ b/adapters/repos/db/lsmkv/binary_search_tree_test.go
@@ -12,6 +12,7 @@
 package lsmkv
 
 import (
+	"fmt"
 	"math/rand"
 	"testing"
 	"time"
@@ -20,11 +21,17 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func setSeed(t *testing.T) {
+	time := time.Now().UnixNano()
+	t.Log("Seed is", fmt.Sprint(time))
+	rand.Seed(time)
+}
+
 // This test asserts that the *binarySearchTree.insert
 // method properly calculates the net additions of a
 // new node into the tree
 func TestInsertNetAdditions_Replace(t *testing.T) {
-	rand.Seed(time.Now().UnixNano())
+	setSeed(t)
 
 	t.Run("single node entry", func(t *testing.T) {
 		tree := &binarySearchTree{}

--- a/adapters/repos/db/lsmkv/red_black_tree.go
+++ b/adapters/repos/db/lsmkv/red_black_tree.go
@@ -1,0 +1,165 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2022 SeMI Technologies B.V. All rights reserved.
+//
+//  CONTACT: hello@semi.technology
+//
+
+package lsmkv
+
+// This function rebalances and recolours trees to be valid RB trees. It needs to be called after each node that
+// was added to the tree.
+//
+// Deletions are currently not supported as this is done through the tombstone flag and from the POV of the RB-tree
+// tombstone-nodes are just normal nodes that get rebalanced the normal way.
+//
+// Throughout ths file the following relationships between nodes are used:
+// GP = grandparent, P = parent, U = uncle, S = sibling, N = node that was just added
+//
+//     GP
+//   /   \
+//  U     P
+//       / \
+//      S   N
+func rebalanceRedBlackTree(node *binarySearchNode) *binarySearchNode {
+	for {
+		parent := node.parent
+
+		// if parent is black or the current node is the root node (== parent is nil) there is nothing to do
+		if !isRedNode(parent) {
+			return nil
+		}
+
+		grandparent := node.parent.parent
+		var uncle *binarySearchNode
+		if parent == grandparent.right {
+			uncle = grandparent.left
+		} else {
+			uncle = grandparent.right
+		}
+
+		if isRedNode(uncle) {
+			// if uncle is red, recoloring the tree up to the grandparent results in a valid RBtree.
+			// The color of the grandfather changes to red, so there might be more fixes needed. Therefore
+			// go up the tree and repeat.
+			recolourNodes(parent, grandparent, uncle)
+			node = grandparent
+		} else {
+			// if uncle is black, there are four possible cases:
+			//   parent is the right child grandparent:
+			//    1) node is right child of parent => left rotate around GP
+			//    2) node is left child of parent => right rotate around parent results in case 1
+			//   For cases 3 and 4 just replace left and right in the two cases above
+			//
+			// In all of these cases the grandfather stays black and there is no need for further fixes up the tree
+			var new_root *binarySearchNode
+			if parent == grandparent.right {
+				if node == parent.left {
+					rightRotate(parent)
+					// node and parent switch places in the tree, update parent to recolour the current node
+					parent = node
+				}
+				new_root = leftRotate(grandparent)
+			} else { // parent == grandparent.left
+				if node == parent.right {
+					leftRotate(parent)
+					parent = node
+				}
+				new_root = rightRotate(grandparent)
+			}
+			recolourNodes(grandparent, parent)
+			return new_root
+		}
+
+	}
+}
+
+func recolourNodes(nodes ...*binarySearchNode) {
+	for _, n := range nodes {
+		if n != nil {
+			n.colourIsred = !n.colourIsred
+		}
+	}
+}
+
+func isRedNode(n *binarySearchNode) bool {
+	return n != nil && n.colourIsred
+}
+
+// Rotate the tree left around the given node.
+//
+// After this rotation, the former right child (FC) will be the new parent and the former parent (FP) will
+// be the left node of the new parent. The left child of the former child is transferred to the former parent.
+//
+//      FP                                FC
+//   /      \         left rotate        /  \
+//  FP_R     FC          =>            FP   FC_R
+//          / \                       / \
+//       FC_L   FC_R               FP_R  FC_L
+//
+// In case FP was the root of the tree, FC will be the new root of the tree.
+func leftRotate(rotation_node *binarySearchNode) *binarySearchNode {
+	former_child := rotation_node.right
+	rootRotate := rotation_node.parent == nil
+
+	// former child node becomes new parent unless the rotation is around the root node
+	if rootRotate {
+		former_child.parent = nil
+	} else {
+		if rotation_node.parent.left == rotation_node {
+			rotation_node.parent.left = former_child
+		} else {
+			rotation_node.parent.right = former_child
+		}
+		former_child.parent = rotation_node.parent
+	}
+
+	rotation_node.parent = former_child
+
+	// Switch left child from former_child to rotation node
+	rotation_node.right = former_child.left
+	if former_child.left != nil {
+		former_child.left.parent = rotation_node
+	}
+	former_child.left = rotation_node
+
+	if rootRotate {
+		return former_child
+	} else {
+		return nil
+	}
+}
+
+// Same as leftRotate, just switch left and right everywhere
+func rightRotate(rotation_node *binarySearchNode) *binarySearchNode {
+	former_child := rotation_node.left
+	rootRotate := rotation_node.parent == nil
+
+	if rootRotate {
+		former_child.parent = nil
+	} else {
+		if rotation_node.parent.left == rotation_node {
+			rotation_node.parent.left = former_child
+		} else {
+			rotation_node.parent.right = former_child
+		}
+		former_child.parent = rotation_node.parent
+	}
+	rotation_node.parent = former_child
+
+	rotation_node.left = former_child.right
+	if former_child.right != nil {
+		former_child.right.parent = rotation_node
+	}
+	former_child.right = rotation_node
+
+	if rootRotate {
+		return former_child
+	} else {
+		return nil
+	}
+}

--- a/adapters/repos/db/lsmkv/red_black_tree_map.go
+++ b/adapters/repos/db/lsmkv/red_black_tree_map.go
@@ -1,0 +1,167 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2022 SeMI Technologies B.V. All rights reserved.
+//
+//  CONTACT: hello@semi.technology
+//
+
+package lsmkv
+
+// This is a copy of adapters/repos/db/lsmkv/red_black_tree.go for maps
+
+// This function rebalances and recolours trees to be valid RB trees. It needs to be called after each node that
+// was added to the tree.
+//
+// Deletions are currently not supported as this is done through the tombstone flag and from the POV of the RB-tree
+// tombstone-nodes are just normal nodes that get rebalanced the normal way.
+//
+// Throughout ths file the following relationships between nodes are used:
+// GP = grandparent, P = parent, U = uncle, S = sibling, N = node that was just added
+//
+//     GP
+//   /   \
+//  U     P
+//       / \
+//      S   N
+func rebalanceRedBlackTreeMap(node *binarySearchNodeMap) *binarySearchNodeMap {
+	for {
+		parent := node.parent
+
+		// if parent is black or the current node is the root node (== parent is nil) there is nothing to do
+		if !isRedNodeMap(parent) {
+			return nil
+		}
+
+		grandparent := node.parent.parent
+		var uncle *binarySearchNodeMap
+		if parent == grandparent.right {
+			uncle = grandparent.left
+		} else {
+			uncle = grandparent.right
+		}
+
+		if isRedNodeMap(uncle) {
+			// if uncle is red, recoloring the tree up to the grandparent results in a valid RBtree.
+			// The color of the grandfather changes to red, so there might be more fixes needed. Therefore
+			// go up the tree and repeat.
+			recolourNodesMap(parent, grandparent, uncle)
+			node = grandparent
+		} else {
+			// if uncle is black, there are four possible cases:
+			//   parent is the right child grandparent:
+			//    1) node is right child of parent => left rotate around GP
+			//    2) node is left child of parent => right rotate around parent results in case 1
+			//   For cases 3 and 4 just replace left and right in the two cases above
+			//
+			// In all of these cases the grandfather stays black and there is no need for further fixes up the tree
+			var new_root *binarySearchNodeMap
+			if parent == grandparent.right {
+				if node == parent.left {
+					rightRotateMap(parent)
+					// node and parent switch places in the tree, update parent to recolour the current node
+					parent = node
+				}
+				new_root = leftRotateMap(grandparent)
+			} else { // parent == grandparent.left
+				if node == parent.right {
+					leftRotateMap(parent)
+					parent = node
+				}
+				new_root = rightRotateMap(grandparent)
+			}
+			recolourNodesMap(grandparent, parent)
+			return new_root
+		}
+
+	}
+}
+
+func recolourNodesMap(nodes ...*binarySearchNodeMap) {
+	for _, n := range nodes {
+		if n != nil {
+			n.colourIsred = !n.colourIsred
+		}
+	}
+}
+
+func isRedNodeMap(n *binarySearchNodeMap) bool {
+	return n != nil && n.colourIsred
+}
+
+// Rotate the tree left around the given node.
+//
+// After this rotation, the former right child (FC) will be the new parent and the former parent (FP) will
+// be the left node of the new parent. The left child of the former child is transferred to the former parent.
+//
+//      FP                                FC
+//   /      \         left rotate        /  \
+//  FP_R     FC          =>            FP   FC_R
+//          / \                       / \
+//       FC_L   FC_R               FP_R  FC_L
+//
+// In case FP was the root of the tree, FC will be the new root of the tree.
+func leftRotateMap(rotation_node *binarySearchNodeMap) *binarySearchNodeMap {
+	former_child := rotation_node.right
+	rootRotate := rotation_node.parent == nil
+
+	// former child node becomes new parent unless the rotation is around the root node
+	if rootRotate {
+		former_child.parent = nil
+	} else {
+		if rotation_node.parent.left == rotation_node {
+			rotation_node.parent.left = former_child
+		} else {
+			rotation_node.parent.right = former_child
+		}
+		former_child.parent = rotation_node.parent
+	}
+
+	rotation_node.parent = former_child
+
+	// Switch left child from former_child to rotation node
+	rotation_node.right = former_child.left
+	if former_child.left != nil {
+		former_child.left.parent = rotation_node
+	}
+	former_child.left = rotation_node
+
+	if rootRotate {
+		return former_child
+	} else {
+		return nil
+	}
+}
+
+// Same as leftRotate, just switch left and right everywhere
+func rightRotateMap(rotation_node *binarySearchNodeMap) *binarySearchNodeMap {
+	former_child := rotation_node.left
+	rootRotate := rotation_node.parent == nil
+
+	if rootRotate {
+		former_child.parent = nil
+	} else {
+		if rotation_node.parent.left == rotation_node {
+			rotation_node.parent.left = former_child
+		} else {
+			rotation_node.parent.right = former_child
+		}
+		former_child.parent = rotation_node.parent
+	}
+	rotation_node.parent = former_child
+
+	rotation_node.left = former_child.right
+	if former_child.right != nil {
+		former_child.right.parent = rotation_node
+	}
+	former_child.right = rotation_node
+
+	if rootRotate {
+		return former_child
+	} else {
+		return nil
+	}
+}

--- a/adapters/repos/db/lsmkv/red_black_tree_map_test.go
+++ b/adapters/repos/db/lsmkv/red_black_tree_map_test.go
@@ -1,0 +1,150 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2022 SeMI Technologies B.V. All rights reserved.
+//
+//  CONTACT: hello@semi.technology
+//
+
+package lsmkv
+
+// THis file is a copy of adapters/repos/db/lsmkv/red_black_tree_test.go and reuses parts of it.
+
+import (
+	"fmt"
+	"math"
+	"math/rand"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// This test adds keys to the RB tree. Afterwards the same nodes are added in the expected order, eg in the way
+// the RB tree is expected to re-order the nodes
+func TestRbTreesMap(t *testing.T) {
+	for _, tt := range rbTests {
+		t.Run(tt.name, func(t *testing.T) {
+			tree := &binarySearchTreeMap{}
+			for _, key := range tt.keys {
+				iByte := []byte{uint8(key)}
+				tree.insert(iByte, MapPair{
+					Key:   []byte("map-key-1"),
+					Value: []byte("map-value-1"),
+				})
+				require.Empty(t, tree.root.parent)
+			}
+			ValidateRBTreeMap(t, tree)
+
+			flatten_tree := tree.flattenInOrder()
+			require.Equal(t, len(tt.keys), len(flatten_tree)) // no entries got lost
+
+			// add tree with the same nodes in the "optimal" order to be able to compare their order afterwards
+			treeCorrectOrder := &binarySearchTreeMap{}
+			for _, key := range tt.ReorderedKeys {
+				iByte := []byte{uint8(key)}
+				treeCorrectOrder.insert(iByte, MapPair{
+					Key:   []byte("map-key-1"),
+					Value: []byte("map-value-1"),
+				})
+			}
+
+			flatten_tree_input := treeCorrectOrder.flattenInOrder()
+			for i := range flatten_tree {
+				byte_key := flatten_tree[i].key
+				originalIndex := getIndexInSlice(tt.keys, byte_key)
+				require.Equal(t, byte_key, flatten_tree_input[i].key)
+				require.Equal(t, flatten_tree[i].colourIsred, tt.expectedColors[originalIndex])
+			}
+		})
+	}
+}
+
+func TestRandomTreesMap(t *testing.T) {
+	setSeed(t)
+	tree := &binarySearchTreeMap{}
+	amount := rand.Intn(100000)
+	keySize := rand.Intn(100)
+	uniqueKeys := make(map[string]void)
+	for i := 0; i < amount; i++ {
+		key := make([]byte, keySize)
+		rand.Read(key)
+		uniqueKeys[fmt.Sprint(key)] = member
+		tree.insert(key, MapPair{
+			Key:   []byte("map-key-1"),
+			Value: []byte("map-value-1"),
+		})
+	}
+
+	// all added keys are still part of the tree
+	treeFlattened := tree.flattenInOrder()
+	require.Equal(t, len(uniqueKeys), len(treeFlattened))
+	for _, entry := range treeFlattened {
+		_, ok := uniqueKeys[fmt.Sprint(entry.key)]
+		require.True(t, ok)
+	}
+	ValidateRBTreeMap(t, tree)
+}
+
+// Checks if a tree is a RB tree
+//
+// There are several properties that valid RB trees follow:
+// 1) The root node is always black
+// 2) The max depth of a tree is 2* Log2(N+1), where N is the number of nodes
+// 3) Every path from root to leave has the same number of _black_ nodes
+// 4) Red nodes only have black (or nil) children
+//
+// In addition this also validates some general tree properties:
+//  - root has no parent
+//  - if node A is a child of B, B must be the parent of A)
+func ValidateRBTreeMap(t *testing.T, tree *binarySearchTreeMap) {
+	require.False(t, tree.root.colourIsred)
+	require.True(t, tree.root.parent == nil)
+
+	treeDepth, nodeCount, _ := WalkTreeMap(t, tree.root)
+	maxDepth := 2 * math.Log2(float64(nodeCount)+1)
+	require.True(t, treeDepth <= int(maxDepth))
+}
+
+// Walks through the tree and counts the depth, number of nodes and number of black nodes
+func WalkTreeMap(t *testing.T, node *binarySearchNodeMap) (int, int, int) {
+	if node == nil {
+		return 0, 0, 0
+	}
+
+	// validate parent/child connections
+	if node.right != nil {
+		require.Equal(t, node.right.parent, node)
+	}
+	if node.left != nil {
+		require.Equal(t, node.left.parent, node)
+	}
+
+	// red nodes need black (or nil) children
+	if node.colourIsred {
+		require.True(t, node.left == nil || !node.left.colourIsred)
+		require.True(t, node.right == nil || !node.right.colourIsred)
+	}
+
+	blackNode := int(1)
+	if node.colourIsred {
+		blackNode = 0
+	}
+
+	if node.right == nil && node.left == nil {
+		return 1, 1, blackNode
+	}
+
+	depthRight, nodeCountRight, blackNodesDepthRight := WalkTreeMap(t, node.right)
+	depthLeft, nodeCountLeft, blackNodesDepthLeft := WalkTreeMap(t, node.left)
+	require.Equal(t, blackNodesDepthRight, blackNodesDepthLeft)
+
+	nodeCount := nodeCountLeft + nodeCountRight + 1
+	if depthRight > depthLeft {
+		return depthRight + 1, nodeCount, blackNodesDepthRight + blackNode
+	} else {
+		return depthLeft + 1, nodeCount, blackNodesDepthRight + blackNode
+	}
+}

--- a/adapters/repos/db/lsmkv/red_black_tree_multi.go
+++ b/adapters/repos/db/lsmkv/red_black_tree_multi.go
@@ -1,0 +1,166 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2022 SeMI Technologies B.V. All rights reserved.
+//
+//  CONTACT: hello@semi.technology
+//
+
+package lsmkv
+
+// This is a copy of adapters/repos/db/lsmkv/red_black_tree.go for maps
+
+// This function rebalances and recolours trees to be valid RB trees. It needs to be called after each node that
+// was added to the tree.
+//
+// Deletions are currently not supported as this is done through the tombstone flag and from the POV of the RB-tree
+// tombstone-nodes are just normal nodes that get rebalanced the normal way.
+//
+// Throughout ths file the following relationships between nodes are used:
+// GP = grandparent, P = parent, U = uncle, S = sibling, N = node that was just added
+//
+//     GP
+//   /   \
+//  U     P
+//       / \
+//      S   N
+func rebalanceRedBlackTreeMulti(node *binarySearchNodeMulti) *binarySearchNodeMulti {
+	for {
+		parent := node.parent
+
+		// if parent is black or the current node is the root node (== parent is nil) there is nothing to do
+		if !isRedNodeMulti(parent) {
+			return nil
+		}
+
+		grandparent := node.parent.parent
+		var uncle *binarySearchNodeMulti
+		if parent == grandparent.right {
+			uncle = grandparent.left
+		} else {
+			uncle = grandparent.right
+		}
+
+		if isRedNodeMulti(uncle) {
+			// if uncle is red, recoloring the tree up to the grandparent results in a valid RBtree.
+			// The color of the grandfather changes to red, so there might be more fixes needed. Therefore
+			// go up the tree and repeat.
+			recolourNodesMulti(parent, grandparent, uncle)
+			node = grandparent
+		} else {
+			// if uncle is black, there are four possible cases:
+			//   parent is the right child grandparent:
+			//    1) node is right child of parent => left rotate around GP
+			//    2) node is left child of parent => right rotate around parent results in case 1
+			//   For cases 3 and 4 just replace left and right in the two cases above
+			//
+			// In all of these cases the grandfather stays black and there is no need for further fixes up the tree
+			var new_root *binarySearchNodeMulti
+			if parent == grandparent.right {
+				if node == parent.left {
+					rightRotateMulti(parent)
+					// node and parent switch places in the tree, update parent to recolour the current node
+					parent = node
+				}
+				new_root = leftRotateMulti(grandparent)
+			} else { // parent == grandparent.left
+				if node == parent.right {
+					leftRotateMulti(parent)
+					parent = node
+				}
+				new_root = rightRotateMulti(grandparent)
+			}
+			recolourNodesMulti(grandparent, parent)
+			return new_root
+		}
+	}
+}
+
+func recolourNodesMulti(nodes ...*binarySearchNodeMulti) {
+	for _, n := range nodes {
+		if n != nil {
+			n.colourIsred = !n.colourIsred
+		}
+	}
+}
+
+func isRedNodeMulti(n *binarySearchNodeMulti) bool {
+	return n != nil && n.colourIsred
+}
+
+// Rotate the tree left around the given node.
+//
+// After this rotation, the former right child (FC) will be the new parent and the former parent (FP) will
+// be the left node of the new parent. The left child of the former child is transferred to the former parent.
+//
+//      FP                                FC
+//   /      \         left rotate        /  \
+//  FP_R     FC          =>            FP   FC_R
+//          / \                       / \
+//       FC_L   FC_R               FP_R  FC_L
+//
+// In case FP was the root of the tree, FC will be the new root of the tree.
+func leftRotateMulti(rotation_node *binarySearchNodeMulti) *binarySearchNodeMulti {
+	former_child := rotation_node.right
+	rootRotate := rotation_node.parent == nil
+
+	// former child node becomes new parent unless the rotation is around the root node
+	if rootRotate {
+		former_child.parent = nil
+	} else {
+		if rotation_node.parent.left == rotation_node {
+			rotation_node.parent.left = former_child
+		} else {
+			rotation_node.parent.right = former_child
+		}
+		former_child.parent = rotation_node.parent
+	}
+
+	rotation_node.parent = former_child
+
+	// Switch left child from former_child to rotation node
+	rotation_node.right = former_child.left
+	if former_child.left != nil {
+		former_child.left.parent = rotation_node
+	}
+	former_child.left = rotation_node
+
+	if rootRotate {
+		return former_child
+	} else {
+		return nil
+	}
+}
+
+// Same as leftRotate, just switch left and right everywhere
+func rightRotateMulti(rotation_node *binarySearchNodeMulti) *binarySearchNodeMulti {
+	former_child := rotation_node.left
+	rootRotate := rotation_node.parent == nil
+
+	if rootRotate {
+		former_child.parent = nil
+	} else {
+		if rotation_node.parent.left == rotation_node {
+			rotation_node.parent.left = former_child
+		} else {
+			rotation_node.parent.right = former_child
+		}
+		former_child.parent = rotation_node.parent
+	}
+	rotation_node.parent = former_child
+
+	rotation_node.left = former_child.right
+	if former_child.right != nil {
+		former_child.right.parent = rotation_node
+	}
+	former_child.right = rotation_node
+
+	if rootRotate {
+		return former_child
+	} else {
+		return nil
+	}
+}

--- a/adapters/repos/db/lsmkv/red_black_tree_multi_test.go
+++ b/adapters/repos/db/lsmkv/red_black_tree_multi_test.go
@@ -1,0 +1,155 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2022 SeMI Technologies B.V. All rights reserved.
+//
+//  CONTACT: hello@semi.technology
+//
+
+package lsmkv
+
+// THis file is a copy of adapters/repos/db/lsmkv/red_black_tree_test.go and reuses parts of it.
+
+import (
+	"fmt"
+	"math"
+	"math/rand"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// This test adds keys to the RB tree. Afterwards the same nodes are added in the expected order, eg in the way
+// the RB tree is expected to re-order the nodes
+func TestRbTreesMulti(t *testing.T) {
+	for _, tt := range rbTests {
+		t.Run(tt.name, func(t *testing.T) {
+			tree := &binarySearchTreeMulti{}
+			for _, key := range tt.keys {
+				iByte := []byte{uint8(key)}
+				values := []value{}
+				for j := uint(0); j < 5; j++ {
+					values = append(values, value{value: []byte{uint8(key * j)}, tombstone: false})
+				}
+				tree.insert(iByte, values)
+				require.Empty(t, tree.root.parent)
+			}
+			ValidateRBTreeMulti(t, tree)
+
+			flatten_tree := tree.flattenInOrder()
+			require.Equal(t, len(tt.keys), len(flatten_tree)) // no entries got lost
+
+			// add tree with the same nodes in the "optimal" order to be able to compare their order afterwards
+			treeCorrectOrder := &binarySearchTreeMulti{}
+			for _, key := range tt.ReorderedKeys {
+				iByte := []byte{uint8(key)}
+				values := []value{}
+				for j := uint(0); j < 5; j++ {
+					values = append(values, value{value: []byte{uint8(key * j)}, tombstone: false})
+				}
+
+				treeCorrectOrder.insert(iByte, values)
+			}
+
+			flatten_tree_input := treeCorrectOrder.flattenInOrder()
+			for i := range flatten_tree {
+				byte_key := flatten_tree[i].key
+				originalIndex := getIndexInSlice(tt.keys, byte_key)
+				require.Equal(t, byte_key, flatten_tree_input[i].key)
+				require.Equal(t, flatten_tree[i].colourIsred, tt.expectedColors[originalIndex])
+			}
+		})
+	}
+}
+
+func TestRandomTreesMulti(t *testing.T) {
+	setSeed(t)
+	tree := &binarySearchTreeMulti{}
+	amount := rand.Intn(100000)
+	keySize := rand.Intn(100)
+	uniqueKeys := make(map[string]void)
+	for i := 0; i < amount; i++ {
+		key := make([]byte, keySize)
+		rand.Read(key)
+		uniqueKeys[fmt.Sprint(key)] = member
+		values := []value{}
+		for j := 0; j < 5; j++ {
+			values = append(values, value{value: []byte{uint8(i * j)}, tombstone: false})
+		}
+
+		tree.insert(key, values)
+	}
+
+	// all added keys are still part of the tree
+	treeFlattened := tree.flattenInOrder()
+	require.Equal(t, len(uniqueKeys), len(treeFlattened))
+	for _, entry := range treeFlattened {
+		_, ok := uniqueKeys[fmt.Sprint(entry.key)]
+		require.True(t, ok)
+	}
+	ValidateRBTreeMulti(t, tree)
+}
+
+// Checks if a tree is a RB tree
+//
+// There are several properties that valid RB trees follow:
+// 1) The root node is always black
+// 2) The max depth of a tree is 2* Log2(N+1), where N is the number of nodes
+// 3) Every path from root to leave has the same number of _black_ nodes
+// 4) Red nodes only have black (or nil) children
+//
+// In addition this also validates some general tree properties:
+//  - root has no parent
+//  - if node A is a child of B, B must be the parent of A)
+func ValidateRBTreeMulti(t *testing.T, tree *binarySearchTreeMulti) {
+	require.False(t, tree.root.colourIsred)
+	require.True(t, tree.root.parent == nil)
+
+	treeDepth, nodeCount, _ := WalkTreeMulti(t, tree.root)
+	maxDepth := 2 * math.Log2(float64(nodeCount)+1)
+	require.True(t, treeDepth <= int(maxDepth))
+}
+
+// Walks through the tree and counts the depth, number of nodes and number of black nodes
+func WalkTreeMulti(t *testing.T, node *binarySearchNodeMulti) (int, int, int) {
+	if node == nil {
+		return 0, 0, 0
+	}
+
+	// validate parent/child connections
+	if node.right != nil {
+		require.Equal(t, node.right.parent, node)
+	}
+	if node.left != nil {
+		require.Equal(t, node.left.parent, node)
+	}
+
+	// red nodes need black (or nil) children
+	if node.colourIsred {
+		require.True(t, node.left == nil || !node.left.colourIsred)
+		require.True(t, node.right == nil || !node.right.colourIsred)
+	}
+
+	blackNode := int(1)
+	if node.colourIsred {
+		blackNode = 0
+	}
+
+	if node.right == nil && node.left == nil {
+		return 1, 1, blackNode
+	}
+
+	depthRight, nodeCountRight, blackNodesDepthRight := WalkTreeMulti(t, node.right)
+	depthLeft, nodeCountLeft, blackNodesDepthLeft := WalkTreeMulti(t, node.left)
+	require.Equal(t, blackNodesDepthRight, blackNodesDepthLeft)
+
+	nodeCount := nodeCountLeft + nodeCountRight + 1
+	if depthRight > depthLeft {
+		return depthRight + 1, nodeCount, blackNodesDepthRight + blackNode
+	} else {
+		return depthLeft + 1, nodeCount, blackNodesDepthRight + blackNode
+	}
+}

--- a/adapters/repos/db/lsmkv/red_black_tree_test.go
+++ b/adapters/repos/db/lsmkv/red_black_tree_test.go
@@ -131,6 +131,55 @@ func TestRbTrees(t *testing.T) {
 	}
 }
 
+// add keys as a) normal keys b) tombstone keys and c) half tombstone, half normal.
+// The resulting trees must have the same order and colors
+var tombstoneTests = []struct {
+	name string
+	keys []uint
+}{
+	{"Rotate left around root", []uint{61, 83, 99}},
+	{"Rotate right around root", []uint{61, 30, 10}},
+	{"Multiple rotations along the tree and colour changes", []uint{166, 92, 33, 133, 227, 236, 71, 183, 18, 139, 245, 161}},
+	{"Ordered nodes increasing",[]uint{1, 2, 3, 4, 5, 6, 7, 8}},
+	{"Ordered nodes decreasing", []uint{8, 7, 6, 5, 4, 3, 2, 1}}}
+
+func TestTombstones(t *testing.T) {
+	for _, tt := range tombstoneTests {
+		t.Run(tt.name, func(t *testing.T) {
+			treeNormal := &binarySearchTree{}
+			treeTombstone := &binarySearchTree{}
+			treeHalfHalf := &binarySearchTree{}
+			for i, key := range tt.keys {
+				iByte := []byte{uint8(key)}
+				treeNormal.insert(iByte, iByte, nil)
+				treeTombstone.setTombstone(iByte, nil)
+				if i%2 == 0 {
+					treeHalfHalf.insert(iByte, iByte, nil)
+				} else {
+					treeHalfHalf.setTombstone(iByte, nil)
+				}
+			}
+			require.True(t, ValidateRBTree(t, treeNormal))
+			require.True(t, ValidateRBTree(t, treeTombstone))
+			require.True(t, ValidateRBTree(t, treeHalfHalf))
+
+			treeNormalFlatten := treeNormal.flattenInOrder()
+			treeTombstoneFlatten := treeTombstone.flattenInOrder()
+			treeHalfHalfFlatten := treeHalfHalf.flattenInOrder()
+			require.Equal(t, len(tt.keys), len(treeNormalFlatten))
+			require.Equal(t, len(tt.keys), len(treeTombstoneFlatten))
+			require.Equal(t, len(tt.keys), len(treeHalfHalfFlatten))
+
+			for i := range treeNormalFlatten {
+				require.Equal(t, treeNormalFlatten[i].key, treeTombstoneFlatten[i].key)
+				require.Equal(t, treeNormalFlatten[i].key, treeHalfHalfFlatten[i].key)
+				require.Equal(t, treeNormalFlatten[i].colourIsred, treeTombstoneFlatten[i].colourIsred)
+				require.Equal(t, treeNormalFlatten[i].colourIsred, treeHalfHalfFlatten[i].colourIsred)
+			}
+		})
+	}
+}
+
 func getIndexInSlice(reorderedKeys []uint, key []byte) int {
 	for i, v := range reorderedKeys {
 		if v == uint(key[0]) {

--- a/adapters/repos/db/lsmkv/red_black_tree_test.go
+++ b/adapters/repos/db/lsmkv/red_black_tree_test.go
@@ -1,0 +1,180 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2022 SeMI Technologies B.V. All rights reserved.
+//
+//  CONTACT: hello@semi.technology
+//
+
+package lsmkv
+
+import (
+	"math"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+const (
+	R = true
+	B = false
+)
+
+// This test adds keys to the RB tree. Afterwards the same nodes are added in the expected order, eg in the way
+// the RB tree is expected to re-order the nodes
+var rbTests = []struct {
+	name           string
+	keys           []uint
+	ReorderedKeys  []uint
+	expectedColors []bool // with respect to the original keys
+}{
+	{
+		"Requires recoloring but no reordering",
+		[]uint{61, 52, 83, 93},
+		[]uint{61, 52, 83, 93},
+		[]bool{B, B, B, R},
+	},
+	{
+		"Requires left rotate around root",
+		[]uint{61, 83, 99},
+		[]uint{83, 61, 99},
+		[]bool{R, B, R},
+	},
+	{
+		"Requires left rotate with more nodes",
+		[]uint{61, 52, 85, 93, 99},
+		[]uint{61, 52, 93, 85, 99},
+		[]bool{B, B, R, B, R},
+	},
+	{
+		"Requires right and then left rotate",
+		[]uint{61, 52, 85, 93, 87},
+		[]uint{61, 52, 87, 85, 93},
+		[]bool{B, B, R, R, B},
+	},
+	{
+		"Requires right rotate around root",
+		[]uint{61, 30, 10},
+		[]uint{30, 10, 61},
+		[]bool{R, B, R},
+	},
+	{
+		"Requires right rotate with more nodes",
+		[]uint{61, 52, 85, 21, 10},
+		[]uint{61, 85, 21, 10, 52},
+		[]bool{B, R, B, B, R},
+	},
+	{
+		"Requires left and then right rotate",
+		[]uint{61, 52, 85, 21, 36},
+		[]uint{61, 85, 36, 21, 52},
+		[]bool{B, R, B, R, B},
+	},
+	{
+		"Require reordering for two nodes",
+		[]uint{61, 52, 40, 85, 105, 110},
+		[]uint{52, 40, 85, 61, 105, 110},
+		[]bool{B, B, B, R, B, R},
+	},
+	{
+		"Ordered nodes increasing",
+		[]uint{1, 2, 3, 4, 5, 6, 7, 8},
+		[]uint{4, 2, 6, 1, 3, 5, 7, 8},
+		[]bool{B, R, B, B, B, R, B, R},
+	},
+	{
+		"Ordered nodes decreasing",
+		[]uint{8, 7, 6, 5, 4, 3, 2, 1},
+		[]uint{5, 3, 7, 2, 4, 6, 8, 1},
+		[]bool{B, R, B, B, B, R, B, R},
+	},
+	{
+		"Multiple rotations along the tree and colour changes",
+		[]uint{166, 92, 33, 133, 227, 236, 71, 183, 18, 139, 245, 161},
+		[]uint{166, 92, 227, 33, 139, 183, 236, 18, 71, 133, 161, 245},
+		[]bool{B, R, B, R, R, B, R, B, R, B, R, R},
+	},
+}
+
+func TestRbTrees(t *testing.T) {
+	for _, tt := range rbTests {
+		t.Run(tt.name, func(t *testing.T) {
+			tree := &binarySearchTree{}
+			for _, key := range tt.keys {
+				iByte := []byte{uint8(key)}
+				tree.insert(iByte, iByte, nil)
+				require.Empty(t, tree.root.parent)
+				require.True(t, ValidateRBTree(t, tree))
+			}
+
+			flatten_tree := tree.flattenInOrder()
+			require.Equal(t, len(tt.keys), len(flatten_tree)) // no entries got lost
+
+			// add tree with the same nodes in the "optimal" order to be able to compare their order afterwards
+			treeCorrectOrder := &binarySearchTree{}
+			for _, key := range tt.ReorderedKeys {
+				iByte := []byte{uint8(key)}
+				treeCorrectOrder.insert(iByte, iByte, nil)
+			}
+
+			flatten_tree_input := treeCorrectOrder.flattenInOrder()
+			for i := range flatten_tree {
+				byte_key := flatten_tree[i].key
+				originalIndex := getIndexInSlice(tt.keys, byte_key)
+				require.Equal(t, byte_key, flatten_tree_input[i].key)
+				require.Equal(t, flatten_tree[i].colourIsred, tt.expectedColors[originalIndex])
+			}
+		})
+	}
+}
+
+func getIndexInSlice(reorderedKeys []uint, key []byte) int {
+	for i, v := range reorderedKeys {
+		if v == uint(key[0]) {
+			return i
+		}
+	}
+	return -1
+}
+
+// Checks if a tree could be an RB tree
+func ValidateRBTree(t *testing.T, tree *binarySearchTree) bool {
+	if tree.root.colourIsred {
+		return false
+	}
+
+	treeDepth, nodeCount := MaxTreeDepthAndNodeCount(t, tree.root)
+	maxDepth := 2 * math.Log2(float64(nodeCount)+1)
+	return treeDepth <= int(maxDepth)
+}
+
+func MaxTreeDepthAndNodeCount(t *testing.T, node *binarySearchNode) (int, int) {
+	if node == nil {
+		return 0, 0
+	}
+
+	// validate parent/child connections
+	if node.right != nil {
+		require.Equal(t, node.right.parent, node)
+	}
+	if node.left != nil {
+		require.Equal(t, node.left.parent, node)
+	}
+
+	if node.right == nil && node.left == nil {
+		return 1, 1
+	}
+
+	depthRight, nodeCountRight := MaxTreeDepthAndNodeCount(t, node.right)
+	depthLeft, nodeCountLeft := MaxTreeDepthAndNodeCount(t, node.left)
+
+	nodeCount := nodeCountLeft + nodeCountRight + 1
+	if depthRight > depthLeft {
+		return depthRight + 1, nodeCount
+	} else {
+		return depthLeft + 1, nodeCount
+	}
+}

--- a/adapters/repos/db/lsmkv/red_black_tree_test.go
+++ b/adapters/repos/db/lsmkv/red_black_tree_test.go
@@ -12,7 +12,9 @@
 package lsmkv
 
 import (
+	"fmt"
 	"math"
+	"math/rand"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -107,8 +109,8 @@ func TestRbTrees(t *testing.T) {
 				iByte := []byte{uint8(key)}
 				tree.insert(iByte, iByte, nil)
 				require.Empty(t, tree.root.parent)
-				require.True(t, ValidateRBTree(t, tree))
 			}
+			ValidateRBTree(t, tree)
 
 			flatten_tree := tree.flattenInOrder()
 			require.Equal(t, len(tt.keys), len(flatten_tree)) // no entries got lost
@@ -132,7 +134,7 @@ func TestRbTrees(t *testing.T) {
 }
 
 // add keys as a) normal keys b) tombstone keys and c) half tombstone, half normal.
-// The resulting trees must have the same order and colors
+// The resulting (reblalanced) trees must have the same order and colors
 var tombstoneTests = []struct {
 	name string
 	keys []uint
@@ -140,8 +142,9 @@ var tombstoneTests = []struct {
 	{"Rotate left around root", []uint{61, 83, 99}},
 	{"Rotate right around root", []uint{61, 30, 10}},
 	{"Multiple rotations along the tree and colour changes", []uint{166, 92, 33, 133, 227, 236, 71, 183, 18, 139, 245, 161}},
-	{"Ordered nodes increasing",[]uint{1, 2, 3, 4, 5, 6, 7, 8}},
-	{"Ordered nodes decreasing", []uint{8, 7, 6, 5, 4, 3, 2, 1}}}
+	{"Ordered nodes increasing", []uint{1, 2, 3, 4, 5, 6, 7, 8}},
+	{"Ordered nodes decreasing", []uint{8, 7, 6, 5, 4, 3, 2, 1}},
+}
 
 func TestTombstones(t *testing.T) {
 	for _, tt := range tombstoneTests {
@@ -159,9 +162,9 @@ func TestTombstones(t *testing.T) {
 					treeHalfHalf.setTombstone(iByte, nil)
 				}
 			}
-			require.True(t, ValidateRBTree(t, treeNormal))
-			require.True(t, ValidateRBTree(t, treeTombstone))
-			require.True(t, ValidateRBTree(t, treeHalfHalf))
+			ValidateRBTree(t, treeNormal)
+			ValidateRBTree(t, treeTombstone)
+			ValidateRBTree(t, treeHalfHalf)
 
 			treeNormalFlatten := treeNormal.flattenInOrder()
 			treeTombstoneFlatten := treeTombstone.flattenInOrder()
@@ -180,6 +183,37 @@ func TestTombstones(t *testing.T) {
 	}
 }
 
+type void struct{}
+
+var member void
+
+func TestRandomTrees(t *testing.T) {
+	setSeed(t)
+	tree := &binarySearchTree{}
+	amount := rand.Intn(100000)
+	keySize := rand.Intn(100)
+	uniqueKeys := make(map[string]void)
+	for i := 0; i < amount; i++ {
+		key := make([]byte, keySize)
+		rand.Read(key)
+		uniqueKeys[fmt.Sprint(key)] = member
+		if rand.Intn(5) == 1 { // add 20% of all entries as tombstone
+			tree.setTombstone(key, nil)
+		} else {
+			tree.insert(key, key, nil)
+		}
+	}
+
+	// all added keys are still part of the tree
+	treeFlattened := tree.flattenInOrder()
+	require.Equal(t, len(uniqueKeys), len(treeFlattened))
+	for _, entry := range treeFlattened {
+		_, ok := uniqueKeys[fmt.Sprint(entry.key)]
+		require.True(t, ok)
+	}
+	ValidateRBTree(t, tree)
+}
+
 func getIndexInSlice(reorderedKeys []uint, key []byte) int {
 	for i, v := range reorderedKeys {
 		if v == uint(key[0]) {
@@ -189,20 +223,30 @@ func getIndexInSlice(reorderedKeys []uint, key []byte) int {
 	return -1
 }
 
-// Checks if a tree could be an RB tree
-func ValidateRBTree(t *testing.T, tree *binarySearchTree) bool {
-	if tree.root.colourIsred {
-		return false
-	}
+// Checks if a tree is a RB tree
+//
+// There are several properties that valid RB trees follow:
+// 1) The root node is always black
+// 2) The max depth of a tree is 2* Log2(N+1), where N is the number of nodes
+// 3) Every path from root to leave has the same number of _black_ nodes
+// 4) Red nodes only have black (or nil) children
+//
+// In addition this also validates some general tree properties:
+//  - root has no parent
+//  - if node A is a child of B, B must be the parent of A)
+func ValidateRBTree(t *testing.T, tree *binarySearchTree) {
+	require.False(t, tree.root.colourIsred)
+	require.True(t, tree.root.parent == nil)
 
-	treeDepth, nodeCount := MaxTreeDepthAndNodeCount(t, tree.root)
+	treeDepth, nodeCount, _ := WalkTree(t, tree.root)
 	maxDepth := 2 * math.Log2(float64(nodeCount)+1)
-	return treeDepth <= int(maxDepth)
+	require.True(t, treeDepth <= int(maxDepth))
 }
 
-func MaxTreeDepthAndNodeCount(t *testing.T, node *binarySearchNode) (int, int) {
+// Walks through the tree and counts the depth, number of nodes and number of black nodes
+func WalkTree(t *testing.T, node *binarySearchNode) (int, int, int) {
 	if node == nil {
-		return 0, 0
+		return 0, 0, 0
 	}
 
 	// validate parent/child connections
@@ -213,17 +257,29 @@ func MaxTreeDepthAndNodeCount(t *testing.T, node *binarySearchNode) (int, int) {
 		require.Equal(t, node.left.parent, node)
 	}
 
-	if node.right == nil && node.left == nil {
-		return 1, 1
+	// red nodes need black (or nil) children
+	if node.colourIsred {
+		require.True(t, node.left == nil || !node.left.colourIsred)
+		require.True(t, node.right == nil || !node.right.colourIsred)
 	}
 
-	depthRight, nodeCountRight := MaxTreeDepthAndNodeCount(t, node.right)
-	depthLeft, nodeCountLeft := MaxTreeDepthAndNodeCount(t, node.left)
+	blackNode := int(1)
+	if node.colourIsred {
+		blackNode = 0
+	}
+
+	if node.right == nil && node.left == nil {
+		return 1, 1, blackNode
+	}
+
+	depthRight, nodeCountRight, blackNodesDepthRight := WalkTree(t, node.right)
+	depthLeft, nodeCountLeft, blackNodesDepthLeft := WalkTree(t, node.left)
+	require.Equal(t, blackNodesDepthRight, blackNodesDepthLeft)
 
 	nodeCount := nodeCountLeft + nodeCountRight + 1
 	if depthRight > depthLeft {
-		return depthRight + 1, nodeCount
+		return depthRight + 1, nodeCount, blackNodesDepthRight + blackNode
 	} else {
-		return depthLeft + 1, nodeCount
+		return depthLeft + 1, nodeCount, blackNodesDepthRight + blackNode
 	}
 }


### PR DESCRIPTION
Closes https://github.com/semi-technologies/weaviate/issues/2032

This PR adds RB-tree rebalancing to the binary search trees that are part of the LSM. 

This should make no difference to any other users of the BSTs as the interface remains unchanged.

In my preliminary tests of RB-tree vs binary tree, sequential data is ~20 times and random data is ~10% faster. [The script from the issue](https://gist.github.com/etiennedi/d9fff98f267c55b4d3397c785b7ec803) with a full weaviate instance running is factor ~3 faster.

---

There are tests for all important cases and in addition tests that create a large tree from random input and then validate that the tree is correct. I ran this random-test a couple of thousand times without any errors. It quickly finds any bugs that I add by hand (eg switching out any assignments etc).

To make the review easier, please check out this visualization: https://www.cs.usfca.edu/~galles/visualization/RedBlack.html
