### PR TITLE
Add thread pooling for batch requests

### DIFF
--- a/adapters/handlers/rest/configure_api.go
+++ b/adapters/handlers/rest/configure_api.go
@@ -159,6 +159,7 @@ func configureAPI(api *operations.WeaviateAPI) http.Handler {
 		QueryMaximumResults:       appState.ServerConfig.Config.QueryMaximumResults,
 		DiskUseWarningPercentage:  appState.ServerConfig.Config.DiskUse.WarningPercentage,
 		DiskUseReadOnlyPercentage: appState.ServerConfig.Config.DiskUse.ReadOnlyPercentage,
+		MaxImportGoroutinesFactor: appState.ServerConfig.Config.MaxImportGoroutinesFactor,
 	}, remoteIndexClient, appState.Cluster, appState.Metrics) // TODO client
 	vectorMigrator = db.NewMigrator(repo, appState.Logger)
 	vectorRepo = repo

--- a/adapters/repos/db/aggregations_integration_test.go
+++ b/adapters/repos/db/aggregations_integration_test.go
@@ -45,6 +45,7 @@ func Test_Aggregations(t *testing.T) {
 		QueryMaximumResults:       10000,
 		DiskUseWarningPercentage:  config.DefaultDiskUseWarningPercentage,
 		DiskUseReadOnlyPercentage: config.DefaultDiskUseReadonlyPercentage,
+		MaxImportGoroutinesFactor: 1,
 	}, &fakeRemoteClient{},
 		&fakeNodeResolver{}, nil)
 	repo.SetSchemaGetter(schemaGetter)
@@ -83,6 +84,7 @@ func Test_Aggregations_MultiShard(t *testing.T) {
 		QueryMaximumResults:       10000,
 		DiskUseWarningPercentage:  config.DefaultDiskUseWarningPercentage,
 		DiskUseReadOnlyPercentage: config.DefaultDiskUseReadonlyPercentage,
+		MaxImportGoroutinesFactor: 1,
 	}, &fakeRemoteClient{}, &fakeNodeResolver{}, nil)
 	repo.SetSchemaGetter(schemaGetter)
 	err := repo.WaitForStartup(testCtx())
