### PR TITLE
Reduce Allocations of Prometheus Instructions

### DIFF
--- a/adapters/repos/db/lsmkv/bloom_filter_metrics.go
+++ b/adapters/repos/db/lsmkv/bloom_filter_metrics.go
@@ -1,0 +1,17 @@
+package lsmkv
+
+type bloomFilterMetrics struct {
+	trueNegative  TimeObserver
+	falsePositive TimeObserver
+	truePositive  TimeObserver
+}
+
+// newBloomFilterMetrics curries the prometheus metrics just once at
+// initialization to prevent further allocs on the hot path
+func newBloomFilterMetrics(metrics *Metrics) *bloomFilterMetrics {
+	return &bloomFilterMetrics{
+		trueNegative:  metrics.BloomFilterObserver("replace", "get_true_negative"),
+		falsePositive: metrics.BloomFilterObserver("replace", "get_false_positive"),
+		truePositive:  metrics.BloomFilterObserver("replace", "get_true_positive"),
+	}
+}

--- a/adapters/repos/db/lsmkv/memtable.go
+++ b/adapters/repos/db/lsmkv/memtable.go
@@ -28,7 +28,6 @@ type Memtable struct {
 	commitlog          *commitLogger
 	size               uint64
 	path               string
-	pathDir            string
 	strategy           string
 	secondaryIndices   uint16
 	secondaryToPrimary []map[string][]byte

--- a/adapters/repos/db/lsmkv/memtable_metrics.go
+++ b/adapters/repos/db/lsmkv/memtable_metrics.go
@@ -6,8 +6,10 @@ type memtableMetrics struct {
 	append          NsObserver
 	appendMapSorted NsObserver
 	get             NsObserver
+	getBySecondary  NsObserver
 	getMap          NsObserver
 	getCollection   NsObserver
+	size            Setter
 }
 
 // newMemtableMetrics curries the prometheus-functions just once to make sure
@@ -20,7 +22,9 @@ func newMemtableMetrics(metrics *Metrics, path, strategy string) *memtableMetric
 		append:          metrics.MemtableOpObserver(path, strategy, "append"),
 		appendMapSorted: metrics.MemtableOpObserver(path, strategy, "appendMapSorted"),
 		get:             metrics.MemtableOpObserver(path, strategy, "get"),
+		getBySecondary:  metrics.MemtableOpObserver(path, strategy, "getBySecondary"),
 		getMap:          metrics.MemtableOpObserver(path, strategy, "getMap"),
 		getCollection:   metrics.MemtableOpObserver(path, strategy, "getCollection"),
+		size:            metrics.MemtableSizeSetter(path, strategy),
 	}
 }

--- a/adapters/repos/db/lsmkv/memtable_metrics.go
+++ b/adapters/repos/db/lsmkv/memtable_metrics.go
@@ -1,0 +1,26 @@
+package lsmkv
+
+type memtableMetrics struct {
+	put             NsObserver
+	setTombstone    NsObserver
+	append          NsObserver
+	appendMapSorted NsObserver
+	get             NsObserver
+	getMap          NsObserver
+	getCollection   NsObserver
+}
+
+// newMemtableMetrics curries the prometheus-functions just once to make sure
+// they don't have to be curried on the hotpath where we this would lead to a
+// lot of allocations.
+func newMemtableMetrics(metrics *Metrics, path, strategy string) *memtableMetrics {
+	return &memtableMetrics{
+		put:             metrics.MemtableOpObserver(path, strategy, "put"),
+		setTombstone:    metrics.MemtableOpObserver(path, strategy, "setTombstone"),
+		append:          metrics.MemtableOpObserver(path, strategy, "append"),
+		appendMapSorted: metrics.MemtableOpObserver(path, strategy, "appendMapSorted"),
+		get:             metrics.MemtableOpObserver(path, strategy, "get"),
+		getMap:          metrics.MemtableOpObserver(path, strategy, "getMap"),
+		getCollection:   metrics.MemtableOpObserver(path, strategy, "getCollection"),
+	}
+}

