### PR TITLE
Add SIFT and profiling data to dockerignore

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -10,3 +10,6 @@ data_wiki/
 logs/
 test/acceptance/
 snapshots-s3/
+*.fvecs  # sift data
+*.png  # profiling
+*.out


### PR DESCRIPTION
This should reduce the time docker takes to "transfer context"