@@ -103,7 +105,8 @@ func Test_Aggregations_MultiShard(t *testing.T) {
 }
 
 func prepareCompanyTestSchemaAndData(repo *DB,
-	migrator *Migrator, schemaGetter *fakeSchemaGetter) func(t *testing.T) {
+	migrator *Migrator, schemaGetter *fakeSchemaGetter,
+) func(t *testing.T) {
 	return func(t *testing.T) {
 		schema := schema.Schema{
 			Objects: &models.Schema{
@@ -193,7 +196,8 @@ func prepareCompanyTestSchemaAndData(repo *DB,
 }
 
 func cleanupCompanyTestSchemaAndData(repo *DB,
-	migrator *Migrator) func(t *testing.T) {
+	migrator *Migrator,
+) func(t *testing.T) {
 	return func(t *testing.T) {
 		assert.Nil(t, repo.Shutdown(context.Background()))
 	}
@@ -1175,7 +1179,8 @@ func testNumericalAggregationsWithGrouping(repo *DB, exact bool) func(t *testing
 }
 
 func testNumericalAggregationsWithoutGrouping(repo *DB,
-	exact bool) func(t *testing.T) {
+	exact bool,
+) func(t *testing.T) {
 	return func(t *testing.T) {
 		t.Run("only meta count, no other aggregations", func(t *testing.T) {
 			params := aggregation.Params{

--- a/adapters/repos/db/batch_integration_test.go
+++ b/adapters/repos/db/batch_integration_test.go
@@ -49,6 +49,7 @@ func TestBatchPutObjects(t *testing.T) {
 		QueryMaximumResults:       10000,
 		DiskUseWarningPercentage:  config.DefaultDiskUseWarningPercentage,
 		DiskUseReadOnlyPercentage: config.DefaultDiskUseReadonlyPercentage,
+		MaxImportGoroutinesFactor: 1,
 	}, &fakeRemoteClient{},
 		&fakeNodeResolver{}, nil)
 	repo.SetSchemaGetter(schemaGetter)
@@ -75,6 +76,7 @@ func TestBatchDeleteObjects(t *testing.T) {
 		QueryMaximumResults:       10000,
 		DiskUseWarningPercentage:  config.DefaultDiskUseWarningPercentage,
 		DiskUseReadOnlyPercentage: config.DefaultDiskUseReadonlyPercentage,
+		MaxImportGoroutinesFactor: 1,
 	}, &fakeRemoteClient{}, &fakeNodeResolver{}, nil)
 	repo.SetSchemaGetter(schemaGetter)
 	err := repo.WaitForStartup(testCtx())
@@ -100,6 +102,7 @@ func TestBatchDeleteObjects_Journey(t *testing.T) {
 		QueryMaximumResults:       queryMaximumResults,
 		DiskUseWarningPercentage:  config.DefaultDiskUseWarningPercentage,
 		DiskUseReadOnlyPercentage: config.DefaultDiskUseReadonlyPercentage,
+		MaxImportGoroutinesFactor: 1,
 	}, &fakeRemoteClient{}, &fakeNodeResolver{}, nil)
 	repo.SetSchemaGetter(schemaGetter)
 	err := repo.WaitForStartup(testCtx())
@@ -114,7 +117,8 @@ func TestBatchDeleteObjects_Journey(t *testing.T) {
 }
 
 func testAddBatchObjectClass(repo *DB, migrator *Migrator,
-	schemaGetter *fakeSchemaGetter) func(t *testing.T) {
+	schemaGetter *fakeSchemaGetter,
+) func(t *testing.T) {
 	return func(t *testing.T) {
 		class := &models.Class{
 			Class:               "ThingForBatching",

--- a/adapters/repos/db/batch_reference_integration_test.go
+++ b/adapters/repos/db/batch_reference_integration_test.go
@@ -47,6 +47,7 @@ func Test_AddingReferencesInBatches(t *testing.T) {
 		QueryMaximumResults:       10000,
 		DiskUseWarningPercentage:  config.DefaultDiskUseWarningPercentage,
 		DiskUseReadOnlyPercentage: config.DefaultDiskUseReadonlyPercentage,
+		MaxImportGoroutinesFactor: 1,
 	}, &fakeRemoteClient{},
 		&fakeNodeResolver{}, nil)
 	repo.SetSchemaGetter(schemaGetter)

--- a/adapters/repos/db/classification_integration_test.go
+++ b/adapters/repos/db/classification_integration_test.go
@@ -45,6 +45,7 @@ func TestClassifications(t *testing.T) {
 		QueryMaximumResults:       10000,
 		DiskUseWarningPercentage:  config.DefaultDiskUseWarningPercentage,
 		DiskUseReadOnlyPercentage: config.DefaultDiskUseReadonlyPercentage,
+		MaxImportGoroutinesFactor: 1,
 	}, &fakeRemoteClient{}, &fakeNodeResolver{}, nil)
 	repo.SetSchemaGetter(schemaGetter)
 	err := repo.WaitForStartup(testCtx())

--- a/adapters/repos/db/clusterintegrationtest/cluster_integration_test.go
+++ b/adapters/repos/db/clusterintegrationtest/cluster_integration_test.go
@@ -690,7 +690,8 @@ type node struct {
 }
 
 func (n *node) init(numberOfNodes int, dirName string, shardStateRaw []byte,
-	allNodes *[]*node) {
+	allNodes *[]*node,
+) {
 	localDir := path.Join(dirName, n.name)
 	logger, _ := test.NewNullLogger()
 
@@ -710,6 +711,7 @@ func (n *node) init(numberOfNodes int, dirName string, shardStateRaw []byte,
 		QueryMaximumResults:       10000,
 		DiskUseWarningPercentage:  config.DefaultDiskUseWarningPercentage,
 		DiskUseReadOnlyPercentage: config.DefaultDiskUseReadonlyPercentage,
+		MaxImportGoroutinesFactor: 1,
 	}, client, nodeResolver, nil)
 	n.schemaGetter = &fakeSchemaGetter{
 		shardState: shardState,
@@ -935,7 +937,8 @@ func exampleDataWithRefs(size int, refCount int, targetObjs []*models.Object) []
 }
 
 func bruteForceObjectsByQuery(objs []*models.Object,
-	query []float32) []*models.Object {
+	query []float32,
+) []*models.Object {
 	type distanceAndObj struct {
 		distance float32
 		obj      *models.Object
@@ -980,7 +983,8 @@ func normalize(v []float32) []float32 {
 
 func manuallyResolveRef(t *testing.T, obj *models.Object,
 	possibleTargets []*models.Object, localPropName,
-	referencedPropName string) []map[string]interface{} {
+	referencedPropName string,
+) []map[string]interface{} {
 	beacons := obj.Properties.(map[string]interface{})[localPropName].(models.MultipleRef)
 	out := make([]map[string]interface{}, len(beacons))
 

--- a/adapters/repos/db/crud_deletion_integration_test.go
+++ b/adapters/repos/db/crud_deletion_integration_test.go
@@ -42,6 +42,7 @@ func TestDeleteJourney(t *testing.T) {
 		QueryMaximumResults:       10000,
 		DiskUseWarningPercentage:  config.DefaultDiskUseWarningPercentage,
 		DiskUseReadOnlyPercentage: config.DefaultDiskUseReadonlyPercentage,
+		MaxImportGoroutinesFactor: 1,
 	}, &fakeRemoteClient{}, &fakeNodeResolver{}, nil)
 	repo.SetSchemaGetter(schemaGetter)
 	err := repo.WaitForStartup(testCtx())

--- a/adapters/repos/db/crud_integration_test.go
+++ b/adapters/repos/db/crud_integration_test.go
@@ -91,6 +91,7 @@ func TestCRUD(t *testing.T) {
 		QueryMaximumResults:       10,
 		DiskUseWarningPercentage:  config.DefaultDiskUseWarningPercentage,
 		DiskUseReadOnlyPercentage: config.DefaultDiskUseReadonlyPercentage,
+		MaxImportGoroutinesFactor: 1,
 	}, &fakeRemoteClient{}, &fakeNodeResolver{}, nil)
 	repo.SetSchemaGetter(schemaGetter)
 	err := repo.WaitForStartup(testCtx())
@@ -1278,6 +1279,7 @@ func Test_ImportWithoutVector_UpdateWithVectorLater(t *testing.T) {
 		QueryMaximumResults:       10000,
 		DiskUseWarningPercentage:  config.DefaultDiskUseWarningPercentage,
 		DiskUseReadOnlyPercentage: config.DefaultDiskUseReadonlyPercentage,
+		MaxImportGoroutinesFactor: 1,
 	}, &fakeRemoteClient{}, &fakeNodeResolver{}, nil)
 	repo.SetSchemaGetter(schemaGetter)
 	err := repo.WaitForStartup(testCtx())
@@ -1437,6 +1439,7 @@ func TestVectorSearch_ByDistance(t *testing.T) {
 		QueryMaximumResults:       1,
 		DiskUseWarningPercentage:  config.DefaultDiskUseWarningPercentage,
 		DiskUseReadOnlyPercentage: config.DefaultDiskUseReadonlyPercentage,
+		MaxImportGoroutinesFactor: 1,
 	}, &fakeRemoteClient{}, &fakeNodeResolver{}, nil)
 	repo.SetSchemaGetter(schemaGetter)
 	err := repo.WaitForStartup(testCtx())
@@ -1573,6 +1576,7 @@ func TestVectorSearch_ByCertainty(t *testing.T) {
 		QueryMaximumResults:       1,
 		DiskUseWarningPercentage:  config.DefaultDiskUseWarningPercentage,
 		DiskUseReadOnlyPercentage: config.DefaultDiskUseReadonlyPercentage,
+		MaxImportGoroutinesFactor: 1,
 	}, &fakeRemoteClient{}, &fakeNodeResolver{}, nil)
 	repo.SetSchemaGetter(schemaGetter)
 	err := repo.WaitForStartup(testCtx())
@@ -1718,6 +1722,7 @@ func Test_PutPatchRestart(t *testing.T) {
 		QueryMaximumResults:       100,
 		DiskUseWarningPercentage:  config.DefaultDiskUseWarningPercentage,
 		DiskUseReadOnlyPercentage: config.DefaultDiskUseReadonlyPercentage,
+		MaxImportGoroutinesFactor: 1,
 	}, &fakeRemoteClient{}, &fakeNodeResolver{}, nil)
 	repo.SetSchemaGetter(schemaGetter)
 	err := repo.WaitForStartup(ctx)

--- a/adapters/repos/db/crud_noindex_property_integration_test.go
+++ b/adapters/repos/db/crud_noindex_property_integration_test.go
@@ -60,6 +60,7 @@ func TestCRUD_NoIndexProp(t *testing.T) {
 		QueryMaximumResults:       10000,
 		DiskUseWarningPercentage:  config.DefaultDiskUseWarningPercentage,
 		DiskUseReadOnlyPercentage: config.DefaultDiskUseReadonlyPercentage,
+		MaxImportGoroutinesFactor: 1,
 	}, &fakeRemoteClient{}, &fakeNodeResolver{}, nil)
 	repo.SetSchemaGetter(schemaGetter)
 	err := repo.WaitForStartup(testCtx())

--- a/adapters/repos/db/crud_references_integration_test.go
+++ b/adapters/repos/db/crud_references_integration_test.go
@@ -121,6 +121,7 @@ func TestNestedReferences(t *testing.T) {
 		RootPath:                  dirName,
 		DiskUseWarningPercentage:  config.DefaultDiskUseWarningPercentage,
 		DiskUseReadOnlyPercentage: config.DefaultDiskUseReadonlyPercentage,
+		MaxImportGoroutinesFactor: 1,
 	}, &fakeRemoteClient{}, &fakeNodeResolver{}, nil)
 	repo.SetSchemaGetter(schemaGetter)
 	err := repo.WaitForStartup(testCtx())
@@ -458,6 +459,7 @@ func Test_AddingReferenceOneByOne(t *testing.T) {
 		RootPath:                  dirName,
 		DiskUseWarningPercentage:  config.DefaultDiskUseWarningPercentage,
 		DiskUseReadOnlyPercentage: config.DefaultDiskUseReadonlyPercentage,
+		MaxImportGoroutinesFactor: 1,
 	}, &fakeRemoteClient{}, &fakeNodeResolver{}, nil)
 	repo.SetSchemaGetter(schemaGetter)
 	err := repo.WaitForStartup(testCtx())

--- a/adapters/repos/db/crud_references_multiple_types_integration_test.go
+++ b/adapters/repos/db/crud_references_multiple_types_integration_test.go
@@ -41,6 +41,7 @@ func TestMultipleCrossRefTypes(t *testing.T) {
 		RootPath:                  dirName,
 		DiskUseWarningPercentage:  config.DefaultDiskUseWarningPercentage,
 		DiskUseReadOnlyPercentage: config.DefaultDiskUseReadonlyPercentage,
+		MaxImportGoroutinesFactor: 1,
 	}, &fakeRemoteClient{}, &fakeNodeResolver{}, nil)
 	repo.SetSchemaGetter(schemaGetter)
 	err := repo.WaitForStartup(testCtx())

--- a/adapters/repos/db/crud_update_integration_test.go
+++ b/adapters/repos/db/crud_update_integration_test.go
@@ -51,6 +51,7 @@ func TestUpdateJourney(t *testing.T) {
 		QueryMaximumResults:       10000,
 		DiskUseWarningPercentage:  config.DefaultDiskUseWarningPercentage,
 		DiskUseReadOnlyPercentage: config.DefaultDiskUseReadonlyPercentage,
+		MaxImportGoroutinesFactor: 1,
 	}, &fakeRemoteClient{}, &fakeNodeResolver{}, nil)
 	repo.SetSchemaGetter(schemaGetter)
 	err := repo.WaitForStartup(testCtx())

--- a/adapters/repos/db/delete_filter_integration_test.go
+++ b/adapters/repos/db/delete_filter_integration_test.go
@@ -64,6 +64,7 @@ func Test_FilterSearchesOnDeletedDocIDsWithLimits(t *testing.T) {
 		QueryMaximumResults:       10000,
 		DiskUseWarningPercentage:  config.DefaultDiskUseWarningPercentage,
 		DiskUseReadOnlyPercentage: config.DefaultDiskUseReadonlyPercentage,
+		MaxImportGoroutinesFactor: 1,
 	}, &fakeRemoteClient{}, &fakeNodeResolver{}, nil)
 	repo.SetSchemaGetter(schemaGetter)
 	err := repo.WaitForStartup(testCtx())
@@ -179,6 +180,7 @@ func TestLimitOneAfterDeletion(t *testing.T) {
 		QueryMaximumResults:       10000,
 		DiskUseWarningPercentage:  config.DefaultDiskUseWarningPercentage,
 		DiskUseReadOnlyPercentage: config.DefaultDiskUseReadonlyPercentage,
+		MaxImportGoroutinesFactor: 1,
 	}, &fakeRemoteClient{}, &fakeNodeResolver{}, nil)
 	repo.SetSchemaGetter(schemaGetter)
 	err := repo.WaitForStartup(testCtx())

--- a/adapters/repos/db/filters_integration_test.go
+++ b/adapters/repos/db/filters_integration_test.go
@@ -45,6 +45,7 @@ func TestFilters(t *testing.T) {
 		QueryMaximumResults:       10000,
 		DiskUseWarningPercentage:  config.DefaultDiskUseWarningPercentage,
 		DiskUseReadOnlyPercentage: config.DefaultDiskUseReadonlyPercentage,
+		MaxImportGoroutinesFactor: 1,
 	}, &fakeRemoteClient{}, &fakeNodeResolver{}, nil)
 	repo.SetSchemaGetter(schemaGetter)
 	err := repo.WaitForStartup(testCtx())
@@ -92,7 +93,8 @@ var (
 )
 
 func prepareCarTestSchemaAndData(repo *DB,
-	migrator *Migrator, schemaGetter *fakeSchemaGetter) func(t *testing.T) {
+	migrator *Migrator, schemaGetter *fakeSchemaGetter,
+) func(t *testing.T) {
 	return func(t *testing.T) {
 		t.Run("creating the class", func(t *testing.T) {
 			require.Nil(t,
@@ -444,7 +446,8 @@ func testPrimitivePropsWithLimit(repo *DB) func(t *testing.T) {
 }
 
 func testChainedPrimitiveProps(repo *DB,
-	migrator *Migrator) func(t *testing.T) {
+	migrator *Migrator,
+) func(t *testing.T) {
 	return func(t *testing.T) {
 		type test struct {
 			name        string
@@ -552,7 +555,8 @@ func buildSortFilter(path []string, order string) filters.Sort {
 }
 
 func compoundFilter(operator filters.Operator,
-	operands ...*filters.LocalFilter) *filters.LocalFilter {
+	operands ...*filters.LocalFilter,
+) *filters.LocalFilter {
 	clauses := make([]filters.Clause, len(operands), len(operands))
 	for i, filter := range operands {
 		clauses[i] = *filter.Root
@@ -730,6 +734,7 @@ func TestGeoPropUpdateJourney(t *testing.T) {
 		QueryMaximumResults:       10000,
 		DiskUseWarningPercentage:  config.DefaultDiskUseWarningPercentage,
 		DiskUseReadOnlyPercentage: config.DefaultDiskUseReadonlyPercentage,
+		MaxImportGoroutinesFactor: 1,
 	}, &fakeRemoteClient{}, &fakeNodeResolver{}, nil)
 	repo.SetSchemaGetter(schemaGetter)
 	err := repo.WaitForStartup(testCtx())
@@ -839,6 +844,7 @@ func TestCasingOfOperatorCombinations(t *testing.T) {
 		QueryMaximumResults:       10000,
 		DiskUseWarningPercentage:  config.DefaultDiskUseWarningPercentage,
 		DiskUseReadOnlyPercentage: config.DefaultDiskUseReadonlyPercentage,
+		MaxImportGoroutinesFactor: 1,
 	}, &fakeRemoteClient{}, &fakeNodeResolver{}, nil)
 	repo.SetSchemaGetter(schemaGetter)
 	err := repo.WaitForStartup(testCtx())

--- a/adapters/repos/db/filters_limits_integration_test.go
+++ b/adapters/repos/db/filters_limits_integration_test.go
@@ -48,6 +48,7 @@ func Test_LimitsOnChainedFilters(t *testing.T) {
 		QueryMaximumResults:       10000,
 		DiskUseWarningPercentage:  config.DefaultDiskUseWarningPercentage,
 		DiskUseReadOnlyPercentage: config.DefaultDiskUseReadonlyPercentage,
+		MaxImportGoroutinesFactor: 1,
 	}, &fakeRemoteClient{}, &fakeNodeResolver{}, nil)
 	repo.SetSchemaGetter(schemaGetter)
 	err := repo.WaitForStartup(testCtx())
@@ -145,6 +146,7 @@ func Test_FilterLimitsAfterUpdates(t *testing.T) {
 		QueryMaximumResults:       10000,
 		DiskUseWarningPercentage:  config.DefaultDiskUseWarningPercentage,
 		DiskUseReadOnlyPercentage: config.DefaultDiskUseReadonlyPercentage,
+		MaxImportGoroutinesFactor: 1,
 	}, &fakeRemoteClient{}, &fakeNodeResolver{}, nil)
 	repo.SetSchemaGetter(schemaGetter)
 	err := repo.WaitForStartup(testCtx())
@@ -271,6 +273,7 @@ func Test_AggregationsAfterUpdates(t *testing.T) {
 		QueryMaximumResults:       10000,
 		DiskUseWarningPercentage:  config.DefaultDiskUseWarningPercentage,
 		DiskUseReadOnlyPercentage: config.DefaultDiskUseReadonlyPercentage,
+		MaxImportGoroutinesFactor: 1,
 	}, &fakeRemoteClient{}, &fakeNodeResolver{}, nil)
 	repo.SetSchemaGetter(schemaGetter)
 	err := repo.WaitForStartup(testCtx())

--- a/adapters/repos/db/filters_on_refs_integration_test.go
+++ b/adapters/repos/db/filters_on_refs_integration_test.go
@@ -46,6 +46,7 @@ func TestRefFilters(t *testing.T) {
 		QueryMaximumResults:       10000,
 		DiskUseWarningPercentage:  config.DefaultDiskUseWarningPercentage,
 		DiskUseReadOnlyPercentage: config.DefaultDiskUseReadonlyPercentage,
+		MaxImportGoroutinesFactor: 1,
 	}, &fakeRemoteClient{}, &fakeNodeResolver{}, nil)
 	repo.SetSchemaGetter(schemaGetter)
 	err := repo.WaitForStartup(testCtx())
@@ -467,6 +468,7 @@ func TestRefFilters_MergingWithAndOperator(t *testing.T) {
 		QueryMaximumResults:       10000,
 		DiskUseWarningPercentage:  config.DefaultDiskUseWarningPercentage,
 		DiskUseReadOnlyPercentage: config.DefaultDiskUseReadonlyPercentage,
+		MaxImportGoroutinesFactor: 1,
 	}, &fakeRemoteClient{}, &fakeNodeResolver{}, nil)
 	repo.SetSchemaGetter(schemaGetter)
 	err := repo.WaitForStartup(testCtx())
@@ -670,7 +672,8 @@ func TestRefFilters_MergingWithAndOperator(t *testing.T) {
 }
 
 func filterCarParkedAtGarage(dataType schema.DataType,
-	prop string, operator filters.Operator, value interface{}) *filters.LocalFilter {
+	prop string, operator filters.Operator, value interface{},
+) *filters.LocalFilter {
 	return &filters.LocalFilter{
 		Root: &filters.Clause{
 			Operator: operator,
@@ -707,7 +710,8 @@ func filterCarParkedCount(operator filters.Operator, value int) *filters.LocalFi
 }
 
 func filterDrivesCarParkedAtGarage(dataType schema.DataType,
-	prop string, operator filters.Operator, value interface{}) *filters.LocalFilter {
+	prop string, operator filters.Operator, value interface{},
+) *filters.LocalFilter {
 	return &filters.LocalFilter{
 		Root: &filters.Clause{
 			Operator: operator,

--- a/adapters/repos/db/helper_for_test.go
+++ b/adapters/repos/db/helper_for_test.go
@@ -212,7 +212,7 @@ func testShard(t *testing.T, ctx context.Context, className string, indexOpts ..
 	schemaGetter := &fakeSchemaGetter{shardState: shardState, schema: sch}
 
 	idx := &Index{
-		Config:                IndexConfig{RootPath: tmpDir, ClassName: schema.ClassName(className)},
+		Config:                IndexConfig{RootPath: tmpDir, ClassName: schema.ClassName(className), MaxImportGoroutinesFactor: 1.5},
 		invertedIndexConfig:   schema.InvertedIndexConfig{CleanupIntervalSeconds: 1},
 		vectorIndexUserConfig: hnsw.UserConfig{Skip: true},
 		logger:                logrus.New(),
@@ -273,5 +273,4 @@ func createRandomObjects(className string, numObj int) []*storobj.Object {
 		}
 	}
 	return obj
-
 }

--- a/adapters/repos/db/helper_for_test.go
+++ b/adapters/repos/db/helper_for_test.go
@@ -258,3 +258,20 @@ func testObject(className string) *storobj.Object {
 		Vector: []float32{1, 2, 3},
 	}
 }
+
+func createRandomObjects(className string, numObj int) []*storobj.Object {
+	obj := make([]*storobj.Object, numObj)
+
+	for i := 0; i < numObj; i++ {
+		obj[i] = &storobj.Object{
+			MarshallerVersion: 1,
+			Object: models.Object{
+				ID:    strfmt.UUID(uuid.NewString()),
+				Class: className,
+			},
+			Vector: []float32{rand.Float32(), rand.Float32(), rand.Float32(), rand.Float32()},
+		}
+	}
+	return obj
+
+}

--- a/adapters/repos/db/index.go
+++ b/adapters/repos/db/index.go
@@ -194,6 +194,7 @@ type IndexConfig struct {
 	QueryMaximumResults       int64
 	DiskUseWarningPercentage  uint64
 	DiskUseReadOnlyPercentage uint64
+	MaxImportGoroutinesFactor float64
 }
 
 func indexID(class schema.ClassName) string {

--- a/adapters/repos/db/init.go
+++ b/adapters/repos/db/init.go
@@ -55,6 +55,7 @@ func (d *DB) init(ctx context.Context) error {
 				DiskUseWarningPercentage:  d.config.DiskUseWarningPercentage,
 				DiskUseReadOnlyPercentage: d.config.DiskUseReadOnlyPercentage,
 				QueryMaximumResults:       d.config.QueryMaximumResults,
+				MaxImportGoroutinesFactor: d.config.MaxImportGoroutinesFactor,
 			}, d.schemaGetter.ShardingState(class.Class),
 				inverted.ConfigFromModel(invertedConfig),
 				class.VectorIndexConfig.(schema.VectorIndexConfig),

--- a/adapters/repos/db/inverted_index_integration_test.go
+++ b/adapters/repos/db/inverted_index_integration_test.go
@@ -46,6 +46,7 @@ func TestIndexByTimestamps_AddClass(t *testing.T) {
 		QueryMaximumResults:       10000,
 		DiskUseWarningPercentage:  config.DefaultDiskUseWarningPercentage,
 		DiskUseReadOnlyPercentage: config.DefaultDiskUseReadonlyPercentage,
+		MaxImportGoroutinesFactor: 1,
 	}, &fakeRemoteClient{}, &fakeNodeResolver{}, nil)
 	repo.SetSchemaGetter(schemaGetter)
 	err := repo.WaitForStartup(testCtx())
@@ -131,6 +132,7 @@ func TestIndexByTimestamps_GetClass(t *testing.T) {
 		QueryMaximumResults:       10000,
 		DiskUseWarningPercentage:  config.DefaultDiskUseWarningPercentage,
 		DiskUseReadOnlyPercentage: config.DefaultDiskUseReadonlyPercentage,
+		MaxImportGoroutinesFactor: 1,
 	}, &fakeRemoteClient{}, &fakeNodeResolver{}, nil)
 	repo.SetSchemaGetter(schemaGetter)
 	err := repo.WaitForStartup(testCtx())

--- a/adapters/repos/db/merge_integration_test.go
+++ b/adapters/repos/db/merge_integration_test.go
@@ -44,6 +44,7 @@ func Test_MergingObjects(t *testing.T) {
 		RootPath:                  dirName,
 		DiskUseWarningPercentage:  config.DefaultDiskUseWarningPercentage,
 		DiskUseReadOnlyPercentage: config.DefaultDiskUseReadonlyPercentage,
+		MaxImportGoroutinesFactor: 1,
 	}, &fakeRemoteClient{}, &fakeNodeResolver{}, nil)
 	repo.SetSchemaGetter(schemaGetter)
 	err := repo.WaitForStartup(testCtx())

--- a/adapters/repos/db/migrator.go
+++ b/adapters/repos/db/migrator.go
@@ -38,6 +38,7 @@ func (m *Migrator) AddClass(ctx context.Context, class *models.Class,
 			DiskUseWarningPercentage:  m.db.config.DiskUseWarningPercentage,
 			DiskUseReadOnlyPercentage: m.db.config.DiskUseReadOnlyPercentage,
 			QueryMaximumResults:       m.db.config.QueryMaximumResults,
+			MaxImportGoroutinesFactor: m.db.config.MaxImportGoroutinesFactor,
 		},
 		shardState,
 		// no backward-compatibility check required, since newly added classes will

--- a/adapters/repos/db/multi_shard_integration_test.go
+++ b/adapters/repos/db/multi_shard_integration_test.go
@@ -278,6 +278,7 @@ func setupMultiShardTest(t *testing.T) (*DB, *logrus.Logger) {
 		QueryMaximumResults:       10000,
 		DiskUseWarningPercentage:  config.DefaultDiskUseWarningPercentage,
 		DiskUseReadOnlyPercentage: config.DefaultDiskUseReadonlyPercentage,
+		MaxImportGoroutinesFactor: 1,
 	}, &fakeRemoteClient{}, &fakeNodeResolver{}, nil)
 
 	return repo, logger
@@ -313,7 +314,8 @@ func makeTestMultiShardSchema(repo *DB, logger logrus.FieldLogger, fixedShardSta
 }
 
 func makeTestRetrievingBaseClass(repo *DB, data []*models.Object,
-	queryVec []float32, groundTruth []*models.Object) func(t *testing.T) {
+	queryVec []float32, groundTruth []*models.Object,
+) func(t *testing.T) {
 	return func(t *testing.T) {
 		t.Run("retrieve all individually", func(t *testing.T) {
 			for _, desired := range data {
@@ -535,12 +537,12 @@ func makeTestSortingClass(repo *DB) func(t *testing.T) {
 				{
 					name:                   "textArrayProp desc",
 					sort:                   []filters.Sort{{Path: []string{"textArrayProp"}, Order: "desc"}},
-					expectedTextArrayProps: [][]string{[]string{"s19", "19"}, []string{"s18", "18"}, []string{"s17", "17"}, []string{"s16", "16"}, []string{"s15", "15"}, []string{"s14", "14"}, []string{"s13", "13"}, []string{"s12", "12"}, []string{"s11", "11"}, []string{"s10", "10"}, []string{"s09", "09"}, []string{"s08", "08"}, []string{"s07", "07"}, []string{"s06", "06"}, []string{"s05", "05"}, []string{"s04", "04"}, []string{"s03", "03"}, []string{"s02", "02"}, []string{"s01", "01"}, []string{"s00", "00"}},
+					expectedTextArrayProps: [][]string{{"s19", "19"}, {"s18", "18"}, {"s17", "17"}, {"s16", "16"}, {"s15", "15"}, {"s14", "14"}, {"s13", "13"}, {"s12", "12"}, {"s11", "11"}, {"s10", "10"}, {"s09", "09"}, {"s08", "08"}, {"s07", "07"}, {"s06", "06"}, {"s05", "05"}, {"s04", "04"}, {"s03", "03"}, {"s02", "02"}, {"s01", "01"}, {"s00", "00"}},
 				},
 				{
 					name:                   "textArrayProp asc",
 					sort:                   []filters.Sort{{Path: []string{"textArrayProp"}, Order: "asc"}},
-					expectedTextArrayProps: [][]string{[]string{"s00", "00"}, []string{"s01", "01"}, []string{"s02", "02"}, []string{"s03", "03"}, []string{"s04", "04"}, []string{"s05", "05"}, []string{"s06", "06"}, []string{"s07", "07"}, []string{"s08", "08"}, []string{"s09", "09"}, []string{"s10", "10"}, []string{"s11", "11"}, []string{"s12", "12"}, []string{"s13", "13"}, []string{"s14", "14"}, []string{"s15", "15"}, []string{"s16", "16"}, []string{"s17", "17"}, []string{"s18", "18"}, []string{"s19", "19"}},
+					expectedTextArrayProps: [][]string{{"s00", "00"}, {"s01", "01"}, {"s02", "02"}, {"s03", "03"}, {"s04", "04"}, {"s05", "05"}, {"s06", "06"}, {"s07", "07"}, {"s08", "08"}, {"s09", "09"}, {"s10", "10"}, {"s11", "11"}, {"s12", "12"}, {"s13", "13"}, {"s14", "14"}, {"s15", "15"}, {"s16", "16"}, {"s17", "17"}, {"s18", "18"}, {"s19", "19"}},
 				},
 				{
 					name:              "boolProp desc",
@@ -749,7 +751,8 @@ func multiShardRefClassData(targets []*models.Object) []*models.Object {
 }
 
 func bruteForceObjectsByQuery(objs []*models.Object,
-	query []float32) []*models.Object {
+	query []float32,
+) []*models.Object {
 	type distanceAndObj struct {
 		distance float32
 		obj      *models.Object

--- a/adapters/repos/db/repo.go
+++ b/adapters/repos/db/repo.go
@@ -72,6 +72,7 @@ type Config struct {
 	QueryMaximumResults       int64
 	DiskUseWarningPercentage  uint64
 	DiskUseReadOnlyPercentage uint64
+	MaxImportGoroutinesFactor float64
 }
 
 // GetIndex returns the index if it exists or nil if it doesn't

--- a/adapters/repos/db/restart_journey_integration_test.go
+++ b/adapters/repos/db/restart_journey_integration_test.go
@@ -56,6 +56,7 @@ func TestRestartJourney(t *testing.T) {
 		QueryMaximumResults:       10000,
 		DiskUseWarningPercentage:  config.DefaultDiskUseWarningPercentage,
 		DiskUseReadOnlyPercentage: config.DefaultDiskUseReadonlyPercentage,
+		MaxImportGoroutinesFactor: 1,
 	}, &fakeRemoteClient{}, &fakeNodeResolver{}, nil)
 	repo.SetSchemaGetter(schemaGetter)
 	err := repo.WaitForStartup(testCtx())
@@ -175,6 +176,7 @@ func TestRestartJourney(t *testing.T) {
 			QueryMaximumResults:       10000,
 			DiskUseWarningPercentage:  config.DefaultDiskUseWarningPercentage,
 			DiskUseReadOnlyPercentage: config.DefaultDiskUseReadonlyPercentage,
+			MaxImportGoroutinesFactor: 1,
 		}, &fakeRemoteClient{}, &fakeNodeResolver{}, nil)
 		newRepo.SetSchemaGetter(schemaGetter)
 		err := newRepo.WaitForStartup(testCtx())

--- a/adapters/repos/db/shard_test.go
+++ b/adapters/repos/db/shard_test.go
@@ -182,15 +182,9 @@ func TestShard_ParallelBatches(t *testing.T) {
 	}
 
 	batches := make([][]*storobj.Object, 4)
-	wgAdd := sync.WaitGroup{}
-	wgAdd.Add(len(batches))
 	for i := range batches {
-		go func() {
-			batches[i] = createRandomObjects("TestClass", 1000)
-			wgAdd.Done()
-		}()
+		batches[i] = createRandomObjects("TestClass", 1000)
 	}
-	wgAdd.Wait()
 	totalObjects := 1000 * len(batches)
 	for _, tt := range parallelTests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -205,10 +199,10 @@ func TestShard_ParallelBatches(t *testing.T) {
 			wg := sync.WaitGroup{}
 			wg.Add(len(batches))
 			for _, batch := range batches {
-				go func() {
-					shd.putObjectBatch(ctx, batch)
+				go func(localBatch []*storobj.Object) {
+					shd.putObjectBatch(ctx, localBatch)
 					wg.Done()
-				}()
+				}(batch)
 			}
 			wg.Wait()
 

--- a/adapters/repos/db/shard_write_batch_objects.go
+++ b/adapters/repos/db/shard_write_batch_objects.go
@@ -13,7 +13,6 @@ package db
 
 import (
 	"context"
-	"runtime"
 	"sync"
 	"time"
 
@@ -32,7 +31,66 @@ func (s *Shard) putObjectBatch(ctx context.Context,
 		return []error{storagestate.ErrStatusReadOnly}
 	}
 
-	return newObjectsBatcher(s).Objects(ctx, objects)
+	// Workers are started with the first batch and keep working as there are objects to add from any batch. Each batch
+	// adds its jobs (that contain the respective object) to a single queue that is then processed by the workers.
+	// When the last batch finishes, all workers receive a shutdown signal and exit
+	s.startBatch()
+	batcher := newObjectsBatcher(s)
+	err := batcher.Objects(ctx, objects)
+
+	// block until all objects of batch have been added
+	batcher.wg.Wait()
+	s.endBatch()
+
+	return err
+}
+
+func (s *Shard) startBatch() {
+	s.activeBatchesLock.Lock()
+	s.numActiveBatches += 1
+
+	// start workers in go routines that can be used by all batches
+	if s.numActiveBatches == 1 {
+		s.shutDownWg.Wait() // wait until any shutdown job is completed
+		if s.promMetrics != nil {
+			s.promMetrics.GoroutinesCount.WithLabelValues("object batcher", "").Add(float64(s.maxNumberGoroutines))
+		}
+		for i := 0; i < s.maxNumberGoroutines; i++ {
+			go s.worker()
+		}
+		s.shutDownWg.Add(s.maxNumberGoroutines)
+	}
+	s.activeBatchesLock.Unlock()
+}
+
+func (s *Shard) endBatch() {
+	s.activeBatchesLock.Lock()
+	s.numActiveBatches -= 1
+
+	// send abort jobs and wait for all workers to end (and finish all jobs before)
+	if s.numActiveBatches == 0 {
+		for i := 0; i < s.maxNumberGoroutines; i++ {
+			s.jobQueueCh <- job{
+				index: -1,
+			}
+		}
+		if s.promMetrics != nil {
+			s.promMetrics.GoroutinesCount.WithLabelValues("object batcher", "").Sub(float64(s.maxNumberGoroutines))
+		}
+	}
+
+	s.activeBatchesLock.Unlock()
+}
+
+func (s *Shard) worker() {
+	for job := range s.jobQueueCh {
+		if job.index < 0 {
+			s.shutDownWg.Done()
+			return
+		}
+		job.batcher.storeSingleObjectInAdditionalStorage(job.ctx, job.object, job.status, job.index)
+		job.batcher.wg.Done()
+	}
 }
 
 // objectsBatcher is a helper type wrapping around an underlying shard that can
@@ -45,6 +103,7 @@ type objectsBatcher struct {
 	errs       []error
 	duplicates map[int]struct{}
 	objects    []*storobj.Object
+	wg         sync.WaitGroup
 }
 
 func newObjectsBatcher(s *Shard) *objectsBatcher {
@@ -157,12 +216,6 @@ func (b *objectsBatcher) setStatusForID(status objectInsertStatus, id strfmt.UUI
 	b.statuses[id] = status
 }
 
-type job struct {
-	object *storobj.Object
-	status objectInsertStatus
-	index  int
-}
-
 // storeAdditionalStorageWithWorkers stores the object in all non-key-value
 // stores, such as the main vector index as well as the property-specific
 // indices, such as the geo-index.
@@ -173,38 +226,24 @@ func (b *objectsBatcher) storeAdditionalStorageWithWorkers(ctx context.Context) 
 		return
 	}
 
-	wg := &sync.WaitGroup{}
-	worker := func(jobs <-chan job) {
-		defer wg.Done()
-		for job := range jobs {
-			b.storeSingleObjectInAdditionalStorage(ctx, job.object, job.status, job.index)
-		}
-	}
-
 	beforeVectorIndex := time.Now()
-
-	jobs := make(chan job, len(b.objects))
-
-	// spawn one worker per thread
-	for i := 0; i < runtime.GOMAXPROCS(0); i++ {
-		wg.Add(1)
-		go worker(jobs)
-	}
 
 	for i, object := range b.objects {
 		if b.shouldSkipInAdditionalStorage(i) {
 			continue
 		}
 
+		b.wg.Add(1)
 		status := b.statuses[object.ID()]
-		jobs <- job{
-			object: object,
-			status: status,
-			index:  i,
+		b.shard.jobQueueCh <- job{
+			object:  object,
+			status:  status,
+			index:   i,
+			ctx:     ctx,
+			batcher: b,
 		}
 	}
-	close(jobs)
-	wg.Wait()
+
 	b.shard.metrics.VectorIndex(beforeVectorIndex)
 }
 

--- a/test/benchmark/benchmark.go
+++ b/test/benchmark/benchmark.go
@@ -34,15 +34,15 @@ type batch struct {
 	Objects []*models.Object
 }
 
-type benchmarkResult map[string](map[string]int64)
+type benchmarkResult map[string]map[string]int64
 
 func main() {
 	var benchmarkName string
-	var failPercentage int
-	var maxEntries int
+	var numBatches, failPercentage, maxEntries int
 
 	flag.StringVar(&benchmarkName, "name", "SIFT", "Which benchmark should be run. Currently only SIFT is available.")
 	flag.IntVar(&maxEntries, "numberEntries", 100000, "Maximum number of entries read from the dataset")
+	flag.IntVar(&numBatches, "numBatches", 1, "With how many parallel batches objects should be added")
 	flag.IntVar(&failPercentage, "fail", -1, "Fail if regression is larger")
 	flag.Parse()
 
@@ -67,7 +67,7 @@ func main() {
 	var err error
 	switch benchmarkName {
 	case "SIFT":
-		newRuntime, err = benchmarkSift(c, url, maxEntries)
+		newRuntime, err = benchmarkSift(c, url, maxEntries, numBatches)
 	default:
 		panic("Unknown benchmark " + benchmarkName)
 	}
@@ -84,7 +84,7 @@ func main() {
 		panic(errors.Wrap(err, "Error occurred during benchmarking"))
 	}
 
-	FullBenchmarkName := benchmarkName + "-" + fmt.Sprint(maxEntries)
+	FullBenchmarkName := benchmarkName + "-" + fmt.Sprint(maxEntries) + "_Entries-" + fmt.Sprint(numBatches) + "_Batch(es)"
 
 	// Write results to file, keeping existing entries
 	oldBenchmarkRunTimes := readCurrentBenchmarkResults()

--- a/test/benchmark/run_performance_tracker.sh
+++ b/test/benchmark/run_performance_tracker.sh
@@ -3,4 +3,4 @@
 # change to script directory
 cd "${0%/*}" || exit
 
-go run . -name "SIFT" -numberEntries 100000 -fail "-1"
+go run . -name "SIFT" -numberEntries 100000 -fail "-1" -numBatches "1"

--- a/tools/dev/grafana/dashboards/vectorindex.json
+++ b/tools/dev/grafana/dashboards/vectorindex.json
@@ -3,7 +3,10 @@
     "list": [
       {
         "builtIn": 1,
-        "datasource": "-- Grafana --",
+        "datasource": {
+          "type": "datasource",
+          "uid": "grafana"
+        },
         "enable": true,
         "hide": true,
         "iconColor": "rgba(0, 211, 255, 1)",
@@ -67,8 +70,7 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green",
-                "value": null
+                "color": "green"
               },
               {
                 "color": "red",
@@ -93,7 +95,8 @@
           "placement": "bottom"
         },
         "tooltip": {
-          "mode": "single"
+          "mode": "single",
+          "sort": "none"
         }
       },
       "targets": [
@@ -240,7 +243,8 @@
           "placement": "bottom"
         },
         "tooltip": {
-          "mode": "single"
+          "mode": "single",
+          "sort": "none"
         }
       },
       "targets": [
@@ -254,6 +258,19 @@
           "interval": "",
           "legendFormat": "{{step}} ({{class_name}}/{{shard_name}})",
           "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "Prometheus"
+          },
+          "editorMode": "builder",
+          "expr": "concurrent_goroutines{class_name=\"object batcher\"}",
+          "hide": false,
+          "interval": "",
+          "legendFormat": "Concurrent goroutines",
+          "range": true,
+          "refId": "B"
         }
       ],
       "title": "Insert Operations",
@@ -302,8 +319,7 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green",
-                "value": null
+                "color": "green"
               },
               {
                 "color": "red",
@@ -328,7 +344,8 @@
           "placement": "bottom"
         },
         "tooltip": {
-          "mode": "single"
+          "mode": "single",
+          "sort": "none"
         }
       },
       "targets": [
@@ -348,7 +365,7 @@
       "type": "timeseries"
     }
   ],
-  "schemaVersion": 34,
+  "schemaVersion": 36,
   "style": "dark",
   "tags": [],
   "templating": {

--- a/usecases/classification/integrationtest/classifier_integration_test.go
+++ b/usecases/classification/integrationtest/classifier_integration_test.go
@@ -50,6 +50,7 @@ func Test_Classifier_KNN_SaveConsistency(t *testing.T) {
 		QueryMaximumResults:       10000,
 		DiskUseWarningPercentage:  config.DefaultDiskUseWarningPercentage,
 		DiskUseReadOnlyPercentage: config.DefaultDiskUseReadonlyPercentage,
+		MaxImportGoroutinesFactor: 1,
 	},
 		&fakeRemoteClient{}, &fakeNodeResolver{}, nil)
 	vrepo.SetSchemaGetter(sg)
@@ -192,6 +193,7 @@ func Test_Classifier_ZeroShot_SaveConsistency(t *testing.T) {
 		QueryMaximumResults:       10000,
 		DiskUseWarningPercentage:  config.DefaultDiskUseWarningPercentage,
 		DiskUseReadOnlyPercentage: config.DefaultDiskUseReadonlyPercentage,
+		MaxImportGoroutinesFactor: 1,
 	}, &fakeRemoteClient{}, &fakeNodeResolver{}, nil)
 	vrepo.SetSchemaGetter(sg)
 	err := vrepo.WaitForStartup(context.Background())

--- a/usecases/config/config_handler.go
+++ b/usecases/config/config_handler.go
@@ -47,6 +47,7 @@ const (
 const (
 	DefaultDiskUseWarningPercentage  = uint64(80)
 	DefaultDiskUseReadonlyPercentage = uint64(90)
+	DefaultMaxImportGoroutinesFactor = float64(1.5)
 )
 
 // Flags are input options
@@ -56,23 +57,24 @@ type Flags struct {
 
 // Config outline of the config file
 type Config struct {
-	Name                    string         `json:"name" yaml:"name"`
-	Debug                   bool           `json:"debug" yaml:"debug"`
-	QueryDefaults           QueryDefaults  `json:"query_defaults" yaml:"query_defaults"`
-	QueryMaximumResults     int64          `json:"query_maximum_results" yaml:"query_maximum_results"`
-	Contextionary           Contextionary  `json:"contextionary" yaml:"contextionary"`
-	Authentication          Authentication `json:"authentication" yaml:"authentication"`
-	Authorization           Authorization  `json:"authorization" yaml:"authorization"`
-	Origin                  string         `json:"origin" yaml:"origin"`
-	Persistence             Persistence    `json:"persistence" yaml:"persistence"`
-	DefaultVectorizerModule string         `json:"default_vectorizer_module" yaml:"default_vectorizer_module"`
-	EnableModules           string         `json:"enable_modules" yaml:"enable_modules"`
-	ModulesPath             string         `json:"modules_path" yaml:"modules_path"`
-	AutoSchema              AutoSchema     `json:"auto_schema" yaml:"auto_schema"`
-	Cluster                 cluster.Config `json:"cluster" yaml:"cluster"`
-	Monitoring              Monitoring     `json:"monitoring" yaml:"monitoring"`
-	Profiling               Profiling      `json:"profiling" yaml:"profiling"`
-	DiskUse                 DiskUse        `json:"disk_use" yaml:"disk_use"`
+	Name                      string         `json:"name" yaml:"name"`
+	Debug                     bool           `json:"debug" yaml:"debug"`
+	QueryDefaults             QueryDefaults  `json:"query_defaults" yaml:"query_defaults"`
+	QueryMaximumResults       int64          `json:"query_maximum_results" yaml:"query_maximum_results"`
+	Contextionary             Contextionary  `json:"contextionary" yaml:"contextionary"`
+	Authentication            Authentication `json:"authentication" yaml:"authentication"`
+	Authorization             Authorization  `json:"authorization" yaml:"authorization"`
+	Origin                    string         `json:"origin" yaml:"origin"`
+	Persistence               Persistence    `json:"persistence" yaml:"persistence"`
+	DefaultVectorizerModule   string         `json:"default_vectorizer_module" yaml:"default_vectorizer_module"`
+	EnableModules             string         `json:"enable_modules" yaml:"enable_modules"`
+	ModulesPath               string         `json:"modules_path" yaml:"modules_path"`
+	AutoSchema                AutoSchema     `json:"auto_schema" yaml:"auto_schema"`
+	Cluster                   cluster.Config `json:"cluster" yaml:"cluster"`
+	Monitoring                Monitoring     `json:"monitoring" yaml:"monitoring"`
+	Profiling                 Profiling      `json:"profiling" yaml:"profiling"`
+	DiskUse                   DiskUse        `json:"disk_use" yaml:"disk_use"`
+	MaxImportGoroutinesFactor float64        `json:"max_import_goroutine_factor" yaml:"max_import_goroutine_factor"`
 }
 
 type moduleProvider interface {

--- a/usecases/config/environment.go
+++ b/usecases/config/environment.go
@@ -130,6 +130,19 @@ func FromEnv(config *Config) error {
 		config.QueryMaximumResults = DefaultQueryMaximumResults
 	}
 
+	if v := os.Getenv("MAX_IMPORT_GOROUTINES_FACTOR"); v != "" {
+		asFloat, err := strconv.ParseFloat(v, 64)
+		if err != nil {
+			return errors.Wrapf(err, "parse MAX_IMPORT_GOROUTINES_FACTOR as float")
+		} else if asFloat <= 0 {
+			return errors.New("negative MAX_IMPORT_GOROUTINES_FACTOR factor")
+		}
+
+		config.MaxImportGoroutinesFactor = asFloat
+	} else {
+		config.MaxImportGoroutinesFactor = DefaultMaxImportGoroutinesFactor
+	}
+
 	if v := os.Getenv("DEFAULT_VECTORIZER_MODULE"); v != "" {
 		config.DefaultVectorizerModule = v
 	} else {

--- a/usecases/config/environment_test.go
+++ b/usecases/config/environment_test.go
@@ -1,0 +1,42 @@
+package config
+
+import (
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+const DefaultGoroutineFactor = 1.5
+
+func TestEnvironmentImportGoroutineFactor(t *testing.T) {
+	factors := []struct {
+		name            string
+		goroutineFactor []string
+		expected        float64
+		expectedErr     bool
+	}{
+		{"Valid factor", []string{"1"}, 1, false},
+		{"Low factor", []string{"0.5"}, 0.5, false},
+		{"not given", []string{}, DefaultGoroutineFactor, false},
+		{"High factor", []string{"5"}, 5, false},
+		{"invalid factor", []string{"-1"}, -1, true},
+		{"not parsable", []string{"I'm not a number"}, -1, true},
+	}
+	for _, tt := range factors {
+		t.Run(tt.name, func(t *testing.T) {
+			os.Clearenv()
+			if len(tt.goroutineFactor) == 1 {
+				os.Setenv("MAX_IMPORT_GOROUTINES_FACTOR", tt.goroutineFactor[0])
+			}
+			conf := Config{}
+			err := FromEnv(&conf)
+
+			if tt.expectedErr {
+				require.NotNil(t, err)
+			} else {
+				require.Equal(t, tt.expected, conf.MaxImportGoroutinesFactor)
+			}
+		})
+	}
+}

--- a/usecases/monitoring/prometheus.go
+++ b/usecases/monitoring/prometheus.go
@@ -37,6 +37,7 @@ type PrometheusMetrics struct {
 	VectorIndexMaintenanceDurations    *prometheus.HistogramVec
 	ObjectCount                        *prometheus.GaugeVec
 	QueriesCount                       *prometheus.GaugeVec
+	GoroutinesCount                    *prometheus.GaugeVec
 
 	StartupProgress  *prometheus.GaugeVec
 	StartupDurations *prometheus.HistogramVec
@@ -71,6 +72,11 @@ func NewPrometheusMetrics() *PrometheusMetrics { // TODO don't rely on global st
 		QueriesCount: promauto.NewGaugeVec(prometheus.GaugeOpts{
 			Name: "concurrent_queries_count",
 			Help: "Number of concurrently running query operations",
+		}, []string{"class_name", "query_type"}),
+
+		GoroutinesCount: promauto.NewGaugeVec(prometheus.GaugeOpts{
+			Name: "concurrent_goroutines",
+			Help: "Number of concurrently running goroutines",
 		}, []string{"class_name", "query_type"}),
 
 		AsyncOperations: promauto.NewGaugeVec(prometheus.GaugeOpts{


### PR DESCRIPTION
This PR adds

- (optional) Batching to the benchmark script
- Add thread pooling for batch requests.
- Add monitoring of how many goroutines are started to grafana

Tests with different numbers of parallel batches with the benchmarking script via the remote machine. This PR is slightly slower, however it scales better with more parallel queries. Note that on my macbook the effect was stronger, eg it was slower with one batch and scaled much better with multiple batches.

| nr batches   |   master  |        This PR  |
| ------------- | ------------- | ------------- |
| 1  | 15056ms  | 15479ms |
| 2  | 27252ms  | 27488ms  |
| 5  | 46213ms  | 40499ms  |

There is currently an environment variable MaxNumberGoroutinesFactor that controls how many goroutines with respect to the number of cores are started. Not sure if this should be merged :)


Here is the profiling output (from my machine), I don't have a good idea why the PR is slower:

[CPU_PR](https://user-images.githubusercontent.com/5353192/184913852-85335014-3102-4c7b-91e7-4fdc331b3c9c.png)
[ALLOCS_PR](https://user-images.githubusercontent.com/5353192/184913885-e7b5835a-7055-4690-8984-5df99f2d3f75.png)
[CPU_master](https://user-images.githubusercontent.com/5353192/184914001-1dddaf0a-5ba5-4ce5-ae0e-b15329eefdc0.png)
[ALLOCS_master](https://user-images.githubusercontent.com/5353192/184914017-cfc37f4e-7012-411e-bd9a-417dac607e31.png)


[Chaos pipeline passed](https://github.com/semi-technologies/weaviate-chaos-engineering/runs/7874556610)