--- a/adapters/repos/db/lsmkv/metrics.go
+++ b/adapters/repos/db/lsmkv/metrics.go
@@ -107,11 +107,11 @@ func NewMetrics(promMetrics *monitoring.PrometheusMetrics, className,
 }
 
 func noOpNsObserver(startNs int64) {
-	return
+	// do nothing
 }
 
 func noOpSetter(val uint64) {
-	return
+	// do nothing
 }
 
 func (m *Metrics) MemtableOpObserver(path, strategy, op string) NsObserver {

--- a/adapters/repos/db/lsmkv/segment.go
+++ b/adapters/repos/db/lsmkv/segment.go
@@ -45,6 +45,7 @@ type segment struct {
 	secondaryIndices      []diskIndex
 	logger                logrus.FieldLogger
 	metrics               *Metrics
+	bloomFilterMetrics    *bloomFilterMetrics
 
 	// the net addition this segment adds with respect to all previous segments
 	countNetAdditions int
@@ -116,6 +117,7 @@ func newSegment(path string, logger logrus.FieldLogger, metrics *Metrics,
 		index:               primaryDiskIndex,
 		logger:              logger,
 		metrics:             metrics,
+		bloomFilterMetrics:  newBloomFilterMetrics(metrics),
 	}
 
 	if ind.secondaryIndexCount > 0 {

--- a/adapters/repos/db/vector/hnsw/index.go
+++ b/adapters/repos/db/vector/hnsw/index.go
@@ -115,7 +115,8 @@ type hnsw struct {
 
 	forbidFlat bool // mostly used in testing scenarios where we want to use the index even in scenarios where we typically wouldn't
 
-	metrics *Metrics
+	metrics       *Metrics
+	insertMetrics *insertMetrics
 }
 
 type CommitLogger interface {
@@ -208,6 +209,8 @@ func New(cfg Config, uc UserConfig) (*hnsw, error) {
 
 		metrics: NewMetrics(cfg.PrometheusMetrics, cfg.ClassName, cfg.ShardName),
 	}
+
+	index.insertMetrics = newInsertMetrics(index.metrics)
 
 	if err := index.init(cfg); err != nil {
 		return nil, errors.Wrapf(err, "init index %q", index.id)

--- a/adapters/repos/db/vector/hnsw/insert.go
+++ b/adapters/repos/db/vector/hnsw/insert.go
@@ -27,7 +27,7 @@ func (h *hnsw) Add(id uint64, vector []float32) error {
 	}
 
 	h.metrics.InsertVector()
-	defer h.metrics.TrackInsert(before, "total")
+	defer h.insertMetrics.total(before)
 
 	node := &vertex{
 		id: id,
@@ -137,7 +137,7 @@ func (h *hnsw) insert(node *vertex, nodeVec []float32) error {
 	h.nodes[nodeId] = node
 	h.Unlock()
 
-	h.metrics.TrackInsert(before, "prepare_and_insert_node")
+	h.insertMetrics.prepareAndInsertNode(before)
 	before = time.Now()
 
 	entryPointID, err = h.findBestEntrypointForNode(currentMaximumLayer, targetLevel,
@@ -146,7 +146,7 @@ func (h *hnsw) insert(node *vertex, nodeVec []float32) error {
 		return errors.Wrap(err, "find best entrypoint")
 	}
 
-	h.metrics.TrackInsert(before, "find_entrypoint")
+	h.insertMetrics.findEntrypoint(before)
 	before = time.Now()
 
 	if err := h.findAndConnectNeighbors(node, entryPointID, nodeVec,
@@ -154,9 +154,9 @@ func (h *hnsw) insert(node *vertex, nodeVec []float32) error {
 		return errors.Wrap(err, "find and connect neighbors")
 	}
 
-	h.metrics.TrackInsert(before, "find_and_connect_total")
+	h.insertMetrics.findAndConnectTotal(before)
 	before = time.Now()
-	defer h.metrics.TrackInsert(before, "update_global_entrypoint")
+	defer h.insertMetrics.updateGlobalEntrypoint(before)
 
 	// go h.insertHook(nodeId, targetLevel, neighborsAtLevel)
 	node.unmarkAsMaintenance()

--- a/adapters/repos/db/vector/hnsw/insert_metrics.go
+++ b/adapters/repos/db/vector/hnsw/insert_metrics.go
@@ -1,0 +1,27 @@
+package hnsw
+
+type insertMetrics struct {
+	total                           Observer
+	prepareAndInsertNode            Observer
+	findEntrypoint                  Observer
+	updateGlobalEntrypoint          Observer
+	findAndConnectTotal             Observer
+	findAndConnectSearch            Observer
+	findAndConnectHeuristic         Observer
+	findAndConnectUpdateConnections Observer
+}
+
+// newInsertMetrics curries the prometheus observers just once at creation time
+// and therefore avoids having to make a lot of allocations on the hot path
+func newInsertMetrics(metrics *Metrics) *insertMetrics {
+	return &insertMetrics{
+		total:                           metrics.TrackInsertObserver("total"),
+		prepareAndInsertNode:            metrics.TrackInsertObserver("prepare_and_insert_node"),
+		findEntrypoint:                  metrics.TrackInsertObserver("find_entrypoint"),
+		updateGlobalEntrypoint:          metrics.TrackInsertObserver("update_global_entrypoint"),
+		findAndConnectTotal:             metrics.TrackInsertObserver("find_and_connect_total"),
+		findAndConnectSearch:            metrics.TrackInsertObserver("find_and_connect_search"),
+		findAndConnectHeuristic:         metrics.TrackInsertObserver("find_and_connect_heuristic"),
+		findAndConnectUpdateConnections: metrics.TrackInsertObserver("find_and_connect_update_connections"),
+	}
+}

--- a/adapters/repos/db/vector/hnsw/metrics.go
+++ b/adapters/repos/db/vector/hnsw/metrics.go
@@ -199,7 +199,7 @@ func (m *Metrics) GrowDuration(start time.Time) {
 type Observer func(start time.Time)
 
 func noOpObserver(start time.Time) {
-	return
+	// do nothing
 }
 
 func (m *Metrics) TrackInsertObserver(step string) Observer {

--- a/adapters/repos/db/vector/hnsw/metrics.go
+++ b/adapters/repos/db/vector/hnsw/metrics.go
@@ -196,13 +196,23 @@ func (m *Metrics) GrowDuration(start time.Time) {
 	m.grow.Observe(took)
 }
 
-func (m *Metrics) TrackInsert(start time.Time, step string) {
+type Observer func(start time.Time)
+
+func noOpObserver(start time.Time) {
+	return
+}
+
+func (m *Metrics) TrackInsertObserver(step string) Observer {
 	if !m.enabled {
-		return
+		return noOpObserver
 	}
 
-	took := float64(time.Since(start)) / float64(time.Millisecond)
-	m.insertTime.With(prometheus.Labels{"step": step}).Observe(took)
+	curried := m.insertTime.With(prometheus.Labels{"step": step})
+
+	return func(start time.Time) {
+		took := float64(time.Since(start)) / float64(time.Millisecond)
+		curried.Observe(took)
+	}
 }
 
 func (m *Metrics) TrackDelete(start time.Time, step string) {

--- a/adapters/repos/db/vector/hnsw/neighbor_connections.go
+++ b/adapters/repos/db/vector/hnsw/neighbor_connections.go
@@ -91,7 +91,7 @@ func (n *neighborFinderConnector) doAtLevel(level int) error {
 		return errors.Wrapf(err, "find neighbors: search layer at level %d", level)
 	}
 
-	n.graph.metrics.TrackInsert(before, "find_and_connect_search")
+	n.graph.insertMetrics.findAndConnectSearch(before)
 	before = time.Now()
 
 	// max := n.maximumConnections(level)
@@ -100,7 +100,7 @@ func (n *neighborFinderConnector) doAtLevel(level int) error {
 		return err
 	}
 
-	n.graph.metrics.TrackInsert(before, "find_and_connect_heuristic")
+	n.graph.insertMetrics.findAndConnectHeuristic(before)
 	before = time.Now()
 
 	// // for distributed spike
@@ -145,7 +145,7 @@ func (n *neighborFinderConnector) doAtLevel(level int) error {
 		n.entryPointDist = dist
 	}
 
-	n.graph.metrics.TrackInsert(before, "find_and_connect_update_connections")
+	n.graph.insertMetrics.findAndConnectUpdateConnections(before)
 	return nil
 }
 


### PR DESCRIPTION
The Prometheus instructions added in the recent past, were added in such a way that some metrics on the hot path lead to a lot of allocations, as described in #2052. This PR fixes that.

closes #2052 

### Before
<img width="657" alt="image" src="https://user-images.githubusercontent.com/8974479/181067794-3afbee04-cb78-47da-b08c-3f740eaaa045.png">

### After
<img width="537" alt="image" src="https://user-images.githubusercontent.com/8974479/181067906-a736ac1b-fd26-44c3-9dee-0473cd1f2f0f.png">


### Before Full 
![profile029](https://user-images.githubusercontent.com/8974479/181068163-bc92f2b1-20e1-477c-84db-0c18f326373d.png)

### After Full
![profile034](https://user-images.githubusercontent.com/8974479/181067987-22650344-e258-4a73-9604-053ecf1e2e63.png)

