### PR TITLE
Add Scripts to automatically execute performance benchmarks on Remote VM

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -109,3 +109,7 @@ vendor/
 
 # benchmark results
 test/benchmark/benchmark_results.json
+# benchmark results files copied from a remote run
+benchmark_results_*.json
+
+

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,8 @@ before_install:
   - sudo apt-get -y -o Dpkg::Options::="--force-confnew" install docker-ce
   - mkdir -vp ~/.docker/cli-plugins/
   - curl --silent -L "https://github.com/docker/buildx/releases/download/v0.3.0/buildx-v0.3.0.linux-amd64" > ~/.docker/cli-plugins/docker-buildx
+  - curl -SL "https://github.com/docker/compose/releases/download/v2.7.0/docker-compose-linux-x86_64" -o ~/.docker/cli-plugins/docker-compose
+
   - chmod a+x ~/.docker/cli-plugins/docker-buildx
 dist: bionic
 go: 

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,7 @@ before_install:
   - curl -SL "https://github.com/docker/compose/releases/download/v2.7.0/docker-compose-linux-x86_64" -o ~/.docker/cli-plugins/docker-compose
 
   - chmod a+x ~/.docker/cli-plugins/docker-buildx
+  - chmod a+x ~/.docker/cli-plugins/docker-compose
 dist: bionic
 go: 
   - "1.16.5"

--- a/test/benchmark/benchmark.go
+++ b/test/benchmark/benchmark.go
@@ -181,7 +181,7 @@ func startWeavaite(c *http.Client, url string) (bool, error) {
 	fmt.Print("(Re-) build and start weaviate.\n")
 	cmd := "./tools/test/run_ci_server.sh"
 	if err := command(cmd, []string{}, true); err != nil {
-		panic("Command to (re-) build and start weaviate failed.")
+		panic("Command to (re-) build and start weaviate failed: " + err.Error())
 	}
 	return false, nil
 }

--- a/test/benchmark/remote/README.md
+++ b/test/benchmark/remote/README.md
@@ -1,0 +1,2 @@
+This folder contains scripts to help execute the benchmark remotely on a GCP
+VM.

--- a/test/benchmark/remote/README.md
+++ b/test/benchmark/remote/README.md
@@ -37,3 +37,16 @@ To do all steps (including spinning up a machine) that happen _before_ running
 the benchmarks you can invoke it with the `--prepare` option. To get an
 interactive ssh session into the machine, use `--ssh`. To destroy the machine
 at an arbitrary point run `--delete_machine`.
+
+## Run on arbitrary branch
+
+*Note: Checking out a branch that does not yet have the scripts from this
+folder, will fail. You need a branch created after this script was initially
+built or has been rebased on top of it.*
+
+```
+test/benchmark/remote/run.sh --prepare
+test/benchmark/remote/run.sh --checkout <name-of-your-branch-or-commit>
+test/benchmark/remote/run.sh --benchmark
+test/benchmark/remote/run.sh --delete_machine
+```

--- a/test/benchmark/remote/README.md
+++ b/test/benchmark/remote/README.md
@@ -1,2 +1,39 @@
 This folder contains scripts to help execute the benchmark remotely on a GCP
 VM.
+
+## Requirements
+
+- Bash
+- gcloud (logged in and permissions to `semi-automated-benchmarking` project
+- terraform
+
+## Usage
+
+From the root folder run
+
+```
+test/benchmark/remote/run.sh --all
+```
+
+To run the whole benchmark suite. The `--all` command will:
+
+- Check that `gcloud` and `terraform` are installed locally
+- Spin up a machine in GCP
+- Install the dependencies on this machine
+- Clone Weaviate
+- Check out the same commit that is check out locally
+- Run the benchmarks script
+- Copy the results file to the local machine
+- Destroy the machine
+
+If any of the command fails the machine will be destroyed.
+
+## Debugging
+
+You can also run all commands individually, simply run the command without
+parameters to list all possible options.
+
+To do all steps (including spinning up a machine) that happen _before_ running
+the benchmarks you can invoke it with the `--prepare` option. To get an
+interactive ssh session into the machine, use `--ssh`. To destroy the machine
+at an arbitrary point run `--delete_machine`.

--- a/test/benchmark/remote/run.sh
+++ b/test/benchmark/remote/run.sh
@@ -1,11 +1,19 @@
 #!/usr/bin/env bash
 
+PROJECT=semi-automated-benchmarking
+ZONE=us-central1-a
+INSTANCE=automated-loadtest
+
 set -eou pipefail
 
 function main() {
   while [[ "$#" -gt 0 ]]; do
       case $1 in
           --all) run_all; exit 0 ;;
+          --create_machine) create_machine; exit 0 ;;
+          --clone_repository) clone_repository; exit 0;;
+          --delete_machine) delete_machine; exit 0;;
+          --install_dependencies) install_dependencies; exit 0;;
           *) echo "Unknown parameter passed: $1"; exit 1 ;;
       esac
       shift
