### PR TITLE
Small aggregation memory allocation improvements

### DIFF
--- a/adapters/repos/db/aggregator/numerical.go
+++ b/adapters/repos/db/aggregator/numerical.go
@@ -94,6 +94,12 @@ func (a *numericalAggregator) AddFloat64(value float64) error {
 
 // turns the value counter into a sorted list, as well as identifying the mode
 func (a *numericalAggregator) buildPairsFromCounts() {
+	if a.pairs == nil {
+		a.pairs = make([]floatCountPair, 0, len(a.valueCounter))
+	} else {
+		a.pairs = append(a.pairs, make([]floatCountPair, 0, len(a.valueCounter))...)
+	}
+
 	for value, count := range a.valueCounter {
 		if count > a.maxCount {
 			a.maxCount = count

--- a/adapters/repos/db/lsmkv/segmentindex/disk_tree.go
+++ b/adapters/repos/db/lsmkv/segmentindex/disk_tree.go
@@ -48,36 +48,43 @@ func (t *DiskTree) Get(key []byte) (Node, error) {
 	if len(t.data) == 0 {
 		return Node{}, NotFound
 	}
+	var out Node
+	byteOps := byte_operations.ByteOperations{Buffer: t.data}
 
-	return t.getAt(0, key)
-}
-
-func (t *DiskTree) getAt(offset int64, key []byte) (Node, error) {
-	node, err := t.readNodeAt(offset)
-	if err != nil {
-		return Node{}, err
-	}
-
-	if bytes.Equal(node.key, key) {
-		return Node{
-			Key:   node.key,
-			Start: node.startPos,
-			End:   node.endPos,
-		}, nil
-	}
-
-	if bytes.Compare(key, node.key) < 0 {
-		if node.leftChild < 0 {
-			return Node{}, NotFound
+	// jump to the buffer until the node with _key_ is found or return a NotFound error.
+	// This function avoids allocations by reusing the same buffer for all keys and avoids memory reads by only
+	// extracting the necessary pieces of information while skipping the rest
+	NodeKeyBuffer := make([]byte, len(key))
+	for {
+		// detect if there is no node with the wanted key.
+		if byteOps.Position+4 > uint64(len(t.data)) || byteOps.Position+4 < 4 {
+			return out, NotFound
 		}
 
-		return t.getAt(node.leftChild, key)
-	} else {
-		if node.rightChild < 0 {
-			return Node{}, NotFound
+		keyLen := byteOps.ReadUint32()
+		if int(keyLen) > len(NodeKeyBuffer) {
+			NodeKeyBuffer = make([]byte, int(keyLen))
+		} else if int(keyLen) < len(NodeKeyBuffer) {
+			NodeKeyBuffer = NodeKeyBuffer[:keyLen]
+		}
+		_, err := byteOps.CopyBytesFromBuffer(uint64(keyLen), NodeKeyBuffer)
+		if err != nil {
+			return out, errors.Wrap(err, "Could not copy node key")
 		}
 
-		return t.getAt(node.rightChild, key)
+		keyEqual := bytes.Compare(key, NodeKeyBuffer)
+		if keyEqual == 0 {
+			out.Key = NodeKeyBuffer
+			out.Start = byteOps.ReadUint64()
+			out.End = byteOps.ReadUint64()
+			return out, nil
+		} else if keyEqual < 0 {
+			byteOps.MoveBufferPositionForward(2 * 8) // jump over start+end position
+			byteOps.Position = byteOps.ReadUint64()  // left child
+		} else {
+			byteOps.MoveBufferPositionForward(3 * 8) // jump over start+end position and left child
+			byteOps.Position = byteOps.ReadUint64()  // right child
+		}
 	}
 }
 
@@ -97,7 +104,7 @@ func (t *DiskTree) readNode(in []byte) (dtNode, int, error) {
 	byteOps := byte_operations.ByteOperations{Buffer: in}
 
 	keyLen := uint64(byteOps.ReadUint32())
-	copiedBytes, err := byteOps.CopyBytesFromBuffer(keyLen)
+	copiedBytes, err := byteOps.CopyBytesFromBuffer(keyLen, nil)
 	if err != nil {
 		return out, int(byteOps.Position), errors.Wrap(err, "Could not copy node key")
 	}

--- a/entities/storobj/storage_object.go
+++ b/entities/storobj/storage_object.go
@@ -470,25 +470,25 @@ func (ko *Object) UnmarshalBinary(data []byte) error {
 	}
 
 	classNameLength := uint64(byteOps.ReadUint16())
-	className, err := byteOps.CopyBytesFromBuffer(classNameLength)
+	className, err := byteOps.CopyBytesFromBuffer(classNameLength, nil)
 	if err != nil {
 		return errors.Wrap(err, "Could not copy class name")
 	}
 
 	schemaLength := uint64(byteOps.ReadUint32())
-	schema, err := byteOps.CopyBytesFromBuffer(schemaLength)
+	schema, err := byteOps.CopyBytesFromBuffer(schemaLength, nil)
 	if err != nil {
 		return errors.Wrap(err, "Could not copy schema")
 	}
 
 	metaLength := uint64(byteOps.ReadUint32())
-	meta, err := byteOps.CopyBytesFromBuffer(metaLength)
+	meta, err := byteOps.CopyBytesFromBuffer(metaLength, nil)
 	if err != nil {
 		return errors.Wrap(err, "Could not copy meta")
 	}
 
 	vectorWeightsLength := uint64(byteOps.ReadUint32())
-	vectorWeights, err := byteOps.CopyBytesFromBuffer(vectorWeightsLength)
+	vectorWeights, err := byteOps.CopyBytesFromBuffer(vectorWeightsLength, nil)
 	if err != nil {
 		return errors.Wrap(err, "Could not copy vectorWeights")
 	}

--- a/usecases/byte_operations/byte_operations.go
+++ b/usecases/byte_operations/byte_operations.go
@@ -43,8 +43,10 @@ func (bo *ByteOperations) ReadUint32() uint32 {
 	return binary.LittleEndian.Uint32(bo.Buffer[bo.Position-uint32Len : bo.Position])
 }
 
-func (bo *ByteOperations) CopyBytesFromBuffer(length uint64) ([]byte, error) {
-	out := make([]byte, length)
+func (bo *ByteOperations) CopyBytesFromBuffer(length uint64, out []byte) ([]byte, error) {
+	if out == nil {
+		out = make([]byte, length)
+	}
 	bo.Position += length
 	numCopiedBytes := copy(out, bo.Buffer[bo.Position-length:bo.Position])
 	if numCopiedBytes != int(length) {

--- a/usecases/byte_operations/byte_operations_test.go
+++ b/usecases/byte_operations/byte_operations_test.go
@@ -44,7 +44,7 @@ func TestReadAnWrite(t *testing.T) {
 	require.Equal(t, byteOpsRead.ReadUint64(), valuesNumbers[0])
 	require.Equal(t, byteOpsRead.ReadUint32(), uint32(valuesNumbers[1]))
 	require.Equal(t, byteOpsRead.ReadUint32(), uint32(valuesNumbers[2]))
-	returnBuf, err := byteOpsRead.CopyBytesFromBuffer(uint64(len(valuesByteArray)))
+	returnBuf, err := byteOpsRead.CopyBytesFromBuffer(uint64(len(valuesByteArray)), nil)
 	assert.Equal(t, returnBuf, valuesByteArray)
 	assert.Equal(t, err, nil)
 	require.Equal(t, byteOpsRead.ReadUint16(), uint16(valuesNumbers[3]))


### PR DESCRIPTION
Two small changes that result in less allocations when aggregating. I split them out of another PR that will take more time and these changes are independent from the rest. 

This reduces the memory allocations by ~5GB (of 30GB).

Comparison (the pictures are form the original PR and contain more changes, only the circled boxes apply to this PR):
[Before](https://user-images.githubusercontent.com/5353192/186384821-a6cc2752-baaa-44e7-9f4b-022b99b025f9.png)
[After](https://user-images.githubusercontent.com/5353192/186384796-99cb473f-9ef1-4dd9-8d07-894dcc205cfb.png)



