### PR TITLE
Improve benchmark tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -108,9 +108,6 @@ coverage*.txt
 # go mod
 vendor/
 
-# benchmark results
 test/benchmark/benchmark_results.json
 # benchmark results files copied from a remote run
 benchmark_results_*.json
-
-

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,8 @@
 addons:
   hosts:
-    - db  
+    - db
+git:
+  lfs_skip_smudge: true
 before_install: 
   # install a newer docker version which supports buildx
   - sudo rm -rf /var/lib/apt/lists/*
@@ -76,7 +78,7 @@ jobs:
   - name: "Unit and integration tests"
     stage: test
     script: 
-    - ./test/run.sh --unit_and_integration_tests || travis_terminate 1
+    - ./test/run.sh --unit-and-integration-only || travis_terminate 1
     - |
       if [ "$TRAVIS_PULL_REQUEST" != "false" ]; then
           # send to codecov.io
@@ -87,14 +89,14 @@ jobs:
           bash <(curl -s https://codecov.io/bash) -F integration
           rm -f coverage.txt
       fi
-  - name: "Acceptance tests (requiring docker to run)"
+  - name: "Acceptance and benchmark tests (requiring docker to run)"
     stage: test
     script: 
-    - ./test/run.sh --acceptance_tests || travis_terminate 1
-  - name: "Acceptance tests for modules (requiring docker to run)"
+    - ./test/run.sh --acceptance-only || travis_terminate 1
+  - name: "Acceptance tests for modules"
     stage: test
     script: 
-    - ./test/run.sh --acceptance_module_tests || travis_terminate 1
+    - ./test/run.sh --acceptance-module-tests-only || travis_terminate 1
   - name: "Push docker container"
     if: type != pull_request
     stage: deploy

--- a/.travis.yml
+++ b/.travis.yml
@@ -89,13 +89,15 @@ jobs:
           bash <(curl -s https://codecov.io/bash) -F integration
           rm -f coverage.txt
       fi
-  - name: "Acceptance and benchmark tests (requiring docker to run)"
+  - name: "Acceptance tests (requiring docker to run)"
     stage: test
+    if: type != pull_request
     script: 
     - ./test/run.sh --acceptance-only || travis_terminate 1
   - name: "Acceptance tests for modules"
     stage: test
-    script: 
+    if: type != pull_request
+    script:
     - ./test/run.sh --acceptance-module-tests-only || travis_terminate 1
   - name: "Push docker container"
     if: type != pull_request

--- a/test/benchmark/benchmark.go
+++ b/test/benchmark/benchmark.go
@@ -60,10 +60,7 @@ func main() {
 	c := &http.Client{Transport: t}
 	url := "http://localhost:8080/v1/"
 
-	alreadyRunning, err := startWeaviate(c, url)
-	if err != nil {
-		panic("Could not start weaviate: " + err.Error())
-	}
+	alreadyRunning := startWeaviate(c, url)
 
 	var newRuntime map[string]int64
 	switch benchmarkName {
@@ -155,6 +152,7 @@ func readCurrentBenchmarkResults() benchmarkResult {
 }
 
 func tearDownWeavaite() error {
+	fmt.Print("Shutting down weaviate.\n")
 	app := "docker-compose"
 	arguments := []string{
 		"down",
@@ -166,19 +164,15 @@ func tearDownWeavaite() error {
 // start weaviate in case it was not already started
 //
 // We want to benchmark the current state and therefore need to rebuild and then start a docker container
-func startWeaviate(c *http.Client, url string) (bool, error) {
-	requestReady, _ := http.NewRequest("GET", url+".well-known/ready", nil)
-	requestReady.Header.Set("content-type", "application/json")
-	response_started, err := c.Do(requestReady)
-	if err != nil {
-		return false, err
-	}
-	defer response_started.Body.Close()
-	alreadyRunning := response_started.StatusCode == 200
+func startWeaviate(c *http.Client, url string) bool {
+	requestReady := createRequest(url+".well-known/ready", "GET", nil)
+
+	response_started_code, _, _, err := performRequest(c, requestReady)
+	alreadyRunning := err == nil && response_started_code == 200
 
 	if alreadyRunning {
 		fmt.Print("Weaviate instance already running.\n")
-		return alreadyRunning, nil
+		return alreadyRunning
 	}
 
 	fmt.Print("(Re-) build and start weaviate.\n")
@@ -186,42 +180,44 @@ func startWeaviate(c *http.Client, url string) (bool, error) {
 	if err := command(cmd, []string{}, true); err != nil {
 		panic("Command to (re-) build and start weaviate failed: " + err.Error())
 	}
-	return false, nil
+	return false
 }
 
 // createRequest creates requests
-func createRequest(url string, method string, payload interface{}) (*http.Request, error) {
-	var body io.Reader
+func createRequest(url string, method string, payload interface{}) *http.Request {
+	var body io.Reader = nil
 	if payload != nil {
-		jsonBody, err := json.Marshal(body)
+		jsonBody, err := json.Marshal(payload)
 		if err != nil {
-			return nil, err
+			panic("Could not marshal request" + err.Error())
 		}
 		body = bytes.NewBuffer(jsonBody)
 	}
-
 	request, err := http.NewRequest(method, url, body)
 	if err != nil {
-		return nil, err
+		panic("Could not create request" + err.Error())
 	}
 	request.Header.Add("Content-Type", "application/json")
 	request.Header.Add("Accept", "application/json")
 
-	return request, nil
+	return request
 }
 
 // performRequest runs requests
-func performRequest(c *http.Client, request *http.Request) (int, []byte, error) {
+func performRequest(c *http.Client, request *http.Request) (int, []byte, int64, error) {
+	timeStart := time.Now()
 	response, err := c.Do(request)
+	requestTime := time.Since(timeStart).Milliseconds()
+
 	if err != nil {
-		return 0, nil, err
+		return 0, nil, requestTime, err
 	}
 
-	defer response.Body.Close()
 	body, err := ioutil.ReadAll(response.Body)
+	response.Body.Close()
 	if err != nil {
-		return 0, nil, err
+		return 0, nil, requestTime, err
 	}
 
-	return response.StatusCode, body, nil
+	return response.StatusCode, body, requestTime, nil
 }

--- a/test/benchmark/benchmark_sift.go
+++ b/test/benchmark/benchmark_sift.go
@@ -72,6 +72,15 @@ func readSiftFloat(file string, maxObjects int) []*models.Object {
 	}
 	defer f.Close()
 
+	fi, err := f.Stat()
+	if err != nil {
+		panic("Could not get SIFT file properties, error: " + err.Error())
+	}
+	fileSize := fi.Size()
+	if fileSize < 1000000 {
+		panic("The file is only "+fmt.Sprint(fileSize)+" bytes long. Did you forgot to install git lfs?" )
+	}
+
 	// The sift data is a binary file containing floating point vectors
 	// For each entry, the first 4 bytes is the length of the vector (in number of floats, not in bytes)
 	// which is followed by the vector data with vector length * 4 bytes.

--- a/test/integration/run.sh
+++ b/test/integration/run.sh
@@ -8,15 +8,9 @@ function echo_yellow() {
   echo -e "${yellow}${*}${nc}"
 }
 
-norestart=false
 includeslow=false
 
 for arg in "$@"; do
-  if [[ $arg == --no-restart ]]; then
-    norestart=true
-    shift
-  fi
-
   if [[ $arg == --include-slow ]]; then
     includeslow=true
     shift


### PR DESCRIPTION
Improves benchmarks after feedback:
- Don't run benchmarks by default when calling the tests/run.sh script (Benchmarks are still run by default in the CI)
- Clear out any existing schema
- Use functions to create/perform requests, to make sure that header/error checking etc is correct
- Add results file to .gitignore
- Check file size of SIFT files and warn if file is too small
- Clean up weaviate instance if error occured 

unrelated:

- removes an unused option from the integration test script
- Only run acceptance tests on branch pipeline