### PR TITLE
Use go testing temporary folders for testdata

### DIFF
--- a/adapters/repos/classifications/repo_integration_test.go
+++ b/adapters/repos/classifications/repo_integration_test.go
@@ -16,9 +16,7 @@ package classifications
 
 import (
 	"context"
-	"fmt"
 	"math/rand"
-	"os"
 	"testing"
 	"time"
 
@@ -30,12 +28,7 @@ import (
 
 func Test_ClassificationsRepo(t *testing.T) {
 	rand.Seed(time.Now().UnixNano())
-	dirName := fmt.Sprintf("./testdata/%d", rand.Intn(10000000))
-	os.MkdirAll(dirName, 0o777)
-	defer func() {
-		err := os.RemoveAll(dirName)
-		fmt.Println(err)
-	}()
+	dirName := t.TempDir()
 
 	logger, _ := test.NewNullLogger()
 

--- a/adapters/repos/db/aggregations_integration_test.go
+++ b/adapters/repos/db/aggregations_integration_test.go
@@ -18,7 +18,6 @@ import (
 	"context"
 	"fmt"
 	"math/rand"
-	"os"
 	"testing"
 	"time"
 
@@ -36,12 +35,7 @@ import (
 
 func Test_Aggregations(t *testing.T) {
 	rand.Seed(time.Now().UnixNano())
-	dirName := fmt.Sprintf("./testdata/%d", rand.Intn(10000000))
-	os.MkdirAll(dirName, 0o777)
-	defer func() {
-		err := os.RemoveAll(dirName)
-		fmt.Println(err)
-	}()
+	dirName := t.TempDir()
 
 	shardState := singleShardState()
 	logger := logrus.New()
@@ -79,12 +73,7 @@ func Test_Aggregations(t *testing.T) {
 
 func Test_Aggregations_MultiShard(t *testing.T) {
 	rand.Seed(time.Now().UnixNano())
-	dirName := fmt.Sprintf("./testdata/%d", rand.Intn(10000000))
-	os.MkdirAll(dirName, 0o777)
-	defer func() {
-		err := os.RemoveAll(dirName)
-		fmt.Println(err)
-	}()
+	dirName := t.TempDir()
 
 	shardState := fixedMultiShardState()
 	logger := logrus.New()

--- a/adapters/repos/db/batch_integration_test.go
+++ b/adapters/repos/db/batch_integration_test.go
@@ -18,7 +18,6 @@ import (
 	"context"
 	"fmt"
 	"math/rand"
-	"os"
 	"sort"
 	"testing"
 	"time"
@@ -41,12 +40,7 @@ import (
 
 func TestBatchPutObjects(t *testing.T) {
 	rand.Seed(time.Now().UnixNano())
-	dirName := fmt.Sprintf("./testdata/%d", rand.Intn(10000000))
-	os.MkdirAll(dirName, 0o777)
-	defer func() {
-		err := os.RemoveAll(dirName)
-		fmt.Println(err)
-	}()
+	dirName := t.TempDir()
 
 	logger := logrus.New()
 	schemaGetter := &fakeSchemaGetter{shardState: singleShardState()}
@@ -72,12 +66,7 @@ func TestBatchPutObjects(t *testing.T) {
 
 func TestBatchDeleteObjects(t *testing.T) {
 	rand.Seed(time.Now().UnixNano())
-	dirName := fmt.Sprintf("./testdata/%d", rand.Intn(10000000))
-	os.MkdirAll(dirName, 0o777)
-	defer func() {
-		err := os.RemoveAll(dirName)
-		fmt.Println(err)
-	}()
+	dirName := t.TempDir()
 
 	logger := logrus.New()
 	schemaGetter := &fakeSchemaGetter{shardState: singleShardState()}
@@ -101,12 +90,7 @@ func TestBatchDeleteObjects(t *testing.T) {
 
 func TestBatchDeleteObjects_Journey(t *testing.T) {
 	rand.Seed(time.Now().UnixNano())
-	dirName := fmt.Sprintf("./testdata/%d", rand.Intn(10000000))
-	os.MkdirAll(dirName, 0o777)
-	defer func() {
-		err := os.RemoveAll(dirName)
-		fmt.Println(err)
-	}()
+	dirName := t.TempDir()
 
 	queryMaximumResults := int64(20)
 	logger := logrus.New()

--- a/adapters/repos/db/batch_reference_integration_test.go
+++ b/adapters/repos/db/batch_reference_integration_test.go
@@ -18,7 +18,6 @@ import (
 	"context"
 	"fmt"
 	"math/rand"
-	"os"
 	"testing"
 	"time"
 
@@ -39,12 +38,7 @@ import (
 
 func Test_AddingReferencesInBatches(t *testing.T) {
 	rand.Seed(time.Now().UnixNano())
-	dirName := fmt.Sprintf("./testdata/%d", rand.Intn(10000000))
-	os.MkdirAll(dirName, 0o777)
-	defer func() {
-		err := os.RemoveAll(dirName)
-		fmt.Println(err)
-	}()
+	dirName := t.TempDir()
 
 	logger := logrus.New()
 	schemaGetter := &fakeSchemaGetter{shardState: singleShardState()}

--- a/adapters/repos/db/classification_integration_test.go
+++ b/adapters/repos/db/classification_integration_test.go
@@ -18,7 +18,6 @@ import (
 	"context"
 	"fmt"
 	"math/rand"
-	"os"
 	"testing"
 	"time"
 
@@ -37,12 +36,7 @@ import (
 
 func TestClassifications(t *testing.T) {
 	rand.Seed(time.Now().UnixNano())
-	dirName := fmt.Sprintf("./testdata/%d", rand.Intn(10000000))
-	os.MkdirAll(dirName, 0o777)
-	defer func() {
-		err := os.RemoveAll(dirName)
-		fmt.Println(err)
-	}()
+	dirName := t.TempDir()
 
 	logger := logrus.New()
 	schemaGetter := &fakeSchemaGetter{shardState: singleShardState()}

--- a/adapters/repos/db/clusterintegrationtest/cluster_integration_test.go
+++ b/adapters/repos/db/clusterintegrationtest/cluster_integration_test.go
@@ -23,7 +23,6 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"net/url"
-	"os"
 	"path"
 	"sort"
 	"strconv"
@@ -66,16 +65,12 @@ const (
 // between the repos.
 func TestDistributedSetup(t *testing.T) {
 	t.Run("individual imports", func(t *testing.T) {
-		dirName, cleanup := setupDirectory()
-		defer cleanup()
-
+		dirName := setupDirectory(t)
 		testDistributed(t, dirName, false)
 	})
 
 	t.Run("batched imports", func(t *testing.T) {
-		dirName, cleanup := setupDirectory()
-		defer cleanup()
-
+		dirName := setupDirectory(t)
 		testDistributed(t, dirName, true)
 	})
 }
@@ -626,16 +621,10 @@ func testDistributed(t *testing.T, dirName string, batch bool) {
 	})
 }
 
-func setupDirectory() (string, func()) {
+func setupDirectory(t *testing.T) string {
 	rand.Seed(time.Now().UnixNano())
-	dirName := fmt.Sprintf("./testdata/%d", rand.Intn(10000000))
-	os.MkdirAll(dirName, 0o777)
-	return dirName, func() {
-		err := os.RemoveAll(dirName)
-		if err != nil {
-			fmt.Println(err)
-		}
-	}
+	dirName := t.TempDir()
+	return dirName
 }
 
 func dataAsBatch(data []*models.Object) objects.BatchObjects {

--- a/adapters/repos/db/crud_deletion_integration_test.go
+++ b/adapters/repos/db/crud_deletion_integration_test.go
@@ -16,9 +16,7 @@ package db
 
 import (
 	"context"
-	"fmt"
 	"math/rand"
-	"os"
 	"testing"
 	"time"
 
@@ -35,12 +33,7 @@ import (
 
 func TestDeleteJourney(t *testing.T) {
 	rand.Seed(time.Now().UnixNano())
-	dirName := fmt.Sprintf("./testdata/%d", rand.Intn(10000000))
-	os.MkdirAll(dirName, 0o777)
-	defer func() {
-		err := os.RemoveAll(dirName)
-		fmt.Println(err)
-	}()
+	dirName := t.TempDir()
 
 	logger := logrus.New()
 	schemaGetter := &fakeSchemaGetter{shardState: singleShardState()}

--- a/adapters/repos/db/crud_integration_test.go
+++ b/adapters/repos/db/crud_integration_test.go
@@ -18,7 +18,6 @@ import (
 	"context"
 	"fmt"
 	"math/rand"
-	"os"
 	"testing"
 	"time"
 
@@ -43,12 +42,7 @@ import (
 
 func TestCRUD(t *testing.T) {
 	rand.Seed(time.Now().UnixNano())
-	dirName := fmt.Sprintf("./testdata/%d", rand.Intn(10000000))
-	os.MkdirAll(dirName, 0o777)
-	defer func() {
-		err := os.RemoveAll(dirName)
-		fmt.Println(err)
-	}()
+	dirName := t.TempDir()
 
 	logger, _ := test.NewNullLogger()
 	thingclass := &models.Class{
@@ -1275,13 +1269,8 @@ func Test_ImportWithoutVector_UpdateWithVectorLater(t *testing.T) {
 	var class *models.Class
 
 	rand.Seed(time.Now().UnixNano())
-	dirName := fmt.Sprintf("./testdata/%d", rand.Intn(10000000))
-	os.MkdirAll(dirName, 0o777)
+	dirName := t.TempDir()
 	logger, _ := test.NewNullLogger()
-	defer func() {
-		err := os.RemoveAll(dirName)
-		fmt.Println(err)
-	}()
 
 	schemaGetter := &fakeSchemaGetter{shardState: singleShardState()}
 	repo := New(logger, Config{
@@ -1436,13 +1425,8 @@ func TestVectorSearch_ByDistance(t *testing.T) {
 	var class *models.Class
 
 	rand.Seed(time.Now().UnixNano())
-	dirName := fmt.Sprintf("./testdata/%d", rand.Intn(10000000))
-	os.MkdirAll(dirName, 0o777)
+	dirName := t.TempDir()
 	logger, _ := test.NewNullLogger()
-	defer func() {
-		err := os.RemoveAll(dirName)
-		fmt.Println(err)
-	}()
 
 	schemaGetter := &fakeSchemaGetter{shardState: singleShardState()}
 	repo := New(logger, Config{
@@ -1577,13 +1561,8 @@ func TestVectorSearch_ByCertainty(t *testing.T) {
 	var class *models.Class
 
 	rand.Seed(time.Now().UnixNano())
-	dirName := fmt.Sprintf("./testdata/%d", rand.Intn(10000000))
-	os.MkdirAll(dirName, 0o777)
+	dirName := t.TempDir()
 	logger, _ := test.NewNullLogger()
-	defer func() {
-		err := os.RemoveAll(dirName)
-		fmt.Println(err)
-	}()
 
 	schemaGetter := &fakeSchemaGetter{shardState: singleShardState()}
 	repo := New(logger, Config{
@@ -1716,13 +1695,7 @@ func TestVectorSearch_ByCertainty(t *testing.T) {
 
 func Test_PutPatchRestart(t *testing.T) {
 	rand.Seed(time.Now().UnixNano())
-	dirName := fmt.Sprintf("./testdata/%d", rand.Intn(10000000))
-	os.MkdirAll(dirName, 0o777)
-	defer func() {
-		err := os.RemoveAll(dirName)
-		fmt.Println(err)
-	}()
-
+	dirName := t.TempDir()
 	logger, _ := test.NewNullLogger()
 	ctx, _ := context.WithTimeout(context.Background(), time.Minute)
 

--- a/adapters/repos/db/crud_noindex_property_integration_test.go
+++ b/adapters/repos/db/crud_noindex_property_integration_test.go
@@ -16,9 +16,7 @@ package db
 
 import (
 	"context"
-	"fmt"
 	"math/rand"
-	"os"
 	"testing"
 	"time"
 
@@ -38,12 +36,7 @@ import (
 
 func TestCRUD_NoIndexProp(t *testing.T) {
 	rand.Seed(time.Now().UnixNano())
-	dirName := fmt.Sprintf("./testdata/%d", rand.Intn(10000000))
-	os.MkdirAll(dirName, 0o777)
-	defer func() {
-		err := os.RemoveAll(dirName)
-		fmt.Println(err)
-	}()
+	dirName := t.TempDir()
 
 	logger, _ := test.NewNullLogger()
 	thingclass := &models.Class{

--- a/adapters/repos/db/crud_references_integration_test.go
+++ b/adapters/repos/db/crud_references_integration_test.go
@@ -18,7 +18,6 @@ import (
 	"context"
 	"fmt"
 	"math/rand"
-	"os"
 	"sync"
 	"testing"
 	"time"
@@ -37,12 +36,7 @@ import (
 
 func TestNestedReferences(t *testing.T) {
 	rand.Seed(time.Now().UnixNano())
-	dirName := fmt.Sprintf("./testdata/%d", rand.Intn(10000000))
-	os.MkdirAll(dirName, 0o777)
-	defer func() {
-		err := os.RemoveAll(dirName)
-		fmt.Println(err)
-	}()
+	dirName := t.TempDir()
 
 	refSchema := schema.Schema{
 		Objects: &models.Schema{
@@ -424,12 +418,7 @@ func (c *testCounter) reset() {
 
 func Test_AddingReferenceOneByOne(t *testing.T) {
 	rand.Seed(time.Now().UnixNano())
-	dirName := fmt.Sprintf("./testdata/%d", rand.Intn(10000000))
-	os.MkdirAll(dirName, 0o777)
-	defer func() {
-		err := os.RemoveAll(dirName)
-		fmt.Println(err)
-	}()
+	dirName := t.TempDir()
 
 	schema := schema.Schema{
 		Objects: &models.Schema{

--- a/adapters/repos/db/crud_references_multiple_types_integration_test.go
+++ b/adapters/repos/db/crud_references_multiple_types_integration_test.go
@@ -18,7 +18,6 @@ import (
 	"context"
 	"fmt"
 	"math/rand"
-	"os"
 	"testing"
 	"time"
 
@@ -34,12 +33,7 @@ import (
 
 func TestMultipleCrossRefTypes(t *testing.T) {
 	rand.Seed(time.Now().UnixNano())
-	dirName := fmt.Sprintf("./testdata/%d", rand.Intn(10000000))
-	os.MkdirAll(dirName, 0o777)
-	defer func() {
-		err := os.RemoveAll(dirName)
-		fmt.Println(err)
-	}()
+	dirName := t.TempDir()
 
 	logger := logrus.New()
 	schemaGetter := &fakeSchemaGetter{shardState: singleShardState()}

--- a/adapters/repos/db/crud_update_integration_test.go
+++ b/adapters/repos/db/crud_update_integration_test.go
@@ -16,9 +16,7 @@ package db
 
 import (
 	"context"
-	"fmt"
 	"math/rand"
-	"os"
 	"testing"
 	"time"
 
@@ -44,12 +42,7 @@ import (
 // regarding the clean up of Doc ID pointers in the inverted indices, etc.
 func TestUpdateJourney(t *testing.T) {
 	rand.Seed(time.Now().UnixNano())
-	dirName := fmt.Sprintf("./testdata/%d", rand.Intn(10000000))
-	os.MkdirAll(dirName, 0o777)
-	defer func() {
-		err := os.RemoveAll(dirName)
-		fmt.Println(err)
-	}()
+	dirName := t.TempDir()
 
 	logger := logrus.New()
 	schemaGetter := &fakeSchemaGetter{shardState: singleShardState()}

--- a/adapters/repos/db/delete_filter_integration_test.go
+++ b/adapters/repos/db/delete_filter_integration_test.go
@@ -16,9 +16,7 @@ package db
 
 import (
 	"context"
-	"fmt"
 	"math/rand"
-	"os"
 	"testing"
 	"time"
 
@@ -44,12 +42,7 @@ import (
 func Test_FilterSearchesOnDeletedDocIDsWithLimits(t *testing.T) {
 	className := "DeletedDocIDLimitTestClass"
 	rand.Seed(time.Now().UnixNano())
-	dirName := fmt.Sprintf("./testdata/%d", rand.Intn(10000000))
-	os.MkdirAll(dirName, 0o777)
-	defer func() {
-		err := os.RemoveAll(dirName)
-		fmt.Println(err)
-	}()
+	dirName := t.TempDir()
 
 	logger, _ := test.NewNullLogger()
 	thingclass := &models.Class{
@@ -167,12 +160,7 @@ func extractIDs(in []search.Result) []strfmt.UUID {
 func TestLimitOneAfterDeletion(t *testing.T) {
 	className := "Test"
 	rand.Seed(time.Now().UnixNano())
-	dirName := fmt.Sprintf("./testdata/%d", rand.Intn(10000000))
-	os.MkdirAll(dirName, 0o777)
-	defer func() {
-		err := os.RemoveAll(dirName)
-		fmt.Println(err)
-	}()
+	dirName := t.TempDir()
 
 	logger, _ := test.NewNullLogger()
 	class := &models.Class{

--- a/adapters/repos/db/filters_integration_test.go
+++ b/adapters/repos/db/filters_integration_test.go
@@ -18,7 +18,6 @@ import (
 	"context"
 	"fmt"
 	"math/rand"
-	"os"
 	"testing"
 	"time"
 
@@ -37,12 +36,7 @@ import (
 
 func TestFilters(t *testing.T) {
 	rand.Seed(time.Now().UnixNano())
-	dirName := fmt.Sprintf("./testdata/%d", rand.Intn(10000000))
-	os.MkdirAll(dirName, 0o777)
-	defer func() {
-		err := os.RemoveAll(dirName)
-		fmt.Println(err)
-	}()
+	dirName := t.TempDir()
 
 	logger, _ := test.NewNullLogger()
 	schemaGetter := &fakeSchemaGetter{shardState: singleShardState()}
@@ -727,12 +721,7 @@ var carVectors = [][]float32{
 
 func TestGeoPropUpdateJourney(t *testing.T) {
 	rand.Seed(time.Now().UnixNano())
-	dirName := fmt.Sprintf("./testdata/%d", rand.Intn(10000000))
-	os.MkdirAll(dirName, 0o777)
-	defer func() {
-		err := os.RemoveAll(dirName)
-		fmt.Println(err)
-	}()
+	dirName := t.TempDir()
 
 	logger, _ := test.NewNullLogger()
 	schemaGetter := &fakeSchemaGetter{shardState: singleShardState()}
@@ -841,12 +830,7 @@ func TestGeoPropUpdateJourney(t *testing.T) {
 // https://github.com/semi-technologies/weaviate/issues/1426
 func TestCasingOfOperatorCombinations(t *testing.T) {
 	rand.Seed(time.Now().UnixNano())
-	dirName := fmt.Sprintf("./testdata/%d", rand.Intn(10000000))
-	os.MkdirAll(dirName, 0o777)
-	defer func() {
-		err := os.RemoveAll(dirName)
-		fmt.Println(err)
-	}()
+	dirName := t.TempDir()
 
 	logger, _ := test.NewNullLogger()
 	schemaGetter := &fakeSchemaGetter{shardState: singleShardState()}

--- a/adapters/repos/db/filters_limits_integration_test.go
+++ b/adapters/repos/db/filters_limits_integration_test.go
@@ -18,7 +18,6 @@ import (
 	"context"
 	"fmt"
 	"math/rand"
-	"os"
 	"testing"
 	"time"
 
@@ -40,12 +39,7 @@ import (
 // isolation as to not interfere with the existing tests
 func Test_LimitsOnChainedFilters(t *testing.T) {
 	rand.Seed(time.Now().UnixNano())
-	dirName := fmt.Sprintf("./testdata/%d", rand.Intn(10000000))
-	os.MkdirAll(dirName, 0o777)
-	defer func() {
-		err := os.RemoveAll(dirName)
-		fmt.Println(err)
-	}()
+	dirName := t.TempDir()
 
 	logger := logrus.New()
 	schemaGetter := &fakeSchemaGetter{shardState: singleShardState()}
@@ -142,12 +136,7 @@ func chainedFilterCompanies(size int) []*models.Object {
 // isolation as to not interfere with the existing tests
 func Test_FilterLimitsAfterUpdates(t *testing.T) {
 	rand.Seed(time.Now().UnixNano())
-	dirName := fmt.Sprintf("./testdata/%d", rand.Intn(10000000))
-	os.MkdirAll(dirName, 0o777)
-	defer func() {
-		err := os.RemoveAll(dirName)
-		fmt.Println(err)
-	}()
+	dirName := t.TempDir()
 
 	logger := logrus.New()
 	schemaGetter := &fakeSchemaGetter{shardState: singleShardState()}
@@ -273,12 +262,7 @@ func Test_FilterLimitsAfterUpdates(t *testing.T) {
 // isolation as to not interfere with the existing tests
 func Test_AggregationsAfterUpdates(t *testing.T) {
 	rand.Seed(time.Now().UnixNano())
-	dirName := fmt.Sprintf("./testdata/%d", rand.Intn(10000000))
-	os.MkdirAll(dirName, 0o777)
-	defer func() {
-		err := os.RemoveAll(dirName)
-		fmt.Println(err)
-	}()
+	dirName := t.TempDir()
 
 	logger := logrus.New()
 	schemaGetter := &fakeSchemaGetter{shardState: singleShardState()}

--- a/adapters/repos/db/filters_on_refs_integration_test.go
+++ b/adapters/repos/db/filters_on_refs_integration_test.go
@@ -18,7 +18,6 @@ import (
 	"context"
 	"fmt"
 	"math/rand"
-	"os"
 	"testing"
 	"time"
 
@@ -37,12 +36,7 @@ import (
 
 func TestRefFilters(t *testing.T) {
 	rand.Seed(time.Now().UnixNano())
-	dirName := fmt.Sprintf("./testdata/%d", rand.Intn(10000000))
-	os.MkdirAll(dirName, 0o777)
-	defer func() {
-		err := os.RemoveAll(dirName)
-		fmt.Println(err)
-	}()
+	dirName := t.TempDir()
 
 	logger, _ := test.NewNullLogger()
 	schemaGetter := &fakeSchemaGetter{shardState: singleShardState()}
@@ -464,12 +458,7 @@ func TestRefFilters_MergingWithAndOperator(t *testing.T) {
 	// The schema is modelled after the journey test, as the regular tests suites
 	// above do not seem to run into this issue on their own
 	rand.Seed(time.Now().UnixNano())
-	dirName := fmt.Sprintf("./testdata/%d", rand.Intn(10000000))
-	os.MkdirAll(dirName, 0o777)
-	defer func() {
-		err := os.RemoveAll(dirName)
-		fmt.Println(err)
-	}()
+	dirName := t.TempDir()
 
 	logger, _ := test.NewNullLogger()
 	schemaGetter := &fakeSchemaGetter{shardState: singleShardState()}

--- a/adapters/repos/db/helper_for_test.go
+++ b/adapters/repos/db/helper_for_test.go
@@ -16,9 +16,8 @@ package db
 
 import (
 	"context"
-	"fmt"
 	"math/rand"
-	"os"
+	"testing"
 	"time"
 
 	"github.com/go-openapi/strfmt"
@@ -200,10 +199,9 @@ func testCtx() context.Context {
 	return ctx
 }
 
-func testShard(ctx context.Context, className string, indexOpts ...func(*Index)) (*Shard, *Index) {
+func testShard(t *testing.T, ctx context.Context, className string, indexOpts ...func(*Index)) (*Shard, *Index) {
 	rand.Seed(time.Now().UnixNano())
-	dirName := fmt.Sprintf("./testdata/%d", rand.Intn(10000000))
-	os.MkdirAll(dirName, 0o777)
+	tmpDir := t.TempDir()
 
 	shardState := singleShardState()
 	sch := schema.Schema{
@@ -214,7 +212,7 @@ func testShard(ctx context.Context, className string, indexOpts ...func(*Index))
 	schemaGetter := &fakeSchemaGetter{shardState: shardState, schema: sch}
 
 	idx := &Index{
-		Config:                IndexConfig{RootPath: dirName, ClassName: schema.ClassName(className)},
+		Config:                IndexConfig{RootPath: tmpDir, ClassName: schema.ClassName(className)},
 		invertedIndexConfig:   schema.InvertedIndexConfig{CleanupIntervalSeconds: 1},
 		vectorIndexUserConfig: hnsw.UserConfig{Skip: true},
 		logger:                logrus.New(),

--- a/adapters/repos/db/index_integration_test.go
+++ b/adapters/repos/db/index_integration_test.go
@@ -39,12 +39,7 @@ func getIndexFilenames(dirName string, className string) ([]string, error) {
 
 // func TestIndex_DropIndex(t *testing.T) {
 // 	rand.Seed(time.Now().UnixNano())
-// 	dirName := fmt.Sprintf("./testdata/%d", rand.Intn(10000000))
-// 	os.MkdirAll(dirName, 0o777)
-// 	defer func() {
-// 		err := os.RemoveAll(dirName)
-// 		fmt.Println(err)
-// 	}()
+// 	dirName := t.TmpDir()
 // 	testClassName := "deletetest"
 // 	logger, _ := test.NewNullLogger()
 // 	shardState := singleShardState()
@@ -71,12 +66,7 @@ func getIndexFilenames(dirName string, className string) ([]string, error) {
 
 // func TestIndex_DropEmptyAndRecreateEmptyIndex(t *testing.T) {
 // 	rand.Seed(time.Now().UnixNano())
-// 	dirName := fmt.Sprintf("./testdata/%d", rand.Intn(10000000))
-// 	os.MkdirAll(dirName, 0o777)
-// 	defer func() {
-// 		err := os.RemoveAll(dirName)
-// 		fmt.Println(err)
-// 	}()
+// 	dirName := t.TmpDir()
 // 	testClassName := "deletetest"
 // 	logger, _ := test.NewNullLogger()
 // 	shardState := singleShardState()
@@ -113,12 +103,7 @@ func getIndexFilenames(dirName string, className string) ([]string, error) {
 
 // func TestIndex_DropWithDataAndRecreateWithDataIndex(t *testing.T) {
 // 	rand.Seed(time.Now().UnixNano())
-// 	dirName := fmt.Sprintf("./testdata/%d", rand.Intn(10000000))
-// 	os.MkdirAll(dirName, 0o777)
-// 	defer func() {
-// 		err := os.RemoveAll(dirName)
-// 		fmt.Println(err)
-// 	}()
+// 	dirName := t.TmpDir()
 // 	logger, _ := test.NewNullLogger()
 // 	testClassName := "deletetest"
 // 	testClass := &models.Class{

--- a/adapters/repos/db/inverted/cached_filters_integration_test.go
+++ b/adapters/repos/db/inverted/cached_filters_integration_test.go
@@ -17,9 +17,7 @@ package inverted
 import (
 	"context"
 	"encoding/binary"
-	"fmt"
 	"math/rand"
-	"os"
 	"testing"
 
 	"github.com/semi-technologies/weaviate/adapters/repos/db/helpers"
@@ -38,12 +36,7 @@ const (
 )
 
 func Test_CachedFilters_String(t *testing.T) {
-	dirName := fmt.Sprintf("./testdata/%d", rand.Intn(10000000))
-	os.MkdirAll(dirName, 0o777)
-	defer func() {
-		err := os.RemoveAll(dirName)
-		fmt.Println(err)
-	}()
+	dirName := t.TempDir()
 
 	logger, _ := test.NewNullLogger()
 	store, err := lsmkv.New(dirName, "", logger, nil)
@@ -386,12 +379,7 @@ func Test_CachedFilters_String(t *testing.T) {
 }
 
 func Test_CachedFilters_Int(t *testing.T) {
-	dirName := fmt.Sprintf("./testdata/%d", rand.Intn(10000000))
-	os.MkdirAll(dirName, 0o777)
-	defer func() {
-		err := os.RemoveAll(dirName)
-		fmt.Println(err)
-	}()
+	dirName := t.TempDir()
 
 	logger, _ := test.NewNullLogger()
 	store, err := lsmkv.New(dirName, "", logger, nil)
@@ -814,12 +802,7 @@ func allowList(in ...uint64) helpers.AllowList {
 // This prevents a regression on
 // https://github.com/semi-technologies/weaviate/issues/1772
 func Test_DuplicateEntriesInAnd_String(t *testing.T) {
-	dirName := fmt.Sprintf("./testdata/%d", rand.Intn(10000000))
-	os.MkdirAll(dirName, 0o777)
-	defer func() {
-		err := os.RemoveAll(dirName)
-		fmt.Println(err)
-	}()
+	dirName := t.TempDir()
 
 	logger, _ := test.NewNullLogger()
 	store, err := lsmkv.New(dirName, "", logger, nil)

--- a/adapters/repos/db/inverted/prop_length_tracker_test.go
+++ b/adapters/repos/db/inverted/prop_length_tracker_test.go
@@ -14,7 +14,6 @@ package inverted
 import (
 	"fmt"
 	"math/rand"
-	"os"
 	"path"
 	"testing"
 	"time"
@@ -25,13 +24,7 @@ import (
 
 func Test_PropertyLengthTracker(t *testing.T) {
 	rand.Seed(time.Now().UnixNano())
-	dirName := fmt.Sprintf("./testdata/%d", rand.Intn(10000000))
-	os.MkdirAll(dirName, 0o777)
-	defer func() {
-		err := os.RemoveAll(dirName)
-		fmt.Println(err)
-	}()
-
+	dirName := t.TempDir()
 	trackerPath := path.Join(dirName, "my_test_shard")
 
 	// This test suite doesn't actually test persistence, there is a separate
@@ -195,12 +188,7 @@ func create20PropsAndVerify(t *testing.T, tracker *PropertyLengthTracker) {
 
 func Test_PropertyLengthTracker_Persistence(t *testing.T) {
 	rand.Seed(time.Now().UnixNano())
-	dirName := fmt.Sprintf("./testdata/%d", rand.Intn(10000000))
-	os.MkdirAll(dirName, 0o777)
-	defer func() {
-		err := os.RemoveAll(dirName)
-		fmt.Println(err)
-	}()
+	dirName := t.TempDir()
 
 	path := path.Join(dirName, "my_test_shard")
 

--- a/adapters/repos/db/inverted_index_integration_test.go
+++ b/adapters/repos/db/inverted_index_integration_test.go
@@ -19,7 +19,6 @@ import (
 	"fmt"
 	"math"
 	"math/rand"
-	"os"
 	"testing"
 	"time"
 
@@ -37,12 +36,7 @@ import (
 
 func TestIndexByTimestamps_AddClass(t *testing.T) {
 	rand.Seed(time.Now().UnixNano())
-	dirName := fmt.Sprintf("./testdata/%d", rand.Intn(10000000))
-	os.MkdirAll(dirName, 0o777)
-	defer func() {
-		err := os.RemoveAll(dirName)
-		fmt.Println(err)
-	}()
+	dirName := t.TempDir()
 
 	shardState := singleShardState()
 	logger := logrus.New()
@@ -104,12 +98,7 @@ func TestIndexByTimestamps_AddClass(t *testing.T) {
 
 func TestIndexByTimestamps_GetClass(t *testing.T) {
 	rand.Seed(time.Now().UnixNano())
-	dirName := fmt.Sprintf("./testdata/%d", rand.Intn(10000000))
-	os.MkdirAll(dirName, 0o777)
-	defer func() {
-		err := os.RemoveAll(dirName)
-		fmt.Println(err)
-	}()
+	dirName := t.TempDir()
 
 	class := &models.Class{
 		Class:             "TestClass",

--- a/adapters/repos/db/lsmkv/bucket_threshold_test.go
+++ b/adapters/repos/db/lsmkv/bucket_threshold_test.go
@@ -18,7 +18,6 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
-	"fmt"
 	"io/fs"
 	"math/rand"
 	"os"
@@ -34,13 +33,7 @@ import (
 // flush to segment followed by a switch to a new WAL is being performed
 // once the threshold is reached
 func TestWriteAheadLogThreshold_Replace(t *testing.T) {
-	dirName := fmt.Sprintf("./testdata/%d", rand.Intn(10000000))
-	os.MkdirAll(dirName, 0o777)
-	defer func() {
-		if err := os.RemoveAll(dirName); err != nil {
-			fmt.Println(err)
-		}
-	}()
+	dirName := t.TempDir()
 
 	amount := 100
 	keys := make([][]byte, amount)
@@ -131,13 +124,7 @@ func TestWriteAheadLogThreshold_Replace(t *testing.T) {
 // that a flush to segment followed by a switch to a new WAL is being
 // performed once the threshold is reached
 func TestMemtableThreshold_Replace(t *testing.T) {
-	dirName := fmt.Sprintf("./testdata/%d", rand.Intn(10000000))
-	os.MkdirAll(dirName, 0o777)
-	defer func() {
-		if err := os.RemoveAll(dirName); err != nil {
-			fmt.Println(err)
-		}
-	}()
+	dirName := t.TempDir()
 
 	amount := 10000
 	sizePerValue := 8
@@ -205,13 +192,7 @@ func isSizeWithinTolerance(t *testing.T, detectedSize uint64, threshold uint64, 
 
 func TestMemtableFlushesIfIdle(t *testing.T) {
 	t.Run("an empty memtable is not flushed", func(t *testing.T) {
-		dirName := fmt.Sprintf("./testdata/%d", rand.Intn(10000000))
-		os.MkdirAll(dirName, 0o777)
-		defer func() {
-			if err := os.RemoveAll(dirName); err != nil {
-				fmt.Println(err)
-			}
-		}()
+		dirName := t.TempDir()
 
 		bucket, err := NewBucket(testCtx(), dirName, "", nullLogger(), nil,
 			WithStrategy(StrategyReplace),
@@ -246,13 +227,7 @@ func TestMemtableFlushesIfIdle(t *testing.T) {
 	})
 
 	t.Run("a dirty memtable is flushed once the idle period is over", func(t *testing.T) {
-		dirName := fmt.Sprintf("./testdata/%d", rand.Intn(10000000))
-		os.MkdirAll(dirName, 0o777)
-		defer func() {
-			if err := os.RemoveAll(dirName); err != nil {
-				fmt.Println(err)
-			}
-		}()
+		dirName := t.TempDir()
 
 		bucket, err := NewBucket(testCtx(), dirName, "", nullLogger(), nil,
 			WithStrategy(StrategyReplace),
@@ -291,13 +266,7 @@ func TestMemtableFlushesIfIdle(t *testing.T) {
 	})
 
 	t.Run("a dirty memtable is not flushed as long as the next write occurs before the idle threshold", func(t *testing.T) {
-		dirName := fmt.Sprintf("./testdata/%d", rand.Intn(10000000))
-		os.MkdirAll(dirName, 0o777)
-		defer func() {
-			if err := os.RemoveAll(dirName); err != nil {
-				fmt.Println(err)
-			}
-		}()
+		dirName := t.TempDir()
 
 		bucket, err := NewBucket(testCtx(), dirName, "", nullLogger(), nil,
 			WithStrategy(StrategyReplace),

--- a/adapters/repos/db/lsmkv/compaction_integration_test.go
+++ b/adapters/repos/db/lsmkv/compaction_integration_test.go
@@ -19,7 +19,6 @@ import (
 	"context"
 	"fmt"
 	"math/rand"
-	"os"
 	"sort"
 	"testing"
 
@@ -47,14 +46,7 @@ func Test_CompactionReplaceStrategy(t *testing.T) {
 	var expected []kv
 	var bucket *Bucket
 
-	dirName := fmt.Sprintf("./testdata/%d", rand.Intn(10000000))
-	os.MkdirAll(dirName, 0o777)
-	defer func() {
-		err := os.RemoveAll(dirName)
-		if err != nil {
-			fmt.Println(err)
-		}
-	}()
+	dirName := t.TempDir()
 
 	t.Run("create test data", func(t *testing.T) {
 		// The test data is split into 4 scenarios evenly:
@@ -256,14 +248,7 @@ func Test_CompactionReplaceStrategy_WithSecondaryKeys(t *testing.T) {
 	var expectedNotPresent []kv
 	var bucket *Bucket
 
-	dirName := fmt.Sprintf("./testdata/%d", rand.Intn(10000000))
-	os.MkdirAll(dirName, 0o777)
-	defer func() {
-		err := os.RemoveAll(dirName)
-		if err != nil {
-			fmt.Println(err)
-		}
-	}()
+	dirName := t.TempDir()
 
 	t.Run("create test data", func(t *testing.T) {
 		// The test data is split into 4 scenarios evenly:
@@ -471,14 +456,7 @@ func Test_CompactionReplaceStrategy_RemoveUnnecessaryDeletes(t *testing.T) {
 	key := []byte("my-key")
 
 	var bucket *Bucket
-	dirName := fmt.Sprintf("./testdata/%d", rand.Intn(10000000))
-	os.MkdirAll(dirName, 0o777)
-	defer func() {
-		err := os.RemoveAll(dirName)
-		if err != nil {
-			fmt.Println(err)
-		}
-	}()
+	dirName := t.TempDir()
 
 	t.Run("init bucket", func(t *testing.T) {
 		b, err := NewBucket(testCtx(), dirName, "", nullLogger(), nil,
@@ -571,14 +549,7 @@ func Test_CompactionReplaceStrategy_RemoveUnnecessaryUpdates(t *testing.T) {
 	key := []byte("my-key")
 
 	var bucket *Bucket
-	dirName := fmt.Sprintf("./testdata/%d", rand.Intn(10000000))
-	os.MkdirAll(dirName, 0o777)
-	defer func() {
-		err := os.RemoveAll(dirName)
-		if err != nil {
-			fmt.Println(err)
-		}
-	}()
+	dirName := t.TempDir()
 
 	t.Run("init bucket", func(t *testing.T) {
 		b, err := NewBucket(testCtx(), dirName, "", nullLogger(), nil,
@@ -669,14 +640,7 @@ func Test_CompactionSetStrategy(t *testing.T) {
 	var expected []kv
 	var bucket *Bucket
 
-	dirName := fmt.Sprintf("./testdata/%d", rand.Intn(10000000))
-	os.MkdirAll(dirName, 0o777)
-	defer func() {
-		err := os.RemoveAll(dirName)
-		if err != nil {
-			fmt.Println(err)
-		}
-	}()
+	dirName := t.TempDir()
 
 	t.Run("create test data", func(t *testing.T) {
 		// The test data is split into 4 scenarios evenly:
@@ -967,14 +931,7 @@ func Test_CompactionSetStrategy_RemoveUnnecessary(t *testing.T) {
 	key := []byte("my-key")
 
 	var bucket *Bucket
-	dirName := fmt.Sprintf("./testdata/%d", rand.Intn(10000000))
-	os.MkdirAll(dirName, 0o777)
-	defer func() {
-		err := os.RemoveAll(dirName)
-		if err != nil {
-			fmt.Println(err)
-		}
-	}()
+	dirName := t.TempDir()
 
 	t.Run("init bucket", func(t *testing.T) {
 		b, err := NewBucket(testCtx(), dirName, "", nullLogger(), nil,
@@ -1081,14 +1038,7 @@ func Test_CompactionMapStrategy(t *testing.T) {
 	var expected []kv
 	var bucket *Bucket
 
-	dirName := fmt.Sprintf("./testdata/%d", rand.Intn(10000000))
-	os.MkdirAll(dirName, 0o777)
-	defer func() {
-		err := os.RemoveAll(dirName)
-		if err != nil {
-			fmt.Println(err)
-		}
-	}()
+	dirName := t.TempDir()
 
 	t.Run("create test data", func(t *testing.T) {
 		// The test data is split into 4 scenarios evenly:
@@ -1454,14 +1404,7 @@ func Test_CompactionMapStrategy_RemoveUnnecessary(t *testing.T) {
 	key := []byte("my-key")
 
 	var bucket *Bucket
-	dirName := fmt.Sprintf("./testdata/%d", rand.Intn(10000000))
-	os.MkdirAll(dirName, 0o777)
-	defer func() {
-		err := os.RemoveAll(dirName)
-		if err != nil {
-			fmt.Println(err)
-		}
-	}()
+	dirName := t.TempDir()
 
 	t.Run("init bucket", func(t *testing.T) {
 		b, err := NewBucket(testCtx(), dirName, "", nullLogger(), nil,
@@ -1583,14 +1526,7 @@ func Test_CompactionReplaceStrategy_FrequentPutDeleteOperations(t *testing.T) {
 	key := []byte("my-key")
 
 	var bucket *Bucket
-	dirName := fmt.Sprintf("./testdata/%d", rand.Intn(10000000))
-	os.MkdirAll(dirName, 0o777)
-	defer func() {
-		err := os.RemoveAll(dirName)
-		if err != nil {
-			fmt.Println(err)
-		}
-	}()
+	dirName := t.TempDir()
 
 	t.Run("init bucket", func(t *testing.T) {
 		b, err := NewBucket(testCtx(), dirName, "", nullLogger(), nil,
@@ -1665,14 +1601,7 @@ func Test_Compaction_FrequentPutDeleteOperations_WithSecondaryKeys(t *testing.T)
 			key := []byte(fmt.Sprintf("key-original"))
 			keySecondary := []byte(fmt.Sprintf("secondary-key-%02d", size-1))
 
-			dirName := fmt.Sprintf("./testdata/%d", rand.Intn(10000000))
-			os.MkdirAll(dirName, 0o777)
-			defer func() {
-				err := os.RemoveAll(dirName)
-				if err != nil {
-					fmt.Println(err)
-				}
-			}()
+			dirName := t.TempDir()
 
 			t.Run("init bucket", func(t *testing.T) {
 				b, err := NewBucket(testCtx(), dirName, "", nullLogger(), nil,
@@ -1753,14 +1682,7 @@ func Test_CompactionSetStrategy_FrequentPutDeleteOperations(t *testing.T) {
 			value2 := []byte("value-02")
 			values := [][]byte{value1, value2}
 
-			dirName := fmt.Sprintf("./testdata/%d", rand.Intn(10000000))
-			os.MkdirAll(dirName, 0o777)
-			defer func() {
-				err := os.RemoveAll(dirName)
-				if err != nil {
-					fmt.Println(err)
-				}
-			}()
+			dirName := t.TempDir()
 
 			t.Run("init bucket", func(t *testing.T) {
 				b, err := NewBucket(testCtx(), dirName, "", nullLogger(), nil,
@@ -1854,14 +1776,7 @@ func Test_CompactionMapStrategy_FrequentPutDeleteOperations(t *testing.T) {
 	for size := 4; size < maxSize; size++ {
 		t.Run(fmt.Sprintf("compact %v segments", size), func(t *testing.T) {
 			var bucket *Bucket
-			dirName := fmt.Sprintf("./testdata/%d", rand.Intn(10000000))
-			os.MkdirAll(dirName, 0o777)
-			defer func() {
-				err := os.RemoveAll(dirName)
-				if err != nil {
-					fmt.Println(err)
-				}
-			}()
+			dirName := t.TempDir()
 
 			t.Run("init bucket", func(t *testing.T) {
 				b, err := NewBucket(testCtx(), dirName, "", nullLogger(), nil,

--- a/adapters/repos/db/lsmkv/concurrent_writing_integration_test.go
+++ b/adapters/repos/db/lsmkv/concurrent_writing_integration_test.go
@@ -19,7 +19,6 @@ import (
 	"context"
 	"fmt"
 	"math/rand"
-	"os"
 	"reflect"
 	"sync"
 	"testing"
@@ -35,12 +34,7 @@ import (
 // there will be no lost writes or other inconsistencies under load
 func TestConcurrentWriting_Replace(t *testing.T) {
 	rand.Seed(time.Now().UnixNano())
-	dirName := fmt.Sprintf("./testdata/%d", rand.Intn(10000000))
-	os.MkdirAll(dirName, 0o777)
-	defer func() {
-		err := os.RemoveAll(dirName)
-		fmt.Println(err)
-	}()
+	dirName := t.TempDir()
 
 	amount := 2000
 	sizePerValue := 128
@@ -131,12 +125,7 @@ func TestConcurrentWriting_Replace(t *testing.T) {
 // there will be no lost writes or other inconsistencies under load
 func TestConcurrentWriting_Set(t *testing.T) {
 	rand.Seed(time.Now().UnixNano())
-	dirName := fmt.Sprintf("./testdata/%d", rand.Intn(10000000))
-	os.MkdirAll(dirName, 0o777)
-	defer func() {
-		err := os.RemoveAll(dirName)
-		fmt.Println(err)
-	}()
+	dirName := t.TempDir()
 
 	amount := 2000
 	valuesPerKey := 4
@@ -225,12 +214,7 @@ func TestConcurrentWriting_Set(t *testing.T) {
 // there will be no lost writes or other inconsistencies under load
 func TestConcurrentWriting_Map(t *testing.T) {
 	rand.Seed(time.Now().UnixNano())
-	dirName := fmt.Sprintf("./testdata/%d", rand.Intn(10000000))
-	os.MkdirAll(dirName, 0o777)
-	defer func() {
-		err := os.RemoveAll(dirName)
-		fmt.Println(err)
-	}()
+	dirName := t.TempDir()
 
 	amount := 2000
 	valuesPerKey := 4

--- a/adapters/repos/db/lsmkv/recover_from_wal_integration_test.go
+++ b/adapters/repos/db/lsmkv/recover_from_wal_integration_test.go
@@ -32,16 +32,8 @@ import (
 
 func TestReplaceStrategy_RecoverFromWAL(t *testing.T) {
 	rand.Seed(time.Now().UnixNano())
-	dirNameOriginal := fmt.Sprintf("./testdata/%d-original", rand.Intn(10000000))
-	dirNameRecovered := fmt.Sprintf("./testdata/%d-recovered", rand.Intn(10000000))
-	os.MkdirAll(dirNameOriginal, 0o777)
-	os.MkdirAll(dirNameRecovered, 0o777)
-	defer func() {
-		err := os.RemoveAll(dirNameOriginal)
-		fmt.Println(err)
-		err = os.RemoveAll(dirNameRecovered)
-		fmt.Println(err)
-	}()
+	dirNameOriginal := t.TempDir()
+	dirNameRecovered := t.TempDir()
 
 	t.Run("with some previous state", func(t *testing.T) {
 		b, err := NewBucket(testCtx(), dirNameOriginal, "", nullLogger(), nil,
@@ -194,16 +186,8 @@ func TestReplaceStrategy_RecoverFromWAL(t *testing.T) {
 
 func TestReplaceStrategy_RecoverFromWALWithCorruptLastElement(t *testing.T) {
 	rand.Seed(time.Now().UnixNano())
-	dirNameOriginal := fmt.Sprintf("./testdata/%d-original", rand.Intn(10000000))
-	dirNameRecovered := fmt.Sprintf("./testdata/%d-recovered", rand.Intn(10000000))
-	os.MkdirAll(dirNameOriginal, 0o777)
-	os.MkdirAll(dirNameRecovered, 0o777)
-	defer func() {
-		err := os.RemoveAll(dirNameOriginal)
-		fmt.Println(err)
-		err = os.RemoveAll(dirNameRecovered)
-		fmt.Println(err)
-	}()
+	dirNameOriginal := t.TempDir()
+	dirNameRecovered := t.TempDir()
 
 	t.Run("without previous state", func(t *testing.T) {
 		b, err := NewBucket(testCtx(), dirNameOriginal, "", nullLogger(), nil,
@@ -349,16 +333,8 @@ func TestReplaceStrategy_RecoverFromWALWithCorruptLastElement(t *testing.T) {
 
 func TestSetStrategy_RecoverFromWAL(t *testing.T) {
 	rand.Seed(time.Now().UnixNano())
-	dirNameOriginal := fmt.Sprintf("./testdata/%d-original", rand.Intn(10000000))
-	dirNameRecovered := fmt.Sprintf("./testdata/%d-recovered", rand.Intn(10000000))
-	os.MkdirAll(dirNameOriginal, 0o777)
-	os.MkdirAll(dirNameRecovered, 0o777)
-	defer func() {
-		err := os.RemoveAll(dirNameOriginal)
-		fmt.Println(err)
-		err = os.RemoveAll(dirNameRecovered)
-		fmt.Println(err)
-	}()
+	dirNameOriginal := t.TempDir()
+	dirNameRecovered := t.TempDir()
 
 	t.Run("without prior state", func(t *testing.T) {
 		b, err := NewBucket(testCtx(), dirNameOriginal, "", nullLogger(), nil,
@@ -498,16 +474,8 @@ func TestSetStrategy_RecoverFromWAL(t *testing.T) {
 
 func TestMapStrategy_RecoverFromWAL(t *testing.T) {
 	rand.Seed(time.Now().UnixNano())
-	dirNameOriginal := fmt.Sprintf("./testdata/%d-original", rand.Intn(10000000))
-	dirNameRecovered := fmt.Sprintf("./testdata/%d-recovered", rand.Intn(10000000))
-	os.MkdirAll(dirNameOriginal, 0o777)
-	os.MkdirAll(dirNameRecovered, 0o777)
-	defer func() {
-		err := os.RemoveAll(dirNameOriginal)
-		fmt.Println(err)
-		err = os.RemoveAll(dirNameRecovered)
-		fmt.Println(err)
-	}()
+	dirNameOriginal := t.TempDir()
+	dirNameRecovered := t.TempDir()
 
 	t.Run("without prior state", func(t *testing.T) {
 		b, err := NewBucket(testCtx(), dirNameOriginal, "", nullLogger(), nil,

--- a/adapters/repos/db/lsmkv/store_integration_test.go
+++ b/adapters/repos/db/lsmkv/store_integration_test.go
@@ -16,9 +16,7 @@ package lsmkv
 
 import (
 	"context"
-	"fmt"
 	"math/rand"
-	"os"
 	"testing"
 	"time"
 
@@ -28,12 +26,7 @@ import (
 
 func TestStoreLifecycle(t *testing.T) {
 	rand.Seed(time.Now().UnixNano())
-	dirName := fmt.Sprintf("./testdata/%d", rand.Intn(10000000))
-	os.MkdirAll(dirName, 0o777)
-	defer func() {
-		err := os.RemoveAll(dirName)
-		fmt.Println(err)
-	}()
+	dirName := t.TempDir()
 
 	t.Run("cycle 1", func(t *testing.T) {
 		store, err := New(dirName, "", nullLogger(), nil)

--- a/adapters/repos/db/lsmkv/strategies_map_integration_test.go
+++ b/adapters/repos/db/lsmkv/strategies_map_integration_test.go
@@ -18,7 +18,6 @@ import (
 	"context"
 	"fmt"
 	"math/rand"
-	"os"
 	"testing"
 	"time"
 
@@ -28,12 +27,7 @@ import (
 
 func TestMapCollectionStrategy_InsertAndAppend(t *testing.T) {
 	rand.Seed(time.Now().UnixNano())
-	dirName := fmt.Sprintf("./testdata/%d", rand.Intn(10000000))
-	os.MkdirAll(dirName, 0o777)
-	defer func() {
-		err := os.RemoveAll(dirName)
-		fmt.Println(err)
-	}()
+	dirName := t.TempDir()
 
 	t.Run("memtable-only", func(t *testing.T) {
 		b, err := NewBucket(testCtx(), dirName, "", nullLogger(), nil,
@@ -419,12 +413,7 @@ func TestMapCollectionStrategy_InsertAndAppend(t *testing.T) {
 
 func TestMapCollectionStrategy_InsertAndDelete(t *testing.T) {
 	rand.Seed(time.Now().UnixNano())
-	dirName := fmt.Sprintf("./testdata/%d", rand.Intn(10000000))
-	os.MkdirAll(dirName, 0o777)
-	defer func() {
-		err := os.RemoveAll(dirName)
-		fmt.Println(err)
-	}()
+	dirName := t.TempDir()
 
 	t.Run("memtable-only", func(t *testing.T) {
 		b, err := NewBucket(testCtx(), dirName, "", nullLogger(), nil,
@@ -725,12 +714,7 @@ func TestMapCollectionStrategy_InsertAndDelete(t *testing.T) {
 func TestMapCollectionStrategy_Cursors(t *testing.T) {
 	t.Run("memtable-only", func(t *testing.T) {
 		rand.Seed(time.Now().UnixNano())
-		dirName := fmt.Sprintf("./testdata/%d", rand.Intn(10000000))
-		os.MkdirAll(dirName, 0o777)
-		defer func() {
-			err := os.RemoveAll(dirName)
-			fmt.Println(err)
-		}()
+		dirName := t.TempDir()
 
 		b, err := NewBucket(testCtx(), dirName, "", nullLogger(), nil,
 			WithStrategy(StrategyMapCollection))
@@ -917,12 +901,7 @@ func TestMapCollectionStrategy_Cursors(t *testing.T) {
 
 	t.Run("with flushes", func(t *testing.T) {
 		rand.Seed(time.Now().UnixNano())
-		dirName := fmt.Sprintf("./testdata/%d", rand.Intn(10000000))
-		os.MkdirAll(dirName, 0o777)
-		defer func() {
-			err := os.RemoveAll(dirName)
-			fmt.Println(err)
-		}()
+		dirName := t.TempDir()
 
 		b, err := NewBucket(testCtx(), dirName, "", nullLogger(), nil,
 			WithStrategy(StrategyMapCollection))

--- a/adapters/repos/db/lsmkv/strategies_replace_integration_test.go
+++ b/adapters/repos/db/lsmkv/strategies_replace_integration_test.go
@@ -18,7 +18,6 @@ import (
 	"context"
 	"fmt"
 	"math/rand"
-	"os"
 	"testing"
 	"time"
 
@@ -28,12 +27,7 @@ import (
 
 func TestReplaceStrategy_InsertAndUpdate(t *testing.T) {
 	rand.Seed(time.Now().UnixNano())
-	dirName := fmt.Sprintf("./testdata/%d", rand.Intn(10000000))
-	os.MkdirAll(dirName, 0o777)
-	defer func() {
-		err := os.RemoveAll(dirName)
-		fmt.Println(err)
-	}()
+	dirName := t.TempDir()
 
 	t.Run("memtable-only", func(t *testing.T) {
 		b, err := NewBucket(testCtx(), dirName, "", nullLogger(), nil,
@@ -319,12 +313,7 @@ func TestReplaceStrategy_InsertAndUpdate(t *testing.T) {
 
 func TestReplaceStrategy_InsertAndUpdate_WithSecondaryKeys(t *testing.T) {
 	rand.Seed(time.Now().UnixNano())
-	dirName := fmt.Sprintf("./testdata/%d", rand.Intn(10000000))
-	os.MkdirAll(dirName, 0o777)
-	defer func() {
-		err := os.RemoveAll(dirName)
-		fmt.Println(err)
-	}()
+	dirName := t.TempDir()
 
 	t.Run("memtable-only", func(t *testing.T) {
 		b, err := NewBucket(testCtx(), dirName, "", nullLogger(), nil,
@@ -622,12 +611,7 @@ func TestReplaceStrategy_InsertAndUpdate_WithSecondaryKeys(t *testing.T) {
 
 func TestReplaceStrategy_InsertAndDelete(t *testing.T) {
 	rand.Seed(time.Now().UnixNano())
-	dirName := fmt.Sprintf("./testdata/%d", rand.Intn(10000000))
-	os.MkdirAll(dirName, 0o777)
-	defer func() {
-		err := os.RemoveAll(dirName)
-		fmt.Println(err)
-	}()
+	dirName := t.TempDir()
 
 	t.Run("memtable-only", func(t *testing.T) {
 		b, err := NewBucket(testCtx(), dirName, "", nullLogger(), nil,
@@ -797,12 +781,7 @@ func TestReplaceStrategy_InsertAndDelete(t *testing.T) {
 func TestReplaceStrategy_Cursors(t *testing.T) {
 	t.Run("memtable-only", func(t *testing.T) {
 		rand.Seed(time.Now().UnixNano())
-		dirName := fmt.Sprintf("./testdata/%d", rand.Intn(10000000))
-		os.MkdirAll(dirName, 0o777)
-		defer func() {
-			err := os.RemoveAll(dirName)
-			fmt.Println(err)
-		}()
+		dirName := t.TempDir()
 
 		b, err := NewBucket(testCtx(), dirName, "", nullLogger(), nil,
 			WithStrategy(StrategyReplace))
@@ -1036,12 +1015,7 @@ func TestReplaceStrategy_Cursors(t *testing.T) {
 
 	t.Run("with a single flush", func(t *testing.T) {
 		rand.Seed(time.Now().UnixNano())
-		dirName := fmt.Sprintf("./testdata/%d", rand.Intn(10000000))
-		os.MkdirAll(dirName, 0o777)
-		defer func() {
-			err := os.RemoveAll(dirName)
-			fmt.Println(err)
-		}()
+		dirName := t.TempDir()
 
 		b, err := NewBucket(testCtx(), dirName, "", nullLogger(), nil, WithStrategy(StrategyReplace))
 		require.Nil(t, err)
@@ -1133,12 +1107,7 @@ func TestReplaceStrategy_Cursors(t *testing.T) {
 
 	t.Run("mixing several disk segments and memtable - with updates", func(t *testing.T) {
 		rand.Seed(time.Now().UnixNano())
-		dirName := fmt.Sprintf("./testdata/%d", rand.Intn(10000000))
-		os.MkdirAll(dirName, 0o777)
-		defer func() {
-			err := os.RemoveAll(dirName)
-			fmt.Println(err)
-		}()
+		dirName := t.TempDir()
 
 		b, err := NewBucket(testCtx(), dirName, "", nullLogger(), nil,
 			WithStrategy(StrategyReplace))
@@ -1431,12 +1400,7 @@ func TestReplaceStrategy_Cursors(t *testing.T) {
 	// always smaller
 	t.Run("with deletes as latest in some segments", func(t *testing.T) {
 		rand.Seed(time.Now().UnixNano())
-		dirName := fmt.Sprintf("./testdata/%d", rand.Intn(10000000))
-		os.MkdirAll(dirName, 0o777)
-		defer func() {
-			err := os.RemoveAll(dirName)
-			fmt.Println(err)
-		}()
+		dirName := t.TempDir()
 
 		b, err := NewBucket(testCtx(), dirName, "", nullLogger(), nil,
 			WithStrategy(StrategyReplace))

--- a/adapters/repos/db/lsmkv/strategies_set_integration_test.go
+++ b/adapters/repos/db/lsmkv/strategies_set_integration_test.go
@@ -18,7 +18,6 @@ import (
 	"context"
 	"fmt"
 	"math/rand"
-	"os"
 	"testing"
 	"time"
 
@@ -28,12 +27,7 @@ import (
 
 func TestSetCollectionStrategy_InsertAndSetAdd(t *testing.T) {
 	rand.Seed(time.Now().UnixNano())
-	dirName := fmt.Sprintf("./testdata/%d", rand.Intn(10000000))
-	os.MkdirAll(dirName, 0o777)
-	defer func() {
-		err := os.RemoveAll(dirName)
-		fmt.Println(err)
-	}()
+	dirName := t.TempDir()
 
 	t.Run("memtable-only", func(t *testing.T) {
 		b, err := NewBucket(testCtx(), dirName, "", nullLogger(), nil,
@@ -310,12 +304,7 @@ func TestSetCollectionStrategy_InsertAndSetAdd(t *testing.T) {
 
 func TestSetCollectionStrategy_InsertAndDelete(t *testing.T) {
 	rand.Seed(time.Now().UnixNano())
-	dirName := fmt.Sprintf("./testdata/%d", rand.Intn(10000000))
-	os.MkdirAll(dirName, 0o777)
-	defer func() {
-		err := os.RemoveAll(dirName)
-		fmt.Println(err)
-	}()
+	dirName := t.TempDir()
 
 	t.Run("memtable-only", func(t *testing.T) {
 		b, err := NewBucket(testCtx(), dirName, "", nullLogger(), nil,
@@ -695,12 +684,7 @@ func TestSetCollectionStrategy_InsertAndDelete(t *testing.T) {
 func TestSetCollectionStrategy_Cursors(t *testing.T) {
 	t.Run("memtable-only", func(t *testing.T) {
 		rand.Seed(time.Now().UnixNano())
-		dirName := fmt.Sprintf("./testdata/%d", rand.Intn(10000000))
-		os.MkdirAll(dirName, 0o777)
-		defer func() {
-			err := os.RemoveAll(dirName)
-			fmt.Println(err)
-		}()
+		dirName := t.TempDir()
 
 		b, err := NewBucket(testCtx(), dirName, "", nullLogger(), nil,
 			WithStrategy(StrategySetCollection))
@@ -828,12 +812,7 @@ func TestSetCollectionStrategy_Cursors(t *testing.T) {
 
 	t.Run("with flushes", func(t *testing.T) {
 		rand.Seed(time.Now().UnixNano())
-		dirName := fmt.Sprintf("./testdata/%d", rand.Intn(10000000))
-		os.MkdirAll(dirName, 0o777)
-		defer func() {
-			err := os.RemoveAll(dirName)
-			fmt.Println(err)
-		}()
+		dirName := t.TempDir()
 
 		b, err := NewBucket(testCtx(), dirName, "", nullLogger(), nil,
 			WithStrategy(StrategySetCollection))

--- a/adapters/repos/db/merge_integration_test.go
+++ b/adapters/repos/db/merge_integration_test.go
@@ -18,7 +18,6 @@ import (
 	"context"
 	"fmt"
 	"math/rand"
-	"os"
 	"testing"
 	"time"
 
@@ -37,12 +36,7 @@ import (
 
 func Test_MergingObjects(t *testing.T) {
 	rand.Seed(time.Now().UnixNano())
-	dirName := fmt.Sprintf("./testdata/%d", rand.Intn(10000000))
-	os.MkdirAll(dirName, 0o777)
-	defer func() {
-		err := os.RemoveAll(dirName)
-		fmt.Println(err)
-	}()
+	dirName := t.TempDir()
 
 	logger := logrus.New()
 	schemaGetter := &fakeSchemaGetter{shardState: singleShardState()}

--- a/adapters/repos/db/multi_shard_integration_test.go
+++ b/adapters/repos/db/multi_shard_integration_test.go
@@ -19,7 +19,6 @@ import (
 	"fmt"
 	"math"
 	"math/rand"
-	"os"
 	"sort"
 	"testing"
 	"time"
@@ -46,13 +45,9 @@ import (
 )
 
 func Test_MultiShardJourneys_IndividualImports(t *testing.T) {
-	repo, logger, dirName := setupMultiShardTest()
+	repo, logger := setupMultiShardTest(t)
 	defer func() {
 		repo.Shutdown(context.Background())
-		err := os.RemoveAll(dirName)
-		if err != nil {
-			fmt.Println(err)
-		}
 	}()
 
 	t.Run("prepare", makeTestMultiShardSchema(repo, logger, false, testClassesForImporting()...))
@@ -85,13 +80,9 @@ func Test_MultiShardJourneys_IndividualImports(t *testing.T) {
 }
 
 func Test_MultiShardJourneys_BatchedImports(t *testing.T) {
-	repo, logger, dirName := setupMultiShardTest()
+	repo, logger := setupMultiShardTest(t)
 	defer func() {
 		repo.Shutdown(context.Background())
-		err := os.RemoveAll(dirName)
-		if err != nil {
-			fmt.Println(err)
-		}
 	}()
 
 	t.Run("prepare", makeTestMultiShardSchema(repo, logger, false, testClassesForImporting()...))
@@ -159,13 +150,9 @@ func Test_MultiShardJourneys_BatchedImports(t *testing.T) {
 }
 
 func Test_MultiShardJourneys_BM25_Search(t *testing.T) {
-	repo, logger, dirName := setupMultiShardTest()
+	repo, logger := setupMultiShardTest(t)
 	defer func() {
 		repo.Shutdown(context.Background())
-		err := os.RemoveAll(dirName)
-		if err != nil {
-			fmt.Println(err)
-		}
 	}()
 
 	className := "RacecarPosts"
@@ -281,10 +268,9 @@ func Test_MultiShardJourneys_BM25_Search(t *testing.T) {
 	})
 }
 
-func setupMultiShardTest() (*DB, *logrus.Logger, string) {
+func setupMultiShardTest(t *testing.T) (*DB, *logrus.Logger) {
 	rand.Seed(time.Now().UnixNano())
-	dirName := fmt.Sprintf("./testdata/%d", rand.Intn(10000000))
-	os.MkdirAll(dirName, 0o777)
+	dirName := t.TempDir()
 
 	logger, _ := test.NewNullLogger()
 	repo := New(logger, Config{
@@ -294,7 +280,7 @@ func setupMultiShardTest() (*DB, *logrus.Logger, string) {
 		DiskUseReadOnlyPercentage: config.DefaultDiskUseReadonlyPercentage,
 	}, &fakeRemoteClient{}, &fakeNodeResolver{}, nil)
 
-	return repo, logger, dirName
+	return repo, logger
 }
 
 func makeTestMultiShardSchema(repo *DB, logger logrus.FieldLogger, fixedShardState bool, classes ...*models.Class) func(t *testing.T) {

--- a/adapters/repos/db/restart_journey_integration_test.go
+++ b/adapters/repos/db/restart_journey_integration_test.go
@@ -16,9 +16,7 @@ package db
 
 import (
 	"context"
-	"fmt"
 	"math/rand"
-	"os"
 	"testing"
 	"time"
 
@@ -36,12 +34,7 @@ import (
 
 func TestRestartJourney(t *testing.T) {
 	rand.Seed(time.Now().UnixNano())
-	dirName := fmt.Sprintf("./testdata/%d", rand.Intn(10000000))
-	os.MkdirAll(dirName, 0o777)
-	defer func() {
-		err := os.RemoveAll(dirName)
-		fmt.Println(err)
-	}()
+	dirName := t.TempDir()
 
 	logger, _ := test.NewNullLogger()
 	thingclass := &models.Class{

--- a/adapters/repos/db/shard_test.go
+++ b/adapters/repos/db/shard_test.go
@@ -34,7 +34,7 @@ import (
 func TestShard_UpdateStatus(t *testing.T) {
 	ctx := testCtx()
 	className := "TestClass"
-	shd, idx := testShard(ctx, className)
+	shd, idx := testShard(t, ctx, className)
 
 	amount := 10
 
@@ -86,7 +86,7 @@ func TestShard_ReadOnly_HaltCompaction(t *testing.T) {
 	keys := make([][]byte, amount)
 	values := make([][]byte, amount)
 
-	shd, idx := testShard(context.Background(), "TestClass")
+	shd, idx := testShard(t, context.Background(), "TestClass")
 
 	defer func(path string) {
 		err := os.RemoveAll(path)

--- a/adapters/repos/db/snapshot_integration_test.go
+++ b/adapters/repos/db/snapshot_integration_test.go
@@ -60,7 +60,7 @@ func TestSnapshot_IndexLevel(t *testing.T) {
 		now := time.Now()
 		snapshot := snapshots.New(className, snapshotID, now)
 
-		shard, index := testShard(ctx, className, withVectorIndexing(true))
+		shard, index := testShard(t, ctx, className, withVectorIndexing(true))
 		// let the index age for a second so that
 		// the commitlogger filenames, which are
 		// based on current timestamp, can differ
@@ -140,7 +140,7 @@ func TestSnapshot_IndexLevel(t *testing.T) {
 		snapshotID := "index-level-snapshot-test"
 		snapshot := snapshots.New(className, snapshotID, time.Now())
 
-		_, index := testShard(ctx, className, withVectorIndexing(true))
+		_, index := testShard(t, ctx, className, withVectorIndexing(true))
 
 		timeout, cancel := context.WithTimeout(context.Background(), 0)
 		defer cancel()
@@ -183,7 +183,7 @@ func TestSnapshot_IndexLevel(t *testing.T) {
 		inProgressSnapshotID := "index-level-snapshot-test"
 		snapshot := snapshots.New(className, "some-new-snapshot", time.Now())
 
-		_, index := testShard(ctx, className, withVectorIndexing(true))
+		_, index := testShard(t, ctx, className, withVectorIndexing(true))
 
 		index.snapshotState = snapshots.State{
 			SnapshotID: inProgressSnapshotID,
@@ -211,7 +211,7 @@ func TestSnapshot_IndexLevel(t *testing.T) {
 func TestSnapshot_BucketLevel(t *testing.T) {
 	ctx := testCtx()
 	className := "BucketLevelSnapshot"
-	shard, _ := testShard(ctx, className)
+	shard, _ := testShard(t, ctx, className)
 
 	t.Run("insert data", func(t *testing.T) {
 		err := shard.putObject(ctx, &storobj.Object{

--- a/adapters/repos/db/vector/hnsw/commit_log_combiner_integration_test.go
+++ b/adapters/repos/db/vector/hnsw/commit_log_combiner_integration_test.go
@@ -12,7 +12,6 @@
 package hnsw
 
 import (
-	"fmt"
 	"math/rand"
 	"os"
 	"testing"
@@ -30,12 +29,7 @@ func Test_CommitlogCombiner(t *testing.T) {
 	// by the condensor
 
 	rand.Seed(time.Now().UnixNano())
-	rootPath := fmt.Sprintf("./testdata/%d", rand.Intn(10000000))
-	os.MkdirAll(rootPath, 0o777)
-	defer func() {
-		err := os.RemoveAll(rootPath)
-		fmt.Println(err)
-	}()
+	rootPath := t.TempDir()
 	logger, _ := test.NewNullLogger()
 
 	threshold := int64(1000)

--- a/adapters/repos/db/vector/hnsw/condensor_integration_test.go
+++ b/adapters/repos/db/vector/hnsw/condensor_integration_test.go
@@ -16,7 +16,6 @@ package hnsw
 
 import (
 	"bufio"
-	"fmt"
 	"math/rand"
 	"os"
 	"strings"
@@ -30,12 +29,7 @@ import (
 
 func TestCondensor(t *testing.T) {
 	rand.Seed(time.Now().UnixNano())
-	rootPath := fmt.Sprintf("./testdata/%d", rand.Intn(10000000))
-	os.MkdirAll(rootPath, 0o777)
-	defer func() {
-		err := os.RemoveAll(rootPath)
-		fmt.Println(err)
-	}()
+	rootPath := t.TempDir()
 
 	logger, _ := test.NewNullLogger()
 	uncondensed, err := NewCommitLogger(rootPath, "uncondensed", 0, logger)
@@ -146,12 +140,7 @@ func TestCondensor(t *testing.T) {
 
 func TestCondensorAppendNodeLinks(t *testing.T) {
 	rand.Seed(time.Now().UnixNano())
-	rootPath := fmt.Sprintf("./testdata/%d", rand.Intn(10000000))
-	os.MkdirAll(rootPath, 0o777)
-	defer func() {
-		err := os.RemoveAll(rootPath)
-		fmt.Println(err)
-	}()
+	rootPath := t.TempDir()
 
 	logger, _ := test.NewNullLogger()
 	uncondensed1, err := NewCommitLogger(rootPath, "uncondensed1", 0, logger)
@@ -239,12 +228,7 @@ func TestCondensorAppendNodeLinks(t *testing.T) {
 // regression.
 func TestCondensorReplaceNodeLinks(t *testing.T) {
 	rand.Seed(time.Now().UnixNano())
-	rootPath := fmt.Sprintf("./testdata/%d", rand.Intn(10000000))
-	os.MkdirAll(rootPath, 0o777)
-	defer func() {
-		err := os.RemoveAll(rootPath)
-		fmt.Println(err)
-	}()
+	rootPath := t.TempDir()
 
 	logger, _ := test.NewNullLogger()
 	uncondensed1, err := NewCommitLogger(rootPath, "uncondensed1", 0, logger)
@@ -337,12 +321,7 @@ func TestCondensorReplaceNodeLinks(t *testing.T) {
 // still added to test the broken (now fixed) behavior in relative isolation.
 func TestCondensorClearLinksAtLevel(t *testing.T) {
 	rand.Seed(time.Now().UnixNano())
-	rootPath := fmt.Sprintf("./testdata/%d", rand.Intn(10000000))
-	os.MkdirAll(rootPath, 0o777)
-	defer func() {
-		err := os.RemoveAll(rootPath)
-		fmt.Println(err)
-	}()
+	rootPath := t.TempDir()
 
 	logger, _ := test.NewNullLogger()
 	uncondensed1, err := NewCommitLogger(rootPath, "uncondensed1", 0, logger)
@@ -431,12 +410,7 @@ func TestCondensorClearLinksAtLevel(t *testing.T) {
 
 func TestCondensorWithoutEntrypoint(t *testing.T) {
 	rand.Seed(time.Now().UnixNano())
-	rootPath := fmt.Sprintf("./testdata/%d", rand.Intn(10000000))
-	os.MkdirAll(rootPath, 0o777)
-	defer func() {
-		err := os.RemoveAll(rootPath)
-		fmt.Println(err)
-	}()
+	rootPath := t.TempDir()
 
 	logger, _ := test.NewNullLogger()
 	uncondensed, err := NewCommitLogger(rootPath, "uncondensed", 0, logger)

--- a/adapters/repos/db/vector/hnsw/condensor_mmap_integration_test.go
+++ b/adapters/repos/db/vector/hnsw/condensor_mmap_integration_test.go
@@ -12,7 +12,6 @@
 package hnsw
 
 import (
-	"fmt"
 	"math/rand"
 	"os"
 	"strings"
@@ -28,12 +27,7 @@ func TestMmapCondensor(t *testing.T) {
 	t.Skip() // TODO
 
 	rand.Seed(time.Now().UnixNano())
-	rootPath := fmt.Sprintf("./testdata/%d", rand.Intn(10000000))
-	os.MkdirAll(rootPath, 0o777)
-	defer func() {
-		err := os.RemoveAll(rootPath)
-		fmt.Println(err)
-	}()
+	rootPath := t.TempDir()
 
 	logger, _ := test.NewNullLogger()
 	uncondensed, err := NewCommitLogger(rootPath, "uncondensed", 0, logger)
@@ -144,12 +138,7 @@ func TestMmapCondensor(t *testing.T) {
 
 // func TestCondensorWithoutEntrypoint(t *testing.T) {
 // 	rand.Seed(time.Now().UnixNano())
-// 	rootPath := fmt.Sprintf("./testdata/%d", rand.Intn(10000000))
-// 	os.MkdirAll(rootPath, 0o777)
-// 	defer func() {
-// 		err := os.RemoveAll(rootPath)
-// 		fmt.Println(err)
-// 	}()
+// 	rootPath := t.TmpDir()
 
 // 	logger, _ := test.NewNullLogger()
 // 	uncondensed, err := NewCommitLogger(rootPath, "uncondensed", 0, logger)

--- a/adapters/repos/db/vector/hnsw/index_corrupt_commitlogs_integration_test.go
+++ b/adapters/repos/db/vector/hnsw/index_corrupt_commitlogs_integration_test.go
@@ -31,12 +31,7 @@ import (
 
 func TestStartupWithCorruptCondenseFiles(t *testing.T) {
 	rand.Seed(time.Now().UnixNano())
-	rootPath := fmt.Sprintf("./testdata/%d", rand.Intn(10000000))
-	os.MkdirAll(rootPath, 0o777)
-	defer func() {
-		err := os.RemoveAll(rootPath)
-		fmt.Println(err)
-	}()
+	rootPath := t.TempDir()
 
 	logger, _ := test.NewNullLogger()
 	original, err := NewCommitLogger(rootPath, "corrupt_test", 0, logger)

--- a/adapters/repos/db/vector/hnsw/index_too_many_links_bug_integration_test.go
+++ b/adapters/repos/db/vector/hnsw/index_too_many_links_bug_integration_test.go
@@ -16,9 +16,7 @@ package hnsw
 
 import (
 	"context"
-	"fmt"
 	"math/rand"
-	"os"
 	"runtime"
 	"sync"
 	"testing"
@@ -44,12 +42,7 @@ func Test_NoRace_ManySmallCommitlogs(t *testing.T) {
 	m := 8
 
 	rand.Seed(time.Now().UnixNano())
-	rootPath := fmt.Sprintf("./testdata/%d", rand.Intn(10000000))
-	os.MkdirAll(rootPath, 0o777)
-	defer func() {
-		err := os.RemoveAll(rootPath)
-		fmt.Println(err)
-	}()
+	rootPath := t.TempDir()
 
 	logger, _ := test.NewNullLogger()
 	original, err := NewCommitLogger(rootPath, "too_many_links_test", 1, logger,

--- a/adapters/repos/db/vector/hnsw/persistence_integration_test.go
+++ b/adapters/repos/db/vector/hnsw/persistence_integration_test.go
@@ -31,13 +31,8 @@ import (
 
 func TestHnswPersistence(t *testing.T) {
 	rand.Seed(time.Now().UnixNano())
-	dirName := fmt.Sprintf("./testdata/%d", rand.Intn(10000000))
-	os.MkdirAll(dirName, 0o777)
+	dirName := t.TempDir()
 	indexID := "integrationtest"
-	defer func() {
-		err := os.RemoveAll(dirName)
-		fmt.Println(err)
-	}()
 
 	logger, _ := test.NewNullLogger()
 	cl, clErr := NewCommitLogger(dirName, indexID, 0, logger)
@@ -104,13 +99,8 @@ func TestHnswPersistence(t *testing.T) {
 
 func TestHnswPersistence_CorruptWAL(t *testing.T) {
 	rand.Seed(time.Now().UnixNano())
-	dirName := fmt.Sprintf("./testdata/%d", rand.Intn(10000000))
-	os.MkdirAll(dirName, 0o777)
+	dirName := t.TempDir()
 	indexID := "integrationtest_corrupt"
-	defer func() {
-		err := os.RemoveAll(dirName)
-		fmt.Println(err)
-	}()
 
 	logger, _ := test.NewNullLogger()
 	cl, clErr := NewCommitLogger(dirName, indexID, 0, logger)
@@ -214,14 +204,8 @@ func TestHnswPersistence_CorruptWAL(t *testing.T) {
 
 func TestHnswPersistence_WithDeletion_WithoutTombstoneCleanup(t *testing.T) {
 	rand.Seed(time.Now().UnixNano())
-	dirName := fmt.Sprintf("./testdata/%d", rand.Intn(10000000))
-	os.MkdirAll(dirName, 0o777)
+	dirName := t.TempDir()
 	indexID := "integrationtest_deletion"
-	defer func() {
-		err := os.RemoveAll(dirName)
-		fmt.Println(err)
-	}()
-
 	logger, _ := test.NewNullLogger()
 	cl, clErr := NewCommitLogger(dirName, indexID, 0, logger)
 	makeCL := func() (CommitLogger, error) {
@@ -297,13 +281,8 @@ func TestHnswPersistence_WithDeletion_WithoutTombstoneCleanup(t *testing.T) {
 
 func TestHnswPersistence_WithDeletion_WithTombstoneCleanup(t *testing.T) {
 	rand.Seed(time.Now().UnixNano())
-	dirName := fmt.Sprintf("./testdata/%d", rand.Intn(10000000))
-	os.MkdirAll(dirName, 0o777)
+	dirName := t.TempDir()
 	indexID := "integrationtest_tombstonecleanup"
-	defer func() {
-		err := os.RemoveAll(dirName)
-		fmt.Println(err)
-	}()
 
 	logger, _ := test.NewNullLogger()
 	makeCL := func() (CommitLogger, error) {

--- a/adapters/repos/db/vector/hnsw/snapshot_integration_test.go
+++ b/adapters/repos/db/vector/hnsw/snapshot_integration_test.go
@@ -34,7 +34,6 @@ func TestSnapshot_Integration(t *testing.T) {
 	indexID := "snapshot-integration-test"
 
 	dirName := makeTestDir(t)
-	defer removeTestDir(t, dirName)
 
 	idx, err := New(Config{
 		RootPath: dirName,

--- a/adapters/repos/db/vector/hnsw/snapshot_test.go
+++ b/adapters/repos/db/vector/hnsw/snapshot_test.go
@@ -32,7 +32,6 @@ func TestSnapshot_PauseMaintenance(t *testing.T) {
 		indexID := "snapshot-pause-maintenance-test"
 
 		dirName := makeTestDir(t)
-		defer removeTestDir(t, dirName)
 
 		userConfig := NewDefaultUserConfig()
 		userConfig.CleanupIntervalSeconds = 1
@@ -65,9 +64,6 @@ func TestSnapshot_PauseMaintenance(t *testing.T) {
 	t.Run("assert tombstone maintenance is successfully paused", func(t *testing.T) {
 		ctx := context.Background()
 
-		dirName := makeTestDir(t)
-		defer removeTestDir(t, dirName)
-
 		idx, err := New(Config{
 			RootPath:              "doesnt-matter-as-committlogger-is-mocked-out",
 			ID:                    "snapshot-pause-maintenance-test",
@@ -94,7 +90,6 @@ func TestSnapshot_SwitchCommitLogs(t *testing.T) {
 	indexID := "snapshot-switch-commitlogs-test"
 
 	dirName := makeTestDir(t)
-	defer removeTestDir(t, dirName)
 
 	idx, err := New(Config{
 		RootPath: dirName,
@@ -122,7 +117,6 @@ func TestSnapshot_ListFiles(t *testing.T) {
 	ctx := context.Background()
 
 	dirName := makeTestDir(t)
-	defer removeTestDir(t, dirName)
 
 	indexID := "snapshot-list-files-test"
 
@@ -170,7 +164,6 @@ func TestSnapshot_ResumeMaintenance(t *testing.T) {
 	indexID := "snapshot-resume-maintenance-test"
 
 	dirName := makeTestDir(t)
-	defer removeTestDir(t, dirName)
 
 	idx, err := New(Config{
 		RootPath: dirName,
@@ -206,15 +199,5 @@ func TestSnapshot_ResumeMaintenance(t *testing.T) {
 
 func makeTestDir(t *testing.T) string {
 	rand.Seed(time.Now().UnixNano())
-	dirName := fmt.Sprintf("./testdata/%d", rand.Intn(10000000))
-	if err := os.MkdirAll(dirName, 0o777); err != nil {
-		t.Fatalf("failed to make test dir '%s': %s", dirName, err)
-	}
-	return dirName
-}
-
-func removeTestDir(t *testing.T, dirName string) {
-	if err := os.RemoveAll(dirName); err != nil {
-		t.Errorf("failed to remove test dir '%s': %s", dirName, err)
-	}
+	return t.TempDir()
 }

--- a/adapters/repos/schema/repo_integration_test.go
+++ b/adapters/repos/schema/repo_integration_test.go
@@ -16,9 +16,7 @@ package schema
 
 import (
 	"context"
-	"fmt"
 	"math/rand"
-	"os"
 	"testing"
 	"time"
 
@@ -31,12 +29,7 @@ import (
 
 func Test_SchemaRepo(t *testing.T) {
 	rand.Seed(time.Now().UnixNano())
-	dirName := fmt.Sprintf("./testdata/%d", rand.Intn(10000000))
-	os.MkdirAll(dirName, 0o777)
-	defer func() {
-		err := os.RemoveAll(dirName)
-		fmt.Println(err)
-	}()
+	dirName := t.TempDir()
 
 	logger, _ := test.NewNullLogger()
 

--- a/usecases/classification/integrationtest/classifier_integration_test.go
+++ b/usecases/classification/integrationtest/classifier_integration_test.go
@@ -17,9 +17,7 @@ package classification_integration_test
 import (
 	"context"
 	"encoding/json"
-	"fmt"
 	"math/rand"
-	"os"
 	"testing"
 	"time"
 
@@ -40,13 +38,7 @@ import (
 
 func Test_Classifier_KNN_SaveConsistency(t *testing.T) {
 	rand.Seed(time.Now().UnixNano())
-	dirName := fmt.Sprintf("./testdata/%d", rand.Intn(10000000))
-	os.MkdirAll(dirName, 0o777)
-	defer func() {
-		err := os.RemoveAll(dirName)
-		fmt.Println(err)
-	}()
-
+	dirName := t.TempDir()
 	logger, _ := test.NewNullLogger()
 	var id strfmt.UUID
 
@@ -188,12 +180,7 @@ func Test_Classifier_KNN_SaveConsistency(t *testing.T) {
 func Test_Classifier_ZeroShot_SaveConsistency(t *testing.T) {
 	t.Skip()
 	rand.Seed(time.Now().UnixNano())
-	dirName := fmt.Sprintf("./testdata/%d", rand.Intn(10000000))
-	os.MkdirAll(dirName, 0o777)
-	defer func() {
-		err := os.RemoveAll(dirName)
-		fmt.Println(err)
-	}()
+	dirName := t.TempDir()
 
 	logger, _ := test.NewNullLogger()
 	var id strfmt.UUID


### PR DESCRIPTION
Currently some test create testdata in temporary folders created on the disk. These files just stay on disk and can result in slow load times when using run_ci_server.sh as the testdata will be aprt of the docker context. It had 3.6GB when I noticed this.

This PR now creates the testdata in a go [testing.tmpdir](https://pkg.go.dev/testing#T.TempDir) that are cleaned up automatically