@@ -17,7 +25,10 @@ function main() {
 function print_help() {
   echo "Valid arguments include:"
   echo ""
-  echo "  --all      Run everything, including machine creation & destruction"
+  echo "  --all               Run everything, including machine creation & destruction"
+  echo "  --create_machine    Only create machine"
+  echo "  --delete_machine    Stop & Delete running machine"
+  echo "  --clone_repository  Clone and checkout Weaviate repo at specified commit"
 }
 
 function run_all() {
@@ -25,6 +36,8 @@ function run_all() {
 
   check
   create_machine
+  install_dependencies
+  clone_repository
 }
 
 function check() {
@@ -47,10 +60,25 @@ function check() {
 function create_machine() {
   (cd terraform && terraform init)
   (cd terraform && terraform apply -auto-approve)
+  echo "Sleeping for 10s, so first ssh doesn't fail. This should be improved through polling"
+  sleep 10
 }
 
 function delete_machine() {
   (cd terraform && terraform destroy -auto-approve)
+}
+
+function install_dependencies() {
+  ssh_command "sudo apt-get update && sudo apt-get install -y git"
+  ssh_command "ssh-keyscan -t rsa github.com >> ~/.ssh/known_hosts"
+}
+
+function clone_repository() {
+  ssh_command "cd; [ ! -d weaviate ] && git clone https://github.com/semi-technologies/weaviate.git weaviate || true"
+  ref=$(git rev-parse HEAD | head -c 7)
+  echo_green "Checking out local commit/branch $ref"
+  ssh_command "cd weaviate; git checkout $ref"
+
 }
 
 
@@ -64,6 +92,10 @@ function echo_red() {
   green='\033[0;31m'
   nc='\033[0m' 
   echo -e "${green}${*}${nc}"
+}
+
+function ssh_command() {
+  gcloud beta compute ssh --project=$PROJECT --zone=$ZONE  "$INSTANCE" --command="$1"
 }
 
 main "$@"

--- a/test/benchmark/remote/run.sh
+++ b/test/benchmark/remote/run.sh
@@ -4,6 +4,7 @@ PROJECT=semi-automated-benchmarking
 ZONE=us-central1-a
 INSTANCE=automated-loadtest
 GOVERSION=https://go.dev/dl/go1.18.4.linux-amd64.tar.gz
+FILE_PREFIX=${FILE_PREFIX:-""}
 
 set -eou pipefail
 
@@ -124,7 +125,7 @@ function benchmark() {
   ssh_command "cd ~/weaviate; rm test/benchmark/benchmark_results.json || true"
   ssh_command "cd ~/weaviate; test/benchmark/run_performance_tracker.sh"
   echo_green "Copy results file to local machine"
-  filename="benchmark_results_$(date +%s).json"
+  filename="${FILE_PREFIX}benchmark_results_$(date +%s).json"
   scp_command "$INSTANCE:~/weaviate/test/benchmark/benchmark_results.json" "$filename"
   echo "Results file succesfully copied to ${PWD}/$filename"
 }

--- a/test/benchmark/remote/run.sh
+++ b/test/benchmark/remote/run.sh
@@ -20,6 +20,7 @@ function main() {
           --install_dependencies) install_dependencies; exit 0;;
           --benchmark) benchmark; exit 0;;
           --prepare) prepare; exit 0;;
+          --checkout) checkout "$2" ; exit 0;;
           --ssh) interactive_ssh; exit 0;;
           *) echo "Unknown parameter passed: $1"; exit 1 ;;
       esac
@@ -37,6 +38,7 @@ function print_help() {
   echo "  --create_machine    Only create machine"
   echo "  --delete_machine    Stop & Delete running machine"
   echo "  --clone_repository  Clone and checkout Weaviate repo at specified commit"
+  echo "  --checkout          Checkout arbitrary branch or commit"
   echo "  --ssh               Interactive SSH session"
 }
 
@@ -108,6 +110,11 @@ function clone_repository() {
   ssh_command "cd weaviate; git-lfs install; git-lfs pull"
   ref=$(git rev-parse HEAD | head -c 7)
   echo_green "Checking out local commit/branch $ref"
+  ssh_command "cd weaviate; git checkout $ref"
+}
+
+function checkout() {
+  ref="$1"
   ssh_command "cd weaviate; git checkout $ref"
 }
 

--- a/test/benchmark/remote/run.sh
+++ b/test/benchmark/remote/run.sh
@@ -1,0 +1,69 @@
+#!/usr/bin/env bash
+
+set -eou pipefail
+
+function main() {
+  while [[ "$#" -gt 0 ]]; do
+      case $1 in
+          --all) run_all; exit 0 ;;
+          *) echo "Unknown parameter passed: $1"; exit 1 ;;
+      esac
+      shift
+  done
+
+  print_help
+}
+
+function print_help() {
+  echo "Valid arguments include:"
+  echo ""
+  echo "  --all      Run everything, including machine creation & destruction"
+}
+
+function run_all() {
+  trap delete_machine EXIT
+
+  check
+  create_machine
+}
+
+function check() {
+  echo_green "Checking required dependencies"
+  if ! command -v gcloud &> /dev/null
+  then
+      echo_red "Missing gcloud binary"
+      return 1
+  fi
+
+  if ! command -v terraform &> /dev/null
+  then
+      echo_red "Missing terraform binary"
+      return 1
+  fi
+
+  echo "Ready to go!"
+}
+
+function create_machine() {
+  (cd terraform && terraform init)
+  (cd terraform && terraform apply -auto-approve)
+}
+
+function delete_machine() {
+  (cd terraform && terraform destroy -auto-approve)
+}
+
+
+function echo_green() {
+  green='\033[0;32m'
+  nc='\033[0m' 
+  echo -e "${green}${*}${nc}"
+}
+
+function echo_red() {
+  green='\033[0;31m'
+  nc='\033[0m' 
+  echo -e "${green}${*}${nc}"
+}
+
+main "$@"

