### PR TITLE
Update golangci-lint to v1.48 and go1.19 on CI

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -7,11 +7,11 @@ jobs:
     steps:
       - uses: actions/setup-go@v3
         with:
-          go-version: '1.18'
+          go-version: '1.19'
       - uses: actions/checkout@v3
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v3
         with:
           # Required: the version of golangci-lint is required and must be specified without patch version: we always use the latest patch version.
-          version: v1.47
+          version: v1.48
           args: --timeout=3m

--- a/adapters/repos/db/inverted/objects_test.go
+++ b/adapters/repos/db/inverted/objects_test.go
@@ -313,14 +313,13 @@ func TestAnalyzeObject(t *testing.T) {
 		})
 
 		t.Run("with array properties", func(t *testing.T) {
-			//nolint:gofumpt // the following block is formatted differently with go1.18 vs go1.19
 			schema := map[string]interface{}{
 				"descriptions": []interface{}{"I am great!", "I am also great!"},
 				"emails":       []interface{}{"john@doe.com", "john2@doe.com"},
 				"about_me":     []interface{}{"I like reading sci-fi books", "I like playing piano"},
-				"professions": []interface{}{"Mechanical Engineer", "	Marketing Analyst"},
-				"integers": []interface{}{int64(1), int64(2), int64(3), int64(4)},
-				"numbers":  []interface{}{float64(1.1), float64(2.2), float64(3.0), float64(4)},
+				"professions":  []interface{}{"Mechanical Engineer", "	Marketing Analyst"},
+				"integers":     []interface{}{int64(1), int64(2), int64(3), int64(4)},
+				"numbers":      []interface{}{float64(1.1), float64(2.2), float64(3.0), float64(4)},
 			}
 
 			uuid := "2609f1bc-7693-48f3-b531-6ddc52cd2501"

--- a/adapters/repos/db/lsmkv/store.go
+++ b/adapters/repos/db/lsmkv/store.go
@@ -202,7 +202,8 @@ func (s *Store) ListFiles(ctx context.Context) ([]string, error) {
 // Additionally, a rollbackFunc may be provided which will be run on the target
 // bucket in the event of an unsuccessful job.
 func (s *Store) runJobOnBuckets(ctx context.Context, jobFunc jobFunc,
-	rollbackFunc rollbackFunc) ([]interface{}, error) {
+	rollbackFunc rollbackFunc,
+) ([]interface{}, error) {
 	var (
 		status      = newBucketJobStatus()
 		resultQueue = make(chan interface{}, len(s.bucketsByName))

--- a/adapters/repos/db/shard_snapshot.go
+++ b/adapters/repos/db/shard_snapshot.go
@@ -2,7 +2,7 @@ package db
 
 import (
 	"context"
-	"io/ioutil"
+	"os"
 
 	"github.com/pkg/errors"
 	"github.com/semi-technologies/weaviate/entities/snapshots"
@@ -135,13 +135,13 @@ func (s *Shard) readSnapshotMetadata() (*snapshots.ShardMetadata, error) {
 }
 
 func (s *Shard) readIndexCounter() ([]byte, error) {
-	return ioutil.ReadFile(s.counter.FileName())
+	return os.ReadFile(s.counter.FileName())
 }
 
 func (s *Shard) readPropLengthTracker() ([]byte, error) {
-	return ioutil.ReadFile(s.propLengths.FileName())
+	return os.ReadFile(s.propLengths.FileName())
 }
 
 func (s *Shard) readShardVersion() ([]byte, error) {
-	return ioutil.ReadFile(s.versioner.path)
+	return os.ReadFile(s.versioner.path)
 }

--- a/entities/snapshots/snapshot.go
+++ b/entities/snapshots/snapshot.go
@@ -13,7 +13,6 @@ package snapshots
 
 import (
 	"encoding/json"
-	"io/ioutil"
 	"os"
 	"path"
 	"sync"
@@ -81,7 +80,7 @@ func New(id string, startedAt time.Time, basePath string) *Snapshot {
 func ReadFromDisk(id, basePath string) (*Snapshot, error) {
 	snapPath := path.Join(basePath, "snapshots", id) + ".json"
 
-	contents, err := ioutil.ReadFile(snapPath)
+	contents, err := os.ReadFile(snapPath)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to read snapshot from disk")
 	}


### PR DESCRIPTION
- Update Go Version to 1.19 on golangci-lint action
- Update golangci-lint to 1.48 (official go 1.19 support)
- Fix new linter errors (mostly gofumpt and ioutil)