### PR TITLE
Fix getting snapshotter when index doesn't exist

### DIFF
--- a/adapters/handlers/rest/snapshot.go
+++ b/adapters/handlers/rest/snapshot.go
@@ -26,5 +26,8 @@ type snapshotterProvider struct {
 }
 
 func (sp *snapshotterProvider) Snapshotter(className string) backup.Snapshotter {
-	return sp.db.GetIndex(schema.ClassName(className))
+	if idx := sp.db.GetIndex(schema.ClassName(className)); idx != nil {
+		return idx
+	}
+	return nil
 }


### PR DESCRIPTION
This fixes the bug  when the backup manager gets a non nil pointer to an index implementing the snapshotter interface even when it doesn' exit