--- a/test/benchmark/remote/run.sh
+++ b/test/benchmark/remote/run.sh
@@ -46,7 +46,6 @@ function print_help() {
 function run_all() {
   trap delete_machine EXIT
 
-  check
   prepare
   benchmark
 }
@@ -107,11 +106,10 @@ function install_docker() {
 }
 
 function clone_repository() {
-  ssh_command "cd; [ ! -d weaviate ] && git clone https://github.com/semi-technologies/weaviate.git weaviate || true"
+  ref=$(git rev-parse --abbrev-ref HEAD)
+  echo_green "Cloning weaviate repo to branch $ref"
+  ssh_command "cd; [ ! -d weaviate ] && git clone --depth 1 --branch $ref https://github.com/semi-technologies/weaviate.git weaviate || true"
   ssh_command "cd weaviate; git-lfs install; git-lfs pull"
-  ref=$(git rev-parse HEAD | head -c 7)
-  echo_green "Checking out local commit/branch $ref"
-  ssh_command "cd weaviate; git checkout $ref"
 }
 
 function checkout() {
@@ -138,9 +136,9 @@ function echo_green() {
 }
 
 function echo_red() {
-  green='\033[0;31m'
+  red='\033[0;31m'
   nc='\033[0m' 
-  echo -e "${green}${*}${nc}"
+  echo -e "${red}${*}${nc}"
 }
 
 function ssh_command() {

--- a/test/benchmark/remote/terraform/.gitignore
+++ b/test/benchmark/remote/terraform/.gitignore
@@ -1,0 +1,9 @@
+# Local .terraform directories
+**/.terraform/*
+
+.terraform.lock.hcl
+
+
+# .tfstate files
+*.tfstate
+*.tfstate.*

--- a/test/benchmark/remote/terraform/main.tf
+++ b/test/benchmark/remote/terraform/main.tf
@@ -1,0 +1,3 @@
+provider "google" {
+  project = "semi-automated-benchmarking"
+}

--- a/test/benchmark/remote/terraform/variables.tf
+++ b/test/benchmark/remote/terraform/variables.tf
@@ -1,0 +1,4 @@
+variable "machine_type" {
+  type = string
+  default = "c2-standard-16"
+}

--- a/test/benchmark/remote/terraform/vm.tf
+++ b/test/benchmark/remote/terraform/vm.tf
@@ -7,7 +7,7 @@ resource "google_compute_instance" "default" {
 
   boot_disk {
     initialize_params {
-      image = "debian-cloud/debian-9"
+      image = "debian-cloud/debian-11"
       size = 100
     }
   }

--- a/test/benchmark/remote/terraform/vm.tf
+++ b/test/benchmark/remote/terraform/vm.tf
@@ -1,6 +1,6 @@
 resource "google_compute_instance" "default" {
   name         = "automated-loadtest"
-  machine_type = "c2-standard-16"
+  machine_type = var.machine_type
   zone         = "us-central1-a"
 
   tags = ["automated-loadtest"]

--- a/test/benchmark/remote/terraform/vm.tf
+++ b/test/benchmark/remote/terraform/vm.tf
@@ -20,6 +20,4 @@ resource "google_compute_instance" "default" {
       // Ephemeral public IP
     }
   }
-
-  metadata_startup_script = "echo hi > /test.txt"
 }

--- a/test/benchmark/remote/terraform/vm.tf
+++ b/test/benchmark/remote/terraform/vm.tf
@@ -9,6 +9,7 @@ resource "google_compute_instance" "default" {
     initialize_params {
       image = "debian-cloud/debian-11"
       size = 100
+      type = "pd-ssd"
     }
   }
 

--- a/test/benchmark/remote/terraform/vm.tf
+++ b/test/benchmark/remote/terraform/vm.tf
@@ -1,0 +1,24 @@
+resource "google_compute_instance" "default" {
+  name         = "automated-loadtest"
+  machine_type = "c2-standard-16"
+  zone         = "us-central1-a"
+
+  tags = ["automated-loadtest"]
+
+  boot_disk {
+    initialize_params {
+      image = "debian-cloud/debian-9"
+      size = 100
+    }
+  }
+
+  network_interface {
+    network = "default"
+
+    access_config {
+      // Ephemeral public IP
+    }
+  }
+
+  metadata_startup_script = "echo hi > /test.txt"
+}

--- a/test/run.sh
+++ b/test/run.sh
@@ -43,7 +43,7 @@ function main() {
   then
     echo "In Acceptance test suite"
     echo_green "Stop any running docker-compose containers..."
-    surpress_on_success docker-compose -f docker-compose-test.yml down --remove-orphans
+    surpress_on_success docker compose -f docker-compose-test.yml down --remove-orphans
 
     echo_green "Start up weaviate and backing dbs in docker-compose..."
     echo "This could take some time..."

--- a/tools/test/run_ci_server.sh
+++ b/tools/test/run_ci_server.sh
@@ -7,9 +7,9 @@ function main() {
   echo "Pull images..."
   surpress_on_success docker pull golang:1.11-alpine
   echo "Build containers (this will take the longest)..."
-  docker-compose -f docker-compose-test.yml build weaviate
-  echo "Start up docker-compose setup..."
-  surpress_on_success docker-compose -f docker-compose-test.yml up --force-recreate -d weaviate \
+  docker compose -f docker-compose-test.yml build weaviate
+  echo "Start up docker compose setup..."
+  surpress_on_success docker compose -f docker-compose-test.yml up --force-recreate -d weaviate \
     contextionary 
 
   MAX_WAIT_SECONDS=60
@@ -22,10 +22,10 @@ function main() {
       if [ $? -eq 7 ]; then
         echo "Weaviate is not up yet. (waited for ${ALREADY_WAITING}s)"
         echo "Weaviate:"
-        docker-compose -f docker-compose-test.yml logs weaviate
+        docker compose -f docker-compose-test.yml logs weaviate
         if [ $ALREADY_WAITING -gt $MAX_WAIT_SECONDS ]; then
           echo "Weaviate did not start up in $MAX_WAIT_SECONDS."
-          docker-compose -f docker-compose-test.yml logs
+          docker compose -f docker-compose-test.yml logs
           exit 1
         else
           sleep 2


### PR DESCRIPTION
## This PR adds (new features)
- a new script `test/benchmark/remote/run.sh` to orchestrate spinning up a VM and running the benchmarks on this VM
- see the new README.md as part of the changed files for usage
- a terraform project which is used by `run.sh` to create and destroy the VM

## Limitations
- The machine has a fixed name, so running the script in parallel would lead to conflicts
- Therefore execution on CI is not supported yet (that can be added in a later step)
- The script only copies the results back to your local machine, it does not store them in a bucket, etc.
- Currently GCP-only, no support for AWS or Azure yet

## Assumptions
- Assumes you have access to `semi-automated-benchmarking` and are logged in with `gcloud` correctly
- Assumes you want to manually run the script to get some results for your local branch.

## Side-effects
When installing Docker on a new VM, `docker-compose` as a standalone binary is no longer supported. Instead, the newer `docker compose` plugin is used. This script changes the usage of `docker-compose` to `docker compose` and also installs the required plugin on travis so that regular builds don't fail.

## Notes
- This is a bit of a quick-and-dirty implementation with lots of potential for future improvement:
  - Almost everything is hard-coded at the moment, only the machine type is a variable
  - The `run.sh` script uses a lot of `gcloud ssh`. I assume it would be cleaner to do this with something like Ansible, but the ssh commands work quite well for now.