### PR TITLE
Fix integer overflow in byte operations

### DIFF
--- a/adapters/repos/db/lsmkv/segmentindex/disk_tree.go
+++ b/adapters/repos/db/lsmkv/segmentindex/disk_tree.go
@@ -96,7 +96,7 @@ func (t *DiskTree) readNode(in []byte) (dtNode, int, error) {
 
 	byteOps := byte_operations.ByteOperations{Buffer: in}
 
-	keyLen := byteOps.ReadUint32()
+	keyLen := uint64(byteOps.ReadUint32())
 	copiedBytes, err := byteOps.CopyBytesFromBuffer(keyLen)
 	if err != nil {
 		return out, int(byteOps.Position), errors.Wrap(err, "Could not copy node key")

--- a/entities/storobj/storage_object.go
+++ b/entities/storobj/storage_object.go
@@ -422,18 +422,18 @@ func UnmarshalPropertiesFromObject(data []byte, properties *models.PropertySchem
 		return errors.Errorf("unsupported binary marshaller version %d", data[0])
 	}
 
-	startPos := uint32(1 + 8 + 1 + 16 + 8 + 8) // elements at the start
+	startPos := uint64(1 + 8 + 1 + 16 + 8 + 8) // elements at the start
 	byteOps := byte_operations.ByteOperations{Position: startPos, Buffer: data}
 	// get the length of the vector, each element is a float32 (4 bytes)
-	vectorLength := byteOps.ReadUint16()
-	byteOps.MoveBufferPositionForward(uint32(vectorLength) * 4)
+	vectorLength := uint64(byteOps.ReadUint16())
+	byteOps.MoveBufferPositionForward(vectorLength * 4)
 
 	// length of class name
-	classnameLength := byteOps.ReadUint16()
-	byteOps.MoveBufferPositionForward(uint32(classnameLength))
+	classnameLength := uint64(byteOps.ReadUint16())
+	byteOps.MoveBufferPositionForward(classnameLength)
 
 	// property schema length
-	propertyLength := byteOps.ReadUint32()
+	propertyLength := uint64(byteOps.ReadUint32())
 	if err := json.Unmarshal(data[byteOps.Position:byteOps.Position+propertyLength], properties); err != nil {
 		return err
 	}
@@ -469,25 +469,25 @@ func (ko *Object) UnmarshalBinary(data []byte) error {
 		ko.Vector[j] = math.Float32frombits(byteOps.ReadUint32())
 	}
 
-	classNameLength := uint32(byteOps.ReadUint16())
+	classNameLength := uint64(byteOps.ReadUint16())
 	className, err := byteOps.CopyBytesFromBuffer(classNameLength)
 	if err != nil {
 		return errors.Wrap(err, "Could not copy class name")
 	}
 
-	schemaLength := byteOps.ReadUint32()
+	schemaLength := uint64(byteOps.ReadUint32())
 	schema, err := byteOps.CopyBytesFromBuffer(schemaLength)
 	if err != nil {
 		return errors.Wrap(err, "Could not copy schema")
 	}
 
-	metaLength := byteOps.ReadUint32()
+	metaLength := uint64(byteOps.ReadUint32())
 	meta, err := byteOps.CopyBytesFromBuffer(metaLength)
 	if err != nil {
 		return errors.Wrap(err, "Could not copy meta")
 	}
 
-	vectorWeightsLength := byteOps.ReadUint32()
+	vectorWeightsLength := uint64(byteOps.ReadUint32())
 	vectorWeights, err := byteOps.CopyBytesFromBuffer(vectorWeightsLength)
 	if err != nil {
 		return errors.Wrap(err, "Could not copy vectorWeights")

--- a/usecases/byte_operations/byte_operations.go
+++ b/usecases/byte_operations/byte_operations.go
@@ -24,7 +24,7 @@ const (
 )
 
 type ByteOperations struct {
-	Position uint32
+	Position uint64
 	Buffer   []byte
 }
 
@@ -43,7 +43,7 @@ func (bo *ByteOperations) ReadUint32() uint32 {
 	return binary.LittleEndian.Uint32(bo.Buffer[bo.Position-uint32Len : bo.Position])
 }
 
-func (bo *ByteOperations) CopyBytesFromBuffer(length uint32) ([]byte, error) {
+func (bo *ByteOperations) CopyBytesFromBuffer(length uint64) ([]byte, error) {
 	out := make([]byte, length)
 	bo.Position += length
 	numCopiedBytes := copy(out, bo.Buffer[bo.Position-length:bo.Position])
@@ -69,7 +69,7 @@ func (bo *ByteOperations) WriteUint16(value uint16) {
 }
 
 func (bo *ByteOperations) CopyBytesToBuffer(copyBytes []byte) error {
-	lenCopyBytes := uint32(len(copyBytes))
+	lenCopyBytes := uint64(len(copyBytes))
 	bo.Position += lenCopyBytes
 	numCopiedBytes := copy(bo.Buffer[bo.Position-lenCopyBytes:bo.Position], copyBytes)
 	if numCopiedBytes != int(lenCopyBytes) {
@@ -78,7 +78,7 @@ func (bo *ByteOperations) CopyBytesToBuffer(copyBytes []byte) error {
 	return nil
 }
 
-func (bo *ByteOperations) MoveBufferPositionForward(length uint32) {
+func (bo *ByteOperations) MoveBufferPositionForward(length uint64) {
 	bo.Position += length
 }
 

--- a/usecases/byte_operations/byte_operations_test.go
+++ b/usecases/byte_operations/byte_operations_test.go
@@ -20,6 +20,8 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+const MaxUint = ^uint32(0)
+
 // Create a buffer with space for several values and first write into it and then test that the values can be read again
 func TestReadAnWrite(t *testing.T) {
 	valuesNumbers := []uint64{234, 78, 23, 66, 8, 9, 2, 346745, 1}
@@ -48,4 +50,16 @@ func TestReadAnWrite(t *testing.T) {
 	require.Equal(t, byteOpsRead.ReadUint16(), uint16(valuesNumbers[3]))
 	require.Equal(t, byteOpsRead.ReadUint64(), valuesNumbers[4])
 	require.Equal(t, byteOpsRead.ReadUint16(), uint16(valuesNumbers[5]))
+}
+
+// create buffer that is larger than uint32 and write to the end and then try to reread it
+func TestReadAnWriteLargeBuffer(t *testing.T) {
+	writeBuffer := make([]byte, uint64(MaxUint)+4)
+	byteOpsWrite := ByteOperations{Buffer: writeBuffer}
+	byteOpsWrite.MoveBufferPositionForward(MaxUint)
+	byteOpsWrite.WriteUint16(uint16(10))
+
+	byteOpsRead := ByteOperations{Buffer: writeBuffer}
+	byteOpsRead.MoveBufferPositionForward(MaxUint)
+	require.Equal(t, byteOpsRead.ReadUint16(), uint16(10))
 }

--- a/usecases/byte_operations/byte_operations_test.go
+++ b/usecases/byte_operations/byte_operations_test.go
@@ -20,7 +20,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-const MaxUint = ^uint32(0)
+const MaxUint32 = ^uint32(0)
 
 // Create a buffer with space for several values and first write into it and then test that the values can be read again
 func TestReadAnWrite(t *testing.T) {
@@ -44,7 +44,7 @@ func TestReadAnWrite(t *testing.T) {
 	require.Equal(t, byteOpsRead.ReadUint64(), valuesNumbers[0])
 	require.Equal(t, byteOpsRead.ReadUint32(), uint32(valuesNumbers[1]))
 	require.Equal(t, byteOpsRead.ReadUint32(), uint32(valuesNumbers[2]))
-	returnBuf, err := byteOpsRead.CopyBytesFromBuffer(uint32(len(valuesByteArray)))
+	returnBuf, err := byteOpsRead.CopyBytesFromBuffer(uint64(len(valuesByteArray)))
 	assert.Equal(t, returnBuf, valuesByteArray)
 	assert.Equal(t, err, nil)
 	require.Equal(t, byteOpsRead.ReadUint16(), uint16(valuesNumbers[3]))
@@ -54,12 +54,12 @@ func TestReadAnWrite(t *testing.T) {
 
 // create buffer that is larger than uint32 and write to the end and then try to reread it
 func TestReadAnWriteLargeBuffer(t *testing.T) {
-	writeBuffer := make([]byte, uint64(MaxUint)+4)
+	writeBuffer := make([]byte, uint64(MaxUint32)+4)
 	byteOpsWrite := ByteOperations{Buffer: writeBuffer}
-	byteOpsWrite.MoveBufferPositionForward(MaxUint)
+	byteOpsWrite.MoveBufferPositionForward(uint64(MaxUint32))
 	byteOpsWrite.WriteUint16(uint16(10))
 
 	byteOpsRead := ByteOperations{Buffer: writeBuffer}
-	byteOpsRead.MoveBufferPositionForward(MaxUint)
+	byteOpsRead.MoveBufferPositionForward(uint64(MaxUint32))
 	require.Equal(t, byteOpsRead.ReadUint16(), uint16(10))
 }


### PR DESCRIPTION
Fixes a bug where the position in a buffer was a uint32 variable which can overflow. Replaced with uint64

- First commit adds (failing) test https://app.travis-ci.com/github/semi-technologies/weaviate/jobs/580148330
- Second commit adds fix: https://app.travis-ci.com/github/semi-technologies/weaviate/jobs/580148982