### PR TITLE
Include usage dimensions on Get Requests in optional Monitoring

### DIFF
--- a/adapters/handlers/rest/configure_api.go
+++ b/adapters/handlers/rest/configure_api.go
@@ -87,7 +87,7 @@ type vectorRepo interface {
 
 type explorer interface {
 	GetClass(ctx context.Context, params traverser.GetParams) ([]interface{}, error)
-	Concepts(ctx context.Context, params traverser.ExploreParams) ([]search.Result, error)
+	CrossClassVectorSearch(ctx context.Context, params traverser.ExploreParams) ([]search.Result, error)
 	SetSchemaGetter(schemaUC.SchemaGetter)
 }
 
@@ -164,7 +164,7 @@ func configureAPI(api *operations.WeaviateAPI) http.Handler {
 	vectorMigrator = db.NewMigrator(repo, appState.Logger)
 	vectorRepo = repo
 	migrator = vectorMigrator
-	explorer = traverser.NewExplorer(repo, appState.Logger, appState.Modules, appState.Metrics)
+	explorer = traverser.NewExplorer(repo, appState.Logger, appState.Modules, traverser.NewMetrics(appState.Metrics))
 	schemaRepo, err = schemarepo.NewRepo(
 		appState.ServerConfig.Config.Persistence.DataPath, appState.Logger)
 	if err != nil {

--- a/adapters/handlers/rest/configure_api.go
+++ b/adapters/handlers/rest/configure_api.go
@@ -164,7 +164,7 @@ func configureAPI(api *operations.WeaviateAPI) http.Handler {
 	vectorMigrator = db.NewMigrator(repo, appState.Logger)
 	vectorRepo = repo
 	migrator = vectorMigrator
-	explorer = traverser.NewExplorer(repo, appState.Logger, appState.Modules)
+	explorer = traverser.NewExplorer(repo, appState.Logger, appState.Modules, appState.Metrics)
 	schemaRepo, err = schemarepo.NewRepo(
 		appState.ServerConfig.Config.Persistence.DataPath, appState.Logger)
 	if err != nil {

--- a/adapters/handlers/rest/configure_api.go
+++ b/adapters/handlers/rest/configure_api.go
@@ -230,7 +230,7 @@ func configureAPI(api *operations.WeaviateAPI) http.Handler {
 	objectsManager := objects.NewManager(appState.Locks,
 		schemaManager, appState.ServerConfig, appState.Logger,
 		appState.Authorizer, appState.Modules, vectorRepo, appState.Modules,
-		appState.Metrics)
+		objects.NewMetrics(appState.Metrics))
 	batchObjectsManager := objects.NewBatchManager(vectorRepo, appState.Modules,
 		appState.Locks, schemaManager, appState.ServerConfig, appState.Logger,
 		appState.Authorizer, appState.Metrics)

--- a/adapters/repos/db/crud_integration_test.go
+++ b/adapters/repos/db/crud_integration_test.go
@@ -1254,6 +1254,7 @@ func TestCRUD(t *testing.T) {
 					},
 					Score:                1,
 					AdditionalProperties: models.AdditionalProperties{},
+					Dims:                 4,
 				},
 			}
 

--- a/entities/search/result.go
+++ b/entities/search/result.go
@@ -32,6 +32,9 @@ type Result struct {
 	Updated              int64
 	AdditionalProperties models.AdditionalProperties
 	VectorWeights        map[string]string
+
+	// Dimensions in case search was vector-based, 0 otherwise
+	Dims int
 }
 
 type Results []Result

--- a/entities/storobj/storage_object.go
+++ b/entities/storobj/storage_object.go
@@ -261,6 +261,7 @@ func (ko *Object) SearchResult(additional additional.Properties) *search.Result 
 		ClassName: ko.Class().String(),
 		Schema:    ko.Properties(),
 		Vector:    ko.Vector,
+		Dims:      ko.VectorLen,
 		// VectorWeights: ko.VectorWeights(), // TODO: add vector weights
 		Created:              ko.CreationTimeUnix(),
 		Updated:              ko.LastUpdateTimeUnix(),

--- a/entities/storobj/storage_object.go
+++ b/entities/storobj/storage_object.go
@@ -33,6 +33,7 @@ type Object struct {
 	MarshallerVersion uint8
 	Object            models.Object `json:"object"`
 	Vector            []float32     `json:"vector"`
+	VectorLen         int
 	docID             uint64
 }
 
@@ -48,6 +49,7 @@ func FromObject(object *models.Object, vector []float32) *Object {
 		Object:            *object,
 		Vector:            vector,
 		MarshallerVersion: 1,
+		VectorLen:         len(vector),
 	}
 }
 
@@ -98,6 +100,7 @@ func FromBinaryOptional(data []byte,
 	ec.AddWrap(binary.Read(r, le, &createTime), "create time")
 	ec.AddWrap(binary.Read(r, le, &updateTime), "update time")
 	ec.AddWrap(binary.Read(r, le, &vectorLength), "vector length")
+	ko.VectorLen = int(vectorLength)
 	if addProp.Vector {
 		ko.Vector = make([]float32, vectorLength)
 		ec.AddWrap(binary.Read(r, le, &ko.Vector), "read vector")
@@ -464,6 +467,7 @@ func (ko *Object) UnmarshalBinary(data []byte) error {
 	updateTime := int64(byteOps.ReadUint64())
 
 	vectorLength := byteOps.ReadUint16()
+	ko.VectorLen = int(vectorLength)
 	ko.Vector = make([]float32, vectorLength)
 	for j := 0; j < int(vectorLength); j++ {
 		ko.Vector[j] = math.Float32frombits(byteOps.ReadUint32())

--- a/entities/storobj/storage_object.go
+++ b/entities/storobj/storage_object.go
@@ -33,7 +33,7 @@ type Object struct {
 	MarshallerVersion uint8
 	Object            models.Object `json:"object"`
 	Vector            []float32     `json:"vector"`
-	VectorLen         int
+	VectorLen         int           `json:"-"`
 	docID             uint64
 }
 

--- a/entities/storobj/storage_object_test.go
+++ b/entities/storobj/storage_object_test.go
@@ -120,9 +120,14 @@ func TestStorageObjectUnmarshallingSpecificProps(t *testing.T) {
 			// modify before to match expectations of after
 			before.Object.Additional = nil
 			before.Vector = nil
+			before.VectorLen = 3
 			assert.Equal(t, before, after)
 
 			assert.Equal(t, before.docID, after.docID)
+
+			// The vector length should always be returned (for usage metrics
+			// purposes) even if the vector itself is skipped
+			assert.Equal(t, after.VectorLen, 3)
 		})
 	})
 }

--- a/usecases/monitoring/prometheus.go
+++ b/usecases/monitoring/prometheus.go
@@ -164,6 +164,6 @@ func NewPrometheusMetrics() *PrometheusMetrics { // TODO don't rely on global st
 		QueryDimensions: promauto.NewCounterVec(prometheus.CounterOpts{
 			Name: "query_dimensions_total",
 			Help: "The vector dimensions used by any read-query that involves vectors",
-		}, []string{"api", "operation", "class_name"}),
+		}, []string{"query_type", "operation", "class_name"}),
 	}
 }

--- a/usecases/monitoring/prometheus.go
+++ b/usecases/monitoring/prometheus.go
@@ -38,6 +38,7 @@ type PrometheusMetrics struct {
 	ObjectCount                        *prometheus.GaugeVec
 	QueriesCount                       *prometheus.GaugeVec
 	GoroutinesCount                    *prometheus.GaugeVec
+	QueryDimensions                    *prometheus.CounterVec
 
 	StartupProgress  *prometheus.GaugeVec
 	StartupDurations *prometheus.HistogramVec
@@ -160,5 +161,9 @@ func NewPrometheusMetrics() *PrometheusMetrics { // TODO don't rely on global st
 			Help:    "Disk I/O throuhput in bytes per second",
 			Buckets: prometheus.ExponentialBuckets(1, 2, 40),
 		}, []string{"operation", "class_name", "shard_name"}),
+		QueryDimensions: promauto.NewCounterVec(prometheus.CounterOpts{
+			Name: "query_dimensions_total",
+			Help: "The vector dimensions used by any read-query that involves vectors",
+		}, []string{"api", "operation", "class_name"}),
 	}
 }

--- a/usecases/objects/add_test.go
+++ b/usecases/objects/add_test.go
@@ -70,7 +70,8 @@ func Test_Add_Object_WithNoVectorizerModule(t *testing.T) {
 		logger, _ := test.NewNullLogger()
 		vectorizer := &fakeVectorizer{}
 		vecProvider := &fakeVectorizerProvider{vectorizer}
-		manager = NewManager(locks, schemaManager, cfg, logger, authorizer, vecProvider, vectorRepo, getFakeModulesProvider(), nil)
+		metrics := &fakeMetrics{}
+		manager = NewManager(locks, schemaManager, cfg, logger, authorizer, vecProvider, vectorRepo, getFakeModulesProvider(), metrics)
 	}
 
 	reset := func() {
@@ -228,7 +229,8 @@ func Test_Add_Object_WithExternalVectorizerModule(t *testing.T) {
 		vectorizer := &fakeVectorizer{}
 		vecProvider := &fakeVectorizerProvider{vectorizer}
 		vectorizer.On("UpdateObject", mock.Anything).Return([]float32{0, 1, 2}, nil)
-		manager = NewManager(locks, schemaManager, cfg, logger, authorizer, vecProvider, vectorRepo, getFakeModulesProvider(), nil)
+		metrics := &fakeMetrics{}
+		manager = NewManager(locks, schemaManager, cfg, logger, authorizer, vecProvider, vectorRepo, getFakeModulesProvider(), metrics)
 	}
 
 	t.Run("without an id set", func(t *testing.T) {
@@ -330,7 +332,8 @@ func Test_Add_Object_OverrideVectorizer(t *testing.T) {
 		logger, _ := test.NewNullLogger()
 		vectorizer := &fakeVectorizer{}
 		vecProvider := &fakeVectorizerProvider{vectorizer}
-		manager = NewManager(locks, schemaManager, cfg, logger, authorizer, vecProvider, vectorRepo, getFakeModulesProvider(), nil)
+		metrics := &fakeMetrics{}
+		manager = NewManager(locks, schemaManager, cfg, logger, authorizer, vecProvider, vectorRepo, getFakeModulesProvider(), metrics)
 	}
 
 	t.Run("overriding the vector by explicitly specifying it", func(t *testing.T) {

--- a/usecases/objects/delete_test.go
+++ b/usecases/objects/delete_test.go
@@ -96,6 +96,6 @@ func newDeleteDependency() (*Manager, *fakeVectorRepo) {
 		&vecProvider,
 		vectorRepo,
 		getFakeModulesProvider(),
-		nil)
+		new(fakeMetrics))
 	return manager, vectorRepo
 }

--- a/usecases/objects/fakes_for_test.go
+++ b/usecases/objects/fakes_for_test.go
@@ -673,3 +673,77 @@ func getFakeModulesProviderWithCustomExtenders(
 ) *fakeModulesProvider {
 	return &fakeModulesProvider{customExtender, customProjector}
 }
+
+type fakeMetrics struct{}
+
+func (f *fakeMetrics) BatchInc() {
+}
+
+func (f *fakeMetrics) BatchDec() {
+}
+
+func (f *fakeMetrics) BatchRefInc() {
+}
+
+func (f *fakeMetrics) BatchRefDec() {
+}
+
+func (f *fakeMetrics) BatchDeleteInc() {
+}
+
+func (f *fakeMetrics) BatchDeleteDec() {
+}
+
+func (f *fakeMetrics) AddObjectInc() {
+}
+
+func (f *fakeMetrics) AddObjectDec() {
+}
+
+func (f *fakeMetrics) UpdateObjectInc() {
+}
+
+func (f *fakeMetrics) UpdateObjectDec() {
+}
+
+func (f *fakeMetrics) MergeObjectInc() {
+}
+
+func (f *fakeMetrics) MergeObjectDec() {
+}
+
+func (f *fakeMetrics) DeleteObjectInc() {
+}
+
+func (f *fakeMetrics) DeleteObjectDec() {
+}
+
+func (f *fakeMetrics) GetObjectInc() {
+}
+
+func (f *fakeMetrics) GetObjectDec() {
+}
+
+func (f *fakeMetrics) HeadObjectInc() {
+}
+
+func (f *fakeMetrics) HeadObjectDec() {
+}
+
+func (f *fakeMetrics) AddReferenceInc() {
+}
+
+func (f *fakeMetrics) AddReferenceDec() {
+}
+
+func (f *fakeMetrics) UpdateReferenceInc() {
+}
+
+func (f *fakeMetrics) UpdateReferenceDec() {
+}
+
+func (f *fakeMetrics) DeleteReferenceInc() {
+}
+
+func (f *fakeMetrics) DeleteReferenceDec() {
+}

--- a/usecases/objects/fakes_for_test.go
+++ b/usecases/objects/fakes_for_test.go
@@ -674,7 +674,11 @@ func getFakeModulesProviderWithCustomExtenders(
 	return &fakeModulesProvider{customExtender, customProjector}
 }
 
-type fakeMetrics struct{}
+type fakeMetrics struct {
+	// Note: only those metric functions that relate to usage-related metrics are
+	// covered by this mock, others are empty shells
+	mock.Mock
+}
 
 func (f *fakeMetrics) BatchInc() {
 }
@@ -746,4 +750,8 @@ func (f *fakeMetrics) DeleteReferenceInc() {
 }
 
 func (f *fakeMetrics) DeleteReferenceDec() {
+}
+
+func (f *fakeMetrics) AddUsageDimensions(className, queryType, op string, dims int) {
+	f.Mock.MethodCalled("AddUsageDimensions", className, queryType, op, dims)
 }

--- a/usecases/objects/fakes_for_test.go
+++ b/usecases/objects/fakes_for_test.go
@@ -180,7 +180,8 @@ func (f *fakeVectorRepo) ObjectSearch(ctx context.Context, offset, limit int, fi
 
 func (f *fakeVectorRepo) Query(ctx context.Context, q *QueryInput) (search.Results, *Error) {
 	args := f.Called(q)
-	return args.Get(0).([]search.Result), args.Error(1).(*Error)
+	res, err := args.Get(0).([]search.Result), args.Error(1).(*Error)
+	return res, err
 }
 
 func (f *fakeVectorRepo) PutObject(ctx context.Context,

--- a/usecases/objects/get.go
+++ b/usecases/objects/get.go
@@ -53,7 +53,7 @@ func (m *Manager) GetObject(ctx context.Context, principal *models.Principal, cl
 	}
 
 	if additional.Vector {
-		m.trackUsageSingle(res, class)
+		m.trackUsageSingle(res)
 	}
 
 	return res.ObjectWithVector(additional.Vector), nil
@@ -154,6 +154,10 @@ func (m *Manager) getObjectsFromRepo(ctx context.Context, offset, limit *int64,
 		}
 	}
 
+	if additional.Vector {
+		m.trackUsageList(res)
+	}
+
 	return res.ObjectsWithVector(additional.Vector), nil
 }
 
@@ -218,9 +222,16 @@ func (m *Manager) localOffsetLimit(paramOffset *int64, paramLimit *int64) (int, 
 	return offset, limit, nil
 }
 
-func (m *Manager) trackUsageSingle(res *search.Result, className string) {
+func (m *Manager) trackUsageSingle(res *search.Result) {
 	if res == nil {
 		return
 	}
 	m.metrics.AddUsageDimensions(res.ClassName, "get_rest", "single_include_vector", res.Dims)
+}
+
+func (m *Manager) trackUsageList(res search.Results) {
+	if len(res) == 0 {
+		return
+	}
+	m.metrics.AddUsageDimensions(res[0].ClassName, "get_rest", "list_include_vector", res[0].Dims)
 }

--- a/usecases/objects/get.go
+++ b/usecases/objects/get.go
@@ -52,6 +52,10 @@ func (m *Manager) GetObject(ctx context.Context, principal *models.Principal, cl
 		return nil, err
 	}
 
+	if additional.Vector {
+		m.trackUsageSingle(res, class)
+	}
+
 	return res.ObjectWithVector(additional.Vector), nil
 }
 
@@ -212,4 +216,11 @@ func (m *Manager) localOffsetLimit(paramOffset *int64, paramLimit *int64) (int, 
 	}
 
 	return offset, limit, nil
+}
+
+func (m *Manager) trackUsageSingle(res *search.Result, className string) {
+	if res == nil {
+		return
+	}
+	m.metrics.AddUsageDimensions(res.ClassName, "get_rest", "single_include_vector", res.Dims)
 }

--- a/usecases/objects/get_test.go
+++ b/usecases/objects/get_test.go
@@ -62,8 +62,9 @@ func Test_GetAction(t *testing.T) {
 		projectorFake = &fakeProjector{}
 		vectorizer := &fakeVectorizer{}
 		vecProvider := &fakeVectorizerProvider{vectorizer}
+		metrics := &fakeMetrics{}
 		manager = NewManager(locks, schemaManager, cfg, logger, authorizer,
-			vecProvider, vectorRepo, getFakeModulesProviderWithCustomExtenders(extender, projectorFake), nil)
+			vecProvider, vectorRepo, getFakeModulesProviderWithCustomExtenders(extender, projectorFake), metrics)
 	}
 
 	t.Run("get non-existing action by id", func(t *testing.T) {
@@ -608,8 +609,9 @@ func Test_GetThing(t *testing.T) {
 		projectorFake = &fakeProjector{}
 		vectorizer := &fakeVectorizer{}
 		vecProvider := &fakeVectorizerProvider{vectorizer}
+		metrics := &fakeMetrics{}
 		manager = NewManager(locks, schemaManager, cfg, logger, authorizer,
-			vecProvider, vectorRepo, getFakeModulesProviderWithCustomExtenders(extender, projectorFake), nil)
+			vecProvider, vectorRepo, getFakeModulesProviderWithCustomExtenders(extender, projectorFake), metrics)
 	}
 
 	t.Run("get non-existing thing by id", func(t *testing.T) {
@@ -978,6 +980,7 @@ type fakeGetManager struct {
 	vectorizer *fakeVectorizer
 	authorizer *fakeAuthorizer
 	locks      *fakeLocks
+	metrics    *fakeMetrics
 }
 
 func newFakeGetManager(schema schema.Schema) fakeGetManager {
@@ -988,6 +991,7 @@ func newFakeGetManager(schema schema.Schema) fakeGetManager {
 		vectorizer: new(fakeVectorizer),
 		authorizer: new(fakeAuthorizer),
 		locks:      new(fakeLocks),
+		metrics:    new(fakeMetrics),
 	}
 	schemaManager := &fakeSchemaManager{
 		GetSchemaResponse: schema,
@@ -998,6 +1002,6 @@ func newFakeGetManager(schema schema.Schema) fakeGetManager {
 	logger, _ := test.NewNullLogger()
 	vecProvider := &fakeVectorizerProvider{r.vectorizer}
 	mProvider := getFakeModulesProviderWithCustomExtenders(r.extender, r.projector)
-	r.Manager = NewManager(r.locks, schemaManager, cfg, logger, r.authorizer, vecProvider, r.repo, mProvider, nil)
+	r.Manager = NewManager(r.locks, schemaManager, cfg, logger, r.authorizer, vecProvider, r.repo, mProvider, r.metrics)
 	return r
 }

--- a/usecases/objects/get_test.go
+++ b/usecases/objects/get_test.go
@@ -157,6 +157,39 @@ func Test_GetAction(t *testing.T) {
 		assert.Equal(t, expected, res)
 	})
 
+	t.Run("list all existing objects with vectors", func(t *testing.T) {
+		reset()
+		id := strfmt.UUID("99ee9968-22ec-416a-9032-cff80f2f7fdf")
+
+		results := []search.Result{
+			{
+				ID:        id,
+				ClassName: "ActionClass",
+				Schema:    map[string]interface{}{"foo": "bar"},
+				Vector:    []float32{1, 2, 3},
+				Dims:      3,
+			},
+		}
+		vectorRepo.On("ObjectSearch", 0, 20, mock.Anything, mock.Anything, mock.Anything,
+			mock.Anything).Return(results, nil).Once()
+
+		metrics.On("AddUsageDimensions", "ActionClass", "get_rest", "list_include_vector", 3)
+
+		expected := []*models.Object{
+			{
+				ID:            id,
+				Class:         "ActionClass",
+				Properties:    map[string]interface{}{"foo": "bar"},
+				VectorWeights: (map[string]string)(nil),
+				Vector:        []float32{1, 2, 3},
+			},
+		}
+
+		res, err := manager.GetObjects(context.Background(), &models.Principal{}, nil, nil, nil, nil, additional.Properties{Vector: true})
+		require.Nil(t, err)
+		assert.Equal(t, expected, res)
+	})
+
 	t.Run("list all existing actions with all explicit offset and limit", func(t *testing.T) {
 		reset()
 		id := strfmt.UUID("99ee9968-22ec-416a-9032-cff80f2f7fdf")

--- a/usecases/objects/manager.go
+++ b/usecases/objects/manager.go
@@ -27,7 +27,6 @@ import (
 	"github.com/semi-technologies/weaviate/entities/models"
 	"github.com/semi-technologies/weaviate/entities/search"
 	"github.com/semi-technologies/weaviate/usecases/config"
-	"github.com/semi-technologies/weaviate/usecases/monitoring"
 	"github.com/sirupsen/logrus"
 )
 
@@ -44,7 +43,34 @@ type Manager struct {
 	timeSource         timeSource
 	modulesProvider    ModulesProvider
 	autoSchemaManager  *autoSchemaManager
-	metrics            *Metrics
+	metrics            objectsMetrics
+}
+
+type objectsMetrics interface {
+	BatchInc()
+	BatchDec()
+	BatchRefInc()
+	BatchRefDec()
+	BatchDeleteInc()
+	BatchDeleteDec()
+	AddObjectInc()
+	AddObjectDec()
+	UpdateObjectInc()
+	UpdateObjectDec()
+	MergeObjectInc()
+	MergeObjectDec()
+	DeleteObjectInc()
+	DeleteObjectDec()
+	GetObjectInc()
+	GetObjectDec()
+	HeadObjectInc()
+	HeadObjectDec()
+	AddReferenceInc()
+	AddReferenceDec()
+	UpdateReferenceInc()
+	UpdateReferenceDec()
+	DeleteReferenceInc()
+	DeleteReferenceDec()
 }
 
 type timeSource interface {
@@ -97,7 +123,7 @@ type ModulesProvider interface {
 func NewManager(locks locks, schemaManager schemaManager,
 	config *config.WeaviateConfig, logger logrus.FieldLogger,
 	authorizer authorizer, vectorizer VectorizerProvider, vectorRepo VectorRepo,
-	modulesProvider ModulesProvider, prom *monitoring.PrometheusMetrics,
+	modulesProvider ModulesProvider, metrics objectsMetrics,
 ) *Manager {
 	return &Manager{
 		config:             config,
@@ -110,7 +136,7 @@ func NewManager(locks locks, schemaManager schemaManager,
 		timeSource:         defaultTimeSource{},
 		modulesProvider:    modulesProvider,
 		autoSchemaManager:  newAutoSchemaManager(schemaManager, vectorRepo, config, logger),
-		metrics:            NewMetrics(prom),
+		metrics:            metrics,
 	}
 }
 

--- a/usecases/objects/manager.go
+++ b/usecases/objects/manager.go
@@ -71,6 +71,7 @@ type objectsMetrics interface {
 	UpdateReferenceDec()
 	DeleteReferenceInc()
 	DeleteReferenceDec()
+	AddUsageDimensions(className, queryType, operation string, dims int)
 }
 
 type timeSource interface {

--- a/usecases/objects/metrics.go
+++ b/usecases/objects/metrics.go
@@ -21,6 +21,7 @@ import (
 type Metrics struct {
 	queriesCount *prometheus.GaugeVec
 	batchTime    *prometheus.HistogramVec
+	dimensions   *prometheus.CounterVec
 }
 
 func NewMetrics(prom *monitoring.PrometheusMetrics) *Metrics {
@@ -164,4 +165,16 @@ func (m *Metrics) BatchOp(op string, startNs int64) {
 		"class_name": "n/a",
 		"shard_name": "n/a",
 	}).Observe(float64(took))
+}
+
+func (m *Metrics) AddUsageDimensions(className, queryType, operation string, dims int) {
+	if m == nil {
+		return
+	}
+
+	m.dimensions.With(prometheus.Labels{
+		"class_name": className,
+		"operation":  operation,
+		"query_type": queryType,
+	}).Add(float64(dims))
 }

--- a/usecases/objects/metrics.go
+++ b/usecases/objects/metrics.go
@@ -32,6 +32,7 @@ func NewMetrics(prom *monitoring.PrometheusMetrics) *Metrics {
 	return &Metrics{
 		queriesCount: prom.QueriesCount,
 		batchTime:    prom.BatchTime,
+		dimensions:   prom.QueryDimensions,
 	}
 }
 

--- a/usecases/objects/query.go
+++ b/usecases/objects/query.go
@@ -82,5 +82,9 @@ func (m *Manager) Query(ctx context.Context, principal *models.Principal, params
 		}
 	}
 
+	if q.Additional.Vector {
+		m.trackUsageList(res)
+	}
+
 	return res.ObjectsWithVector(q.Additional.Vector), nil
 }

--- a/usecases/objects/update_test.go
+++ b/usecases/objects/update_test.go
@@ -70,8 +70,9 @@ func Test_UpdateAction(t *testing.T) {
 		projectorFake = &fakeProjector{}
 		vectorizer = &fakeVectorizer{}
 		vecProvider := &fakeVectorizerProvider{vectorizer}
+		metrics := &fakeMetrics{}
 		manager = NewManager(locks, schemaManager, cfg, logger, authorizer,
-			vecProvider, db, getFakeModulesProviderWithCustomExtenders(extender, projectorFake), nil)
+			vecProvider, db, getFakeModulesProviderWithCustomExtenders(extender, projectorFake), metrics)
 	}
 
 	t.Run("ensure creation timestamp persists", func(t *testing.T) {

--- a/usecases/traverser/explorer_test.go
+++ b/usecases/traverser/explorer_test.go
@@ -60,7 +60,7 @@ func Test_Explorer_GetClass(t *testing.T) {
 
 		search := &fakeVectorSearcher{}
 		log, _ := test.NewNullLogger()
-		explorer := NewExplorer(search, log, getFakeModulesProvider())
+		explorer := NewExplorer(search, log, getFakeModulesProvider(), nil)
 		expectedParamsToSearch := params
 		expectedParamsToSearch.SearchVector = []float32{0.8, 0.2, 0.7}
 		search.
@@ -102,7 +102,7 @@ func Test_Explorer_GetClass(t *testing.T) {
 
 			search := &fakeVectorSearcher{}
 			log, _ := test.NewNullLogger()
-			explorer := NewExplorer(search, log, getFakeModulesProvider())
+			explorer := NewExplorer(search, log, getFakeModulesProvider(), nil)
 
 			res, err := explorer.GetClass(context.Background(), params)
 
@@ -127,7 +127,7 @@ func Test_Explorer_GetClass(t *testing.T) {
 
 			search := &fakeVectorSearcher{}
 			log, _ := test.NewNullLogger()
-			explorer := NewExplorer(search, log, getFakeModulesProvider())
+			explorer := NewExplorer(search, log, getFakeModulesProvider(), nil)
 
 			res, err := explorer.GetClass(context.Background(), params)
 
@@ -178,7 +178,7 @@ func Test_Explorer_GetClass(t *testing.T) {
 
 				search := &fakeVectorSearcher{}
 				log, _ := test.NewNullLogger()
-				explorer := NewExplorer(search, log, getFakeModulesProvider())
+				explorer := NewExplorer(search, log, getFakeModulesProvider(), nil)
 				expectedParamsToSearch := params
 				search.
 					On("Object", "BestClass", strfmt.UUID("e9c12c22-766f-4bde-b140-d4cf8fd6e041")).
@@ -245,7 +245,7 @@ func Test_Explorer_GetClass(t *testing.T) {
 
 			search := &fakeVectorSearcher{}
 			log, _ := test.NewNullLogger()
-			explorer := NewExplorer(search, log, getFakeModulesProvider())
+			explorer := NewExplorer(search, log, getFakeModulesProvider(), nil)
 			expectedParamsToSearch := params
 			search.
 				On("Object", "BestClass", strfmt.UUID("e9c12c22-766f-4bde-b140-d4cf8fd6e041")).
@@ -313,7 +313,7 @@ func Test_Explorer_GetClass(t *testing.T) {
 
 			search := &fakeVectorSearcher{}
 			log, _ := test.NewNullLogger()
-			explorer := NewExplorer(search, log, getFakeModulesProvider())
+			explorer := NewExplorer(search, log, getFakeModulesProvider(), nil)
 			expectedParamsToSearch := params
 			search.
 				On("Object", "BestClass", strfmt.UUID("e9c12c22-766f-4bde-b140-d4cf8fd6e041")).
@@ -379,7 +379,7 @@ func Test_Explorer_GetClass(t *testing.T) {
 
 			search := &fakeVectorSearcher{}
 			log, _ := test.NewNullLogger()
-			explorer := NewExplorer(search, log, getFakeModulesProvider())
+			explorer := NewExplorer(search, log, getFakeModulesProvider(), nil)
 			expectedParamsToSearch := params
 			search.
 				On("Object", "BestClass", strfmt.UUID("e9c12c22-766f-4bde-b140-d4cf8fd6e041")).
@@ -436,7 +436,7 @@ func Test_Explorer_GetClass(t *testing.T) {
 
 				search := &fakeVectorSearcher{}
 				log, _ := test.NewNullLogger()
-				explorer := NewExplorer(search, log, getFakeModulesProvider())
+				explorer := NewExplorer(search, log, getFakeModulesProvider(), nil)
 				expectedParamsToSearch := params
 				expectedParamsToSearch.SearchVector = []float32{0.8, 0.2, 0.7}
 				search.
@@ -479,7 +479,7 @@ func Test_Explorer_GetClass(t *testing.T) {
 
 				search := &fakeVectorSearcher{}
 				log, _ := test.NewNullLogger()
-				explorer := NewExplorer(search, log, getFakeModulesProvider())
+				explorer := NewExplorer(search, log, getFakeModulesProvider(), nil)
 				expectedParamsToSearch := params
 				expectedParamsToSearch.SearchVector = []float32{0.8, 0.2, 0.7}
 				search.
@@ -514,7 +514,7 @@ func Test_Explorer_GetClass(t *testing.T) {
 
 		search := &fakeVectorSearcher{}
 		log, _ := test.NewNullLogger()
-		explorer := NewExplorer(search, log, getFakeModulesProvider())
+		explorer := NewExplorer(search, log, getFakeModulesProvider(), nil)
 		_, err := explorer.GetClass(context.Background(), params)
 		require.NotNil(t, err)
 		assert.Contains(t, err.Error(), "parameters which are conflicting")
@@ -544,7 +544,7 @@ func Test_Explorer_GetClass(t *testing.T) {
 
 		search := &fakeVectorSearcher{}
 		log, _ := test.NewNullLogger()
-		explorer := NewExplorer(search, log, getFakeModulesProvider())
+		explorer := NewExplorer(search, log, getFakeModulesProvider(), nil)
 		expectedParamsToSearch := params
 		expectedParamsToSearch.SearchVector = nil
 		search.
@@ -600,7 +600,7 @@ func Test_Explorer_GetClass(t *testing.T) {
 
 		search := &fakeVectorSearcher{}
 		log, _ := test.NewNullLogger()
-		explorer := NewExplorer(search, log, getFakeModulesProvider())
+		explorer := NewExplorer(search, log, getFakeModulesProvider(), nil)
 		expectedParamsToSearch := params
 		expectedParamsToSearch.SearchVector = nil
 		search.
@@ -651,7 +651,7 @@ func Test_Explorer_GetClass(t *testing.T) {
 
 		search := &fakeVectorSearcher{}
 		log, _ := test.NewNullLogger()
-		explorer := NewExplorer(search, log, getFakeModulesProvider())
+		explorer := NewExplorer(search, log, getFakeModulesProvider(), nil)
 		expectedParamsToSearch := params
 		expectedParamsToSearch.SearchVector = nil
 		search.
@@ -726,7 +726,7 @@ func Test_Explorer_GetClass(t *testing.T) {
 
 		search := &fakeVectorSearcher{}
 		log, _ := test.NewNullLogger()
-		explorer := NewExplorer(search, log, getFakeModulesProvider())
+		explorer := NewExplorer(search, log, getFakeModulesProvider(), nil)
 		expectedParamsToSearch := params
 		expectedParamsToSearch.SearchVector = nil
 		search.
@@ -786,7 +786,7 @@ func Test_Explorer_GetClass(t *testing.T) {
 
 		search := &fakeVectorSearcher{}
 		log, _ := test.NewNullLogger()
-		explorer := NewExplorer(search, log, getFakeModulesProvider())
+		explorer := NewExplorer(search, log, getFakeModulesProvider(), nil)
 		expectedParamsToSearch := params
 		expectedParamsToSearch.SearchVector = nil
 		search.
@@ -836,7 +836,7 @@ func Test_Explorer_GetClass(t *testing.T) {
 
 		search := &fakeVectorSearcher{}
 		log, _ := test.NewNullLogger()
-		explorer := NewExplorer(search, log, getFakeModulesProvider())
+		explorer := NewExplorer(search, log, getFakeModulesProvider(), nil)
 		expectedParamsToSearch := params
 		expectedParamsToSearch.SearchVector = nil
 		search.
@@ -886,7 +886,7 @@ func Test_Explorer_GetClass(t *testing.T) {
 
 		search := &fakeVectorSearcher{}
 		log, _ := test.NewNullLogger()
-		explorer := NewExplorer(search, log, getFakeModulesProvider())
+		explorer := NewExplorer(search, log, getFakeModulesProvider(), nil)
 		expectedParamsToSearch := params
 		expectedParamsToSearch.SearchVector = nil
 		search.
@@ -977,7 +977,7 @@ func Test_Explorer_GetClass(t *testing.T) {
 				},
 			},
 		}
-		explorer := NewExplorer(searcher, log, getFakeModulesProviderWithCustomExtenders(extender, nil, nil))
+		explorer := NewExplorer(searcher, log, getFakeModulesProviderWithCustomExtenders(extender, nil, nil), nil)
 		expectedParamsToSearch := params
 		expectedParamsToSearch.SearchVector = nil
 		searcher.
@@ -1079,7 +1079,7 @@ func Test_Explorer_GetClass(t *testing.T) {
 				},
 			},
 		}
-		explorer := NewExplorer(searcher, log, getFakeModulesProviderWithCustomExtenders(nil, projector, nil))
+		explorer := NewExplorer(searcher, log, getFakeModulesProviderWithCustomExtenders(nil, projector, nil), nil)
 		expectedParamsToSearch := params
 		expectedParamsToSearch.SearchVector = nil
 		searcher.
@@ -1177,7 +1177,7 @@ func Test_Explorer_GetClass(t *testing.T) {
 
 		fakeSearch := &fakeVectorSearcher{}
 		log, _ := test.NewNullLogger()
-		explorer := NewExplorer(fakeSearch, log, getFakeModulesProvider())
+		explorer := NewExplorer(fakeSearch, log, getFakeModulesProvider(), nil)
 		expectedParamsToSearch := params
 		expectedParamsToSearch.SearchVector = nil
 		fakeSearch.
@@ -1321,7 +1321,7 @@ func Test_Explorer_GetClass(t *testing.T) {
 
 		fakeSearch := &fakeVectorSearcher{}
 		log, _ := test.NewNullLogger()
-		explorer := NewExplorer(fakeSearch, log, getFakeModulesProvider())
+		explorer := NewExplorer(fakeSearch, log, getFakeModulesProvider(), nil)
 		expectedParamsToSearch := params
 		expectedParamsToSearch.SearchVector = nil
 		fakeSearch.
@@ -1516,7 +1516,7 @@ func Test_Explorer_GetClass(t *testing.T) {
 
 		fakeSearch := &fakeVectorSearcher{}
 		log, _ := test.NewNullLogger()
-		explorer := NewExplorer(fakeSearch, log, getFakeModulesProvider())
+		explorer := NewExplorer(fakeSearch, log, getFakeModulesProvider(), nil)
 		expectedParamsToSearch := params
 		expectedParamsToSearch.SearchVector = nil
 		fakeSearch.
@@ -1732,7 +1732,7 @@ func Test_Explorer_GetClass(t *testing.T) {
 				},
 			},
 		}
-		explorer := NewExplorer(searcher, log, getFakeModulesProviderWithCustomExtenders(extender, nil, nil))
+		explorer := NewExplorer(searcher, log, getFakeModulesProviderWithCustomExtenders(extender, nil, nil), nil)
 		expectedParamsToSearch := params
 		expectedParamsToSearch.SearchVector = nil
 		searcher.
@@ -1836,7 +1836,7 @@ func Test_Explorer_GetClass_With_Modules(t *testing.T) {
 
 		search := &fakeVectorSearcher{}
 		log, _ := test.NewNullLogger()
-		explorer := NewExplorer(search, log, getFakeModulesProvider())
+		explorer := NewExplorer(search, log, getFakeModulesProvider(), nil)
 		expectedParamsToSearch := params
 		expectedParamsToSearch.SearchVector = []float32{1, 2, 3}
 		search.
@@ -1890,7 +1890,7 @@ func Test_Explorer_GetClass_With_Modules(t *testing.T) {
 
 			search := &fakeVectorSearcher{}
 			log, _ := test.NewNullLogger()
-			explorer := NewExplorer(search, log, getFakeModulesProvider())
+			explorer := NewExplorer(search, log, getFakeModulesProvider(), nil)
 			expectedParamsToSearch := params
 			expectedParamsToSearch.SearchVector = []float32{1, 2, 3}
 			search.
@@ -1936,7 +1936,7 @@ func Test_Explorer_GetClass_With_Modules(t *testing.T) {
 
 			search := &fakeVectorSearcher{}
 			log, _ := test.NewNullLogger()
-			explorer := NewExplorer(search, log, getFakeModulesProvider())
+			explorer := NewExplorer(search, log, getFakeModulesProvider(), nil)
 			expectedParamsToSearch := params
 			expectedParamsToSearch.SearchVector = []float32{1, 2, 3}
 			search.
@@ -1972,7 +1972,7 @@ func Test_Explorer_GetClass_With_Modules(t *testing.T) {
 
 		search := &fakeVectorSearcher{}
 		log, _ := test.NewNullLogger()
-		explorer := NewExplorer(search, log, getFakeModulesProvider())
+		explorer := NewExplorer(search, log, getFakeModulesProvider(), nil)
 		_, err := explorer.GetClass(context.Background(), params)
 		require.NotNil(t, err)
 		assert.Contains(t, err.Error(), "parameters which are conflicting")
@@ -1995,7 +1995,7 @@ func Test_Explorer_GetClass_With_Modules(t *testing.T) {
 
 		search := &fakeVectorSearcher{}
 		log, _ := test.NewNullLogger()
-		explorer := NewExplorer(search, log, getFakeModulesProvider())
+		explorer := NewExplorer(search, log, getFakeModulesProvider(), nil)
 		_, err := explorer.GetClass(context.Background(), params)
 		require.NotNil(t, err)
 		assert.Contains(t, err.Error(), "parameters which are conflicting")
@@ -2021,7 +2021,7 @@ func Test_Explorer_GetClass_With_Modules(t *testing.T) {
 
 		search := &fakeVectorSearcher{}
 		log, _ := test.NewNullLogger()
-		explorer := NewExplorer(search, log, getFakeModulesProvider())
+		explorer := NewExplorer(search, log, getFakeModulesProvider(), nil)
 		_, err := explorer.GetClass(context.Background(), params)
 		require.NotNil(t, err)
 		assert.Contains(t, err.Error(), "parameters which are conflicting")
@@ -2044,7 +2044,7 @@ func Test_Explorer_GetClass_With_Modules(t *testing.T) {
 
 		search := &fakeVectorSearcher{}
 		log, _ := test.NewNullLogger()
-		explorer := NewExplorer(search, log, getFakeModulesProvider())
+		explorer := NewExplorer(search, log, getFakeModulesProvider(), nil)
 		_, err := explorer.GetClass(context.Background(), params)
 		require.NotNil(t, err)
 		assert.Contains(t, err.Error(), "needs to have defined either 'concepts' or 'objects' fields")
@@ -2067,7 +2067,7 @@ func Test_Explorer_GetClass_With_Modules(t *testing.T) {
 
 		search := &fakeVectorSearcher{}
 		log, _ := test.NewNullLogger()
-		explorer := NewExplorer(search, log, getFakeModulesProvider())
+		explorer := NewExplorer(search, log, getFakeModulesProvider(), nil)
 		_, err := explorer.GetClass(context.Background(), params)
 		require.NotNil(t, err)
 		assert.Contains(t, err.Error(), "needs to have defined either 'concepts' or 'objects' fields")
@@ -2104,7 +2104,7 @@ func Test_Explorer_GetClass_With_Modules(t *testing.T) {
 
 		search := &fakeVectorSearcher{}
 		log, _ := test.NewNullLogger()
-		explorer := NewExplorer(search, log, getFakeModulesProvider())
+		explorer := NewExplorer(search, log, getFakeModulesProvider(), nil)
 		expectedParamsToSearch := params
 		expectedParamsToSearch.SearchVector = []float32{1.0, 2.0, 3.0}
 		// expectedParamsToSearch.SearchVector = nil
@@ -2163,7 +2163,7 @@ func Test_Explorer_GetClass_With_Modules(t *testing.T) {
 
 		search := &fakeVectorSearcher{}
 		log, _ := test.NewNullLogger()
-		explorer := NewExplorer(search, log, getFakeModulesProvider())
+		explorer := NewExplorer(search, log, getFakeModulesProvider(), nil)
 		schemaGetter := newFakeSchemaGetter("BestClass")
 		schemaGetter.SetVectorIndexConfig(hnsw.UserConfig{Distance: "cosine"})
 		explorer.schemaGetter = schemaGetter
@@ -2285,7 +2285,7 @@ func Test_Explorer_GetClass_With_Modules(t *testing.T) {
 				},
 			},
 		}
-		explorer := NewExplorer(searcher, log, getFakeModulesProviderWithCustomExtenders(nil, nil, pathBuilder))
+		explorer := NewExplorer(searcher, log, getFakeModulesProviderWithCustomExtenders(nil, nil, pathBuilder), nil)
 		expectedParamsToSearch := params
 		expectedParamsToSearch.SearchVector = []float32{1, 2, 3}
 		expectedParamsToSearch.AdditionalProperties.Vector = true // any custom additional params will trigger vector

--- a/usecases/traverser/explorer_test.go
+++ b/usecases/traverser/explorer_test.go
@@ -820,6 +820,7 @@ func Test_Explorer_GetClass(t *testing.T) {
 					"name": "Foo",
 				},
 				Vector: []float32{0.1, -0.3},
+				Dims:   128,
 			},
 		}
 
@@ -832,6 +833,7 @@ func Test_Explorer_GetClass(t *testing.T) {
 		search.
 			On("ClassSearch", expectedParamsToSearch).
 			Return(searchResults, nil)
+		metrics.On("AddUsageDimensions", "BestClass", "get_graphql", "_additional.vector", 128)
 
 		res, err := explorer.GetClass(context.Background(), params)
 

--- a/usecases/traverser/explorer_test.go
+++ b/usecases/traverser/explorer_test.go
@@ -49,24 +49,28 @@ func Test_Explorer_GetClass(t *testing.T) {
 				Schema: map[string]interface{}{
 					"name": "Foo",
 				},
+				Dims: 128,
 			},
 			{
 				ID: "id2",
 				Schema: map[string]interface{}{
 					"age": 200,
 				},
+				Dims: 128,
 			},
 		}
 
 		search := &fakeVectorSearcher{}
+		metrics := &fakeMetrics{}
 		log, _ := test.NewNullLogger()
-		explorer := NewExplorer(search, log, getFakeModulesProvider(), nil)
+		explorer := NewExplorer(search, log, getFakeModulesProvider(), metrics)
 		expectedParamsToSearch := params
 		expectedParamsToSearch.SearchVector = []float32{0.8, 0.2, 0.7}
 		search.
 			On("VectorClassSearch", expectedParamsToSearch).
 			Return(searchResults, nil)
 
+		metrics.On("AddUsageDimensions", "BestClass", "get_graphql", "nearVector", 128)
 		res, err := explorer.GetClass(context.Background(), params)
 
 		t.Run("vector search must be called with right params", func(t *testing.T) {
@@ -85,6 +89,10 @@ func Test_Explorer_GetClass(t *testing.T) {
 					"age": 200,
 				}, res[1])
 		})
+
+		t.Run("usage must be tracked", func(t *testing.T) {
+			metrics.AssertExpectations(t)
+		})
 	})
 
 	t.Run("when an explore param is set for nearObject without id and beacon", func(t *testing.T) {
@@ -102,7 +110,8 @@ func Test_Explorer_GetClass(t *testing.T) {
 
 			search := &fakeVectorSearcher{}
 			log, _ := test.NewNullLogger()
-			explorer := NewExplorer(search, log, getFakeModulesProvider(), nil)
+			metrics := &fakeMetrics{}
+			explorer := NewExplorer(search, log, getFakeModulesProvider(), metrics)
 
 			res, err := explorer.GetClass(context.Background(), params)
 
@@ -127,7 +136,8 @@ func Test_Explorer_GetClass(t *testing.T) {
 
 			search := &fakeVectorSearcher{}
 			log, _ := test.NewNullLogger()
-			explorer := NewExplorer(search, log, getFakeModulesProvider(), nil)
+			metrics := &fakeMetrics{}
+			explorer := NewExplorer(search, log, getFakeModulesProvider(), metrics)
 
 			res, err := explorer.GetClass(context.Background(), params)
 
@@ -167,18 +177,21 @@ func Test_Explorer_GetClass(t *testing.T) {
 						Schema: map[string]interface{}{
 							"name": "Foo",
 						},
+						Dims: 128,
 					},
 					{
 						ID: "id2",
 						Schema: map[string]interface{}{
 							"age": 200,
 						},
+						Dims: 128,
 					},
 				}
 
 				search := &fakeVectorSearcher{}
 				log, _ := test.NewNullLogger()
-				explorer := NewExplorer(search, log, getFakeModulesProvider(), nil)
+				metrics := &fakeMetrics{}
+				explorer := NewExplorer(search, log, getFakeModulesProvider(), metrics)
 				expectedParamsToSearch := params
 				search.
 					On("Object", "BestClass", strfmt.UUID("e9c12c22-766f-4bde-b140-d4cf8fd6e041")).
@@ -186,6 +199,7 @@ func Test_Explorer_GetClass(t *testing.T) {
 				search.
 					On("VectorClassSearch", expectedParamsToSearch).
 					Return(searchResults, nil)
+				metrics.On("AddUsageDimensions", "BestClass", "get_graphql", "nearObject", 128)
 
 				res, err := explorer.GetClass(context.Background(), params)
 
@@ -234,18 +248,21 @@ func Test_Explorer_GetClass(t *testing.T) {
 					Schema: map[string]interface{}{
 						"name": "Foo",
 					},
+					Dims: 128,
 				},
 				{
 					ID: "id2",
 					Schema: map[string]interface{}{
 						"age": 200,
 					},
+					Dims: 128,
 				},
 			}
 
 			search := &fakeVectorSearcher{}
 			log, _ := test.NewNullLogger()
-			explorer := NewExplorer(search, log, getFakeModulesProvider(), nil)
+			metrics := &fakeMetrics{}
+			explorer := NewExplorer(search, log, getFakeModulesProvider(), metrics)
 			expectedParamsToSearch := params
 			search.
 				On("Object", "BestClass", strfmt.UUID("e9c12c22-766f-4bde-b140-d4cf8fd6e041")).
@@ -253,6 +270,7 @@ func Test_Explorer_GetClass(t *testing.T) {
 			search.
 				On("VectorClassSearch", expectedParamsToSearch).
 				Return(searchResults, nil)
+			metrics.On("AddUsageDimensions", "BestClass", "get_graphql", "nearObject", 128)
 
 			res, err := explorer.GetClass(context.Background(), params)
 
@@ -302,18 +320,21 @@ func Test_Explorer_GetClass(t *testing.T) {
 					Schema: map[string]interface{}{
 						"name": "Foo",
 					},
+					Dims: 128,
 				},
 				{
 					ID: "id2",
 					Schema: map[string]interface{}{
 						"age": 200,
 					},
+					Dims: 128,
 				},
 			}
 
 			search := &fakeVectorSearcher{}
 			log, _ := test.NewNullLogger()
-			explorer := NewExplorer(search, log, getFakeModulesProvider(), nil)
+			metrics := &fakeMetrics{}
+			explorer := NewExplorer(search, log, getFakeModulesProvider(), metrics)
 			expectedParamsToSearch := params
 			search.
 				On("Object", "BestClass", strfmt.UUID("e9c12c22-766f-4bde-b140-d4cf8fd6e041")).
@@ -321,6 +342,7 @@ func Test_Explorer_GetClass(t *testing.T) {
 			search.
 				On("VectorClassSearch", expectedParamsToSearch).
 				Return(searchResults, nil)
+			metrics.On("AddUsageDimensions", "BestClass", "get_graphql", "nearObject", 128)
 
 			res, err := explorer.GetClass(context.Background(), params)
 
@@ -368,18 +390,21 @@ func Test_Explorer_GetClass(t *testing.T) {
 					Schema: map[string]interface{}{
 						"name": "Foo",
 					},
+					Dims: 128,
 				},
 				{
 					ID: "id2",
 					Schema: map[string]interface{}{
 						"age": 200,
 					},
+					Dims: 128,
 				},
 			}
 
 			search := &fakeVectorSearcher{}
+			metrics := &fakeMetrics{}
 			log, _ := test.NewNullLogger()
-			explorer := NewExplorer(search, log, getFakeModulesProvider(), nil)
+			explorer := NewExplorer(search, log, getFakeModulesProvider(), metrics)
 			expectedParamsToSearch := params
 			search.
 				On("Object", "BestClass", strfmt.UUID("e9c12c22-766f-4bde-b140-d4cf8fd6e041")).
@@ -387,6 +412,7 @@ func Test_Explorer_GetClass(t *testing.T) {
 			search.
 				On("VectorClassSearch", expectedParamsToSearch).
 				Return(searchResults, nil)
+			metrics.On("AddUsageDimensions", "BestClass", "get_graphql", "nearObject", 128)
 
 			res, err := explorer.GetClass(context.Background(), params)
 
@@ -427,21 +453,25 @@ func Test_Explorer_GetClass(t *testing.T) {
 					{
 						ID:   "id1",
 						Dist: 2 * 0.69,
+						Dims: 128,
 					},
 					{
 						ID:   "id2",
 						Dist: 2 * 0.69,
+						Dims: 128,
 					},
 				}
 
 				search := &fakeVectorSearcher{}
 				log, _ := test.NewNullLogger()
-				explorer := NewExplorer(search, log, getFakeModulesProvider(), nil)
+				metrics := &fakeMetrics{}
+				explorer := NewExplorer(search, log, getFakeModulesProvider(), metrics)
 				expectedParamsToSearch := params
 				expectedParamsToSearch.SearchVector = []float32{0.8, 0.2, 0.7}
 				search.
 					On("VectorClassSearch", expectedParamsToSearch).
 					Return(searchResults, nil)
+				metrics.On("AddUsageDimensions", "BestClass", "get_graphql", "nearVector", 128)
 
 				res, err := explorer.GetClass(context.Background(), params)
 
@@ -470,21 +500,25 @@ func Test_Explorer_GetClass(t *testing.T) {
 					{
 						ID:   "id1",
 						Dist: 2 * 0.69,
+						Dims: 128,
 					},
 					{
 						ID:   "id2",
 						Dist: 2 * 0.69,
+						Dims: 128,
 					},
 				}
 
 				search := &fakeVectorSearcher{}
 				log, _ := test.NewNullLogger()
-				explorer := NewExplorer(search, log, getFakeModulesProvider(), nil)
+				metrics := &fakeMetrics{}
+				explorer := NewExplorer(search, log, getFakeModulesProvider(), metrics)
 				expectedParamsToSearch := params
 				expectedParamsToSearch.SearchVector = []float32{0.8, 0.2, 0.7}
 				search.
 					On("VectorClassSearch", expectedParamsToSearch).
 					Return(searchResults, nil)
+				metrics.On("AddUsageDimensions", "BestClass", "get_graphql", "nearVector", 128)
 
 				res, err := explorer.GetClass(context.Background(), params)
 
@@ -514,7 +548,8 @@ func Test_Explorer_GetClass(t *testing.T) {
 
 		search := &fakeVectorSearcher{}
 		log, _ := test.NewNullLogger()
-		explorer := NewExplorer(search, log, getFakeModulesProvider(), nil)
+		metrics := &fakeMetrics{}
+		explorer := NewExplorer(search, log, getFakeModulesProvider(), metrics)
 		_, err := explorer.GetClass(context.Background(), params)
 		require.NotNil(t, err)
 		assert.Contains(t, err.Error(), "parameters which are conflicting")
@@ -544,7 +579,8 @@ func Test_Explorer_GetClass(t *testing.T) {
 
 		search := &fakeVectorSearcher{}
 		log, _ := test.NewNullLogger()
-		explorer := NewExplorer(search, log, getFakeModulesProvider(), nil)
+		metrics := &fakeMetrics{}
+		explorer := NewExplorer(search, log, getFakeModulesProvider(), metrics)
 		expectedParamsToSearch := params
 		expectedParamsToSearch.SearchVector = nil
 		search.
@@ -600,7 +636,8 @@ func Test_Explorer_GetClass(t *testing.T) {
 
 		search := &fakeVectorSearcher{}
 		log, _ := test.NewNullLogger()
-		explorer := NewExplorer(search, log, getFakeModulesProvider(), nil)
+		metrics := &fakeMetrics{}
+		explorer := NewExplorer(search, log, getFakeModulesProvider(), metrics)
 		expectedParamsToSearch := params
 		expectedParamsToSearch.SearchVector = nil
 		search.
@@ -651,7 +688,8 @@ func Test_Explorer_GetClass(t *testing.T) {
 
 		search := &fakeVectorSearcher{}
 		log, _ := test.NewNullLogger()
-		explorer := NewExplorer(search, log, getFakeModulesProvider(), nil)
+		metrics := &fakeMetrics{}
+		explorer := NewExplorer(search, log, getFakeModulesProvider(), metrics)
 		expectedParamsToSearch := params
 		expectedParamsToSearch.SearchVector = nil
 		search.
@@ -726,7 +764,8 @@ func Test_Explorer_GetClass(t *testing.T) {
 
 		search := &fakeVectorSearcher{}
 		log, _ := test.NewNullLogger()
-		explorer := NewExplorer(search, log, getFakeModulesProvider(), nil)
+		metrics := &fakeMetrics{}
+		explorer := NewExplorer(search, log, getFakeModulesProvider(), metrics)
 		expectedParamsToSearch := params
 		expectedParamsToSearch.SearchVector = nil
 		search.
@@ -786,7 +825,8 @@ func Test_Explorer_GetClass(t *testing.T) {
 
 		search := &fakeVectorSearcher{}
 		log, _ := test.NewNullLogger()
-		explorer := NewExplorer(search, log, getFakeModulesProvider(), nil)
+		metrics := &fakeMetrics{}
+		explorer := NewExplorer(search, log, getFakeModulesProvider(), metrics)
 		expectedParamsToSearch := params
 		expectedParamsToSearch.SearchVector = nil
 		search.
@@ -836,7 +876,8 @@ func Test_Explorer_GetClass(t *testing.T) {
 
 		search := &fakeVectorSearcher{}
 		log, _ := test.NewNullLogger()
-		explorer := NewExplorer(search, log, getFakeModulesProvider(), nil)
+		metrics := &fakeMetrics{}
+		explorer := NewExplorer(search, log, getFakeModulesProvider(), metrics)
 		expectedParamsToSearch := params
 		expectedParamsToSearch.SearchVector = nil
 		search.
@@ -886,7 +927,8 @@ func Test_Explorer_GetClass(t *testing.T) {
 
 		search := &fakeVectorSearcher{}
 		log, _ := test.NewNullLogger()
-		explorer := NewExplorer(search, log, getFakeModulesProvider(), nil)
+		metrics := &fakeMetrics{}
+		explorer := NewExplorer(search, log, getFakeModulesProvider(), metrics)
 		expectedParamsToSearch := params
 		expectedParamsToSearch.SearchVector = nil
 		search.
@@ -1177,7 +1219,8 @@ func Test_Explorer_GetClass(t *testing.T) {
 
 		fakeSearch := &fakeVectorSearcher{}
 		log, _ := test.NewNullLogger()
-		explorer := NewExplorer(fakeSearch, log, getFakeModulesProvider(), nil)
+		metrics := &fakeMetrics{}
+		explorer := NewExplorer(fakeSearch, log, getFakeModulesProvider(), metrics)
 		expectedParamsToSearch := params
 		expectedParamsToSearch.SearchVector = nil
 		fakeSearch.
@@ -1321,7 +1364,8 @@ func Test_Explorer_GetClass(t *testing.T) {
 
 		fakeSearch := &fakeVectorSearcher{}
 		log, _ := test.NewNullLogger()
-		explorer := NewExplorer(fakeSearch, log, getFakeModulesProvider(), nil)
+		metrics := &fakeMetrics{}
+		explorer := NewExplorer(fakeSearch, log, getFakeModulesProvider(), metrics)
 		expectedParamsToSearch := params
 		expectedParamsToSearch.SearchVector = nil
 		fakeSearch.
@@ -1516,7 +1560,8 @@ func Test_Explorer_GetClass(t *testing.T) {
 
 		fakeSearch := &fakeVectorSearcher{}
 		log, _ := test.NewNullLogger()
-		explorer := NewExplorer(fakeSearch, log, getFakeModulesProvider(), nil)
+		metrics := &fakeMetrics{}
+		explorer := NewExplorer(fakeSearch, log, getFakeModulesProvider(), metrics)
 		expectedParamsToSearch := params
 		expectedParamsToSearch.SearchVector = nil
 		fakeSearch.
@@ -1825,23 +1870,27 @@ func Test_Explorer_GetClass_With_Modules(t *testing.T) {
 				Schema: map[string]interface{}{
 					"name": "Foo",
 				},
+				Dims: 128,
 			},
 			{
 				ID: "id2",
 				Schema: map[string]interface{}{
 					"age": 200,
 				},
+				Dims: 128,
 			},
 		}
 
 		search := &fakeVectorSearcher{}
 		log, _ := test.NewNullLogger()
-		explorer := NewExplorer(search, log, getFakeModulesProvider(), nil)
+		metrics := &fakeMetrics{}
+		explorer := NewExplorer(search, log, getFakeModulesProvider(), metrics)
 		expectedParamsToSearch := params
 		expectedParamsToSearch.SearchVector = []float32{1, 2, 3}
 		search.
 			On("VectorClassSearch", expectedParamsToSearch).
 			Return(searchResults, nil)
+		metrics.On("AddUsageDimensions", "BestClass", "get_graphql", "nearCustomText", 128)
 
 		res, err := explorer.GetClass(context.Background(), params)
 
@@ -1881,21 +1930,25 @@ func Test_Explorer_GetClass_With_Modules(t *testing.T) {
 				{
 					ID:   "id1",
 					Dist: 2 * 0.69,
+					Dims: 128,
 				},
 				{
 					ID:   "id2",
 					Dist: 2 * 0.69,
+					Dims: 128,
 				},
 			}
 
 			search := &fakeVectorSearcher{}
 			log, _ := test.NewNullLogger()
-			explorer := NewExplorer(search, log, getFakeModulesProvider(), nil)
+			metrics := &fakeMetrics{}
+			explorer := NewExplorer(search, log, getFakeModulesProvider(), metrics)
 			expectedParamsToSearch := params
 			expectedParamsToSearch.SearchVector = []float32{1, 2, 3}
 			search.
 				On("VectorClassSearch", expectedParamsToSearch).
 				Return(searchResults, nil)
+			metrics.On("AddUsageDimensions", "BestClass", "get_graphql", "nearCustomText", 128)
 
 			res, err := explorer.GetClass(context.Background(), params)
 
@@ -1927,21 +1980,25 @@ func Test_Explorer_GetClass_With_Modules(t *testing.T) {
 				{
 					ID:   "id1",
 					Dist: 2 * 0.69,
+					Dims: 128,
 				},
 				{
 					ID:   "id2",
 					Dist: 2 * 0.69,
+					Dims: 128,
 				},
 			}
 
 			search := &fakeVectorSearcher{}
 			log, _ := test.NewNullLogger()
-			explorer := NewExplorer(search, log, getFakeModulesProvider(), nil)
+			metrics := &fakeMetrics{}
+			explorer := NewExplorer(search, log, getFakeModulesProvider(), metrics)
 			expectedParamsToSearch := params
 			expectedParamsToSearch.SearchVector = []float32{1, 2, 3}
 			search.
 				On("VectorClassSearch", expectedParamsToSearch).
 				Return(searchResults, nil)
+			metrics.On("AddUsageDimensions", "BestClass", "get_graphql", "nearCustomText", 128)
 
 			res, err := explorer.GetClass(context.Background(), params)
 
@@ -1972,7 +2029,8 @@ func Test_Explorer_GetClass_With_Modules(t *testing.T) {
 
 		search := &fakeVectorSearcher{}
 		log, _ := test.NewNullLogger()
-		explorer := NewExplorer(search, log, getFakeModulesProvider(), nil)
+		metrics := &fakeMetrics{}
+		explorer := NewExplorer(search, log, getFakeModulesProvider(), metrics)
 		_, err := explorer.GetClass(context.Background(), params)
 		require.NotNil(t, err)
 		assert.Contains(t, err.Error(), "parameters which are conflicting")
@@ -1995,7 +2053,8 @@ func Test_Explorer_GetClass_With_Modules(t *testing.T) {
 
 		search := &fakeVectorSearcher{}
 		log, _ := test.NewNullLogger()
-		explorer := NewExplorer(search, log, getFakeModulesProvider(), nil)
+		metrics := &fakeMetrics{}
+		explorer := NewExplorer(search, log, getFakeModulesProvider(), metrics)
 		_, err := explorer.GetClass(context.Background(), params)
 		require.NotNil(t, err)
 		assert.Contains(t, err.Error(), "parameters which are conflicting")
@@ -2021,7 +2080,8 @@ func Test_Explorer_GetClass_With_Modules(t *testing.T) {
 
 		search := &fakeVectorSearcher{}
 		log, _ := test.NewNullLogger()
-		explorer := NewExplorer(search, log, getFakeModulesProvider(), nil)
+		metrics := &fakeMetrics{}
+		explorer := NewExplorer(search, log, getFakeModulesProvider(), metrics)
 		_, err := explorer.GetClass(context.Background(), params)
 		require.NotNil(t, err)
 		assert.Contains(t, err.Error(), "parameters which are conflicting")
@@ -2044,7 +2104,8 @@ func Test_Explorer_GetClass_With_Modules(t *testing.T) {
 
 		search := &fakeVectorSearcher{}
 		log, _ := test.NewNullLogger()
-		explorer := NewExplorer(search, log, getFakeModulesProvider(), nil)
+		metrics := &fakeMetrics{}
+		explorer := NewExplorer(search, log, getFakeModulesProvider(), metrics)
 		_, err := explorer.GetClass(context.Background(), params)
 		require.NotNil(t, err)
 		assert.Contains(t, err.Error(), "needs to have defined either 'concepts' or 'objects' fields")
@@ -2067,7 +2128,8 @@ func Test_Explorer_GetClass_With_Modules(t *testing.T) {
 
 		search := &fakeVectorSearcher{}
 		log, _ := test.NewNullLogger()
-		explorer := NewExplorer(search, log, getFakeModulesProvider(), nil)
+		metrics := &fakeMetrics{}
+		explorer := NewExplorer(search, log, getFakeModulesProvider(), metrics)
 		_, err := explorer.GetClass(context.Background(), params)
 		require.NotNil(t, err)
 		assert.Contains(t, err.Error(), "needs to have defined either 'concepts' or 'objects' fields")
@@ -2099,18 +2161,21 @@ func Test_Explorer_GetClass_With_Modules(t *testing.T) {
 				},
 				Vector: []float32{0.5, 1.5, 0.0},
 				Dist:   2 * 0.69,
+				Dims:   128,
 			},
 		}
 
 		search := &fakeVectorSearcher{}
 		log, _ := test.NewNullLogger()
-		explorer := NewExplorer(search, log, getFakeModulesProvider(), nil)
+		metrics := &fakeMetrics{}
+		explorer := NewExplorer(search, log, getFakeModulesProvider(), metrics)
 		expectedParamsToSearch := params
 		expectedParamsToSearch.SearchVector = []float32{1.0, 2.0, 3.0}
 		// expectedParamsToSearch.SearchVector = nil
 		search.
 			On("VectorClassSearch", expectedParamsToSearch).
 			Return(searchResults, nil)
+		metrics.On("AddUsageDimensions", "BestClass", "get_graphql", "nearCustomText", 128)
 
 		res, err := explorer.GetClass(context.Background(), params)
 
@@ -2158,12 +2223,14 @@ func Test_Explorer_GetClass_With_Modules(t *testing.T) {
 				},
 				Vector: []float32{0.5, 1.5, 0.0},
 				Dist:   2 * 0.69,
+				Dims:   128,
 			},
 		}
 
 		search := &fakeVectorSearcher{}
 		log, _ := test.NewNullLogger()
-		explorer := NewExplorer(search, log, getFakeModulesProvider(), nil)
+		metrics := &fakeMetrics{}
+		explorer := NewExplorer(search, log, getFakeModulesProvider(), metrics)
 		schemaGetter := newFakeSchemaGetter("BestClass")
 		schemaGetter.SetVectorIndexConfig(hnsw.UserConfig{Distance: "cosine"})
 		explorer.schemaGetter = schemaGetter
@@ -2173,6 +2240,7 @@ func Test_Explorer_GetClass_With_Modules(t *testing.T) {
 		search.
 			On("VectorClassSearch", expectedParamsToSearch).
 			Return(searchResults, nil)
+		metrics.On("AddUsageDimensions", "BestClass", "get_graphql", "nearCustomText", 128)
 
 		res, err := explorer.GetClass(context.Background(), params)
 
@@ -2232,7 +2300,8 @@ func Test_Explorer_GetClass_With_Modules(t *testing.T) {
 		pathBuilder := &fakePathBuilder{
 			returnArgs: []search.Result{
 				{
-					ID: "id1",
+					ID:   "id1",
+					Dims: 128,
 					Schema: map[string]interface{}{
 						"name": "Foo",
 					},
@@ -2258,7 +2327,8 @@ func Test_Explorer_GetClass_With_Modules(t *testing.T) {
 					},
 				},
 				{
-					ID: "id2",
+					ID:   "id2",
+					Dims: 128,
 					Schema: map[string]interface{}{
 						"name": "Bar",
 					},
@@ -2285,13 +2355,15 @@ func Test_Explorer_GetClass_With_Modules(t *testing.T) {
 				},
 			},
 		}
-		explorer := NewExplorer(searcher, log, getFakeModulesProviderWithCustomExtenders(nil, nil, pathBuilder), nil)
+		metrics := &fakeMetrics{}
+		explorer := NewExplorer(searcher, log, getFakeModulesProviderWithCustomExtenders(nil, nil, pathBuilder), metrics)
 		expectedParamsToSearch := params
 		expectedParamsToSearch.SearchVector = []float32{1, 2, 3}
 		expectedParamsToSearch.AdditionalProperties.Vector = true // any custom additional params will trigger vector
 		searcher.
 			On("VectorClassSearch", expectedParamsToSearch).
 			Return(searchResults, nil)
+		metrics.On("AddUsageDimensions", "BestClass", "get_graphql", "nearCustomText", 128)
 
 		res, err := explorer.GetClass(context.Background(), params)
 

--- a/usecases/traverser/explorer_validate_filters_test.go
+++ b/usecases/traverser/explorer_validate_filters_test.go
@@ -367,7 +367,10 @@ func Test_Explorer_GetClass_WithFilters(t *testing.T) {
 				sg := &fakeSchemaGetter{
 					schema: schemaForFiltersValidation(),
 				}
-				explorer := NewExplorer(search, log, getFakeModulesProvider(), nil)
+				metrics := &fakeMetrics{}
+				metrics.On("AddUsageDimensions", mock.Anything, mock.Anything, mock.Anything,
+					mock.Anything)
+				explorer := NewExplorer(search, log, getFakeModulesProvider(), metrics)
 				explorer.SetSchemaGetter(sg)
 
 				if test.expectedError == nil {

--- a/usecases/traverser/explorer_validate_filters_test.go
+++ b/usecases/traverser/explorer_validate_filters_test.go
@@ -367,7 +367,7 @@ func Test_Explorer_GetClass_WithFilters(t *testing.T) {
 				sg := &fakeSchemaGetter{
 					schema: schemaForFiltersValidation(),
 				}
-				explorer := NewExplorer(search, log, getFakeModulesProvider())
+				explorer := NewExplorer(search, log, getFakeModulesProvider(), nil)
 				explorer.SetSchemaGetter(sg)
 
 				if test.expectedError == nil {

--- a/usecases/traverser/explorer_validate_sort_test.go
+++ b/usecases/traverser/explorer_validate_sort_test.go
@@ -376,7 +376,7 @@ func Test_Explorer_GetClass_WithSort(t *testing.T) {
 						schema: schemaForFiltersValidation(),
 					}
 					log, _ := testLogger.NewNullLogger()
-					explorer := NewExplorer(search, log, getFakeModulesProvider())
+					explorer := NewExplorer(search, log, getFakeModulesProvider(), nil)
 					explorer.SetSchemaGetter(sg)
 
 					if td.expectedError == nil {

--- a/usecases/traverser/explorer_validate_sort_test.go
+++ b/usecases/traverser/explorer_validate_sort_test.go
@@ -376,7 +376,10 @@ func Test_Explorer_GetClass_WithSort(t *testing.T) {
 						schema: schemaForFiltersValidation(),
 					}
 					log, _ := testLogger.NewNullLogger()
-					explorer := NewExplorer(search, log, getFakeModulesProvider(), nil)
+					metrics := &fakeMetrics{}
+					metrics.On("AddUsageDimensions", mock.Anything, mock.Anything, mock.Anything,
+						mock.Anything)
+					explorer := NewExplorer(search, log, getFakeModulesProvider(), metrics)
 					explorer.SetSchemaGetter(sg)
 
 					if td.expectedError == nil {

--- a/usecases/traverser/fakes_for_test.go
+++ b/usecases/traverser/fakes_for_test.go
@@ -184,7 +184,7 @@ func (f *fakeExplorer) GetClass(ctx context.Context, p GetParams) ([]interface{}
 	return nil, nil
 }
 
-func (f *fakeExplorer) Concepts(ctx context.Context, p ExploreParams) ([]search.Result, error) {
+func (f *fakeExplorer) CrossClassVectorSearch(ctx context.Context, p ExploreParams) ([]search.Result, error) {
 	return nil, nil
 }
 
@@ -823,4 +823,12 @@ func (s *fakeSearcher) vectorForNearTextParam(ctx context.Context, params interf
 		vector = afterMoveAway
 	}
 	return vector, nil
+}
+
+type fakeMetrics struct {
+	mock.Mock
+}
+
+func (m *fakeMetrics) AddUsageDimensions(class, query, op string, dims int) {
+	m.Called(class, query, op, dims)
 }

--- a/usecases/traverser/metrics.go
+++ b/usecases/traverser/metrics.go
@@ -76,18 +76,14 @@ func (m *Metrics) QueriesGetDec(className string) {
 	}).Dec()
 }
 
-func (m *Metrics) AddGetDimensions(className, operation string, dims int) {
-	m.dimensions.With(prometheus.Labels{
-		"class_name": className,
-		"operation":  operation,
-		"query_type": "get_graphql",
-	}).Add(float64(dims))
-}
+func (m *Metrics) AddUsageDimensions(className, queryType, operation string, dims int) {
+	if m == nil {
+		return
+	}
 
-func (m *Metrics) AddExploreDimensions(className, operation string, dims int) {
 	m.dimensions.With(prometheus.Labels{
 		"class_name": className,
 		"operation":  operation,
-		"query_type": "explore_graphql",
+		"query_type": queryType,
 	}).Add(float64(dims))
 }

--- a/usecases/traverser/metrics.go
+++ b/usecases/traverser/metrics.go
@@ -18,6 +18,7 @@ import (
 
 type Metrics struct {
 	queriesCount *prometheus.GaugeVec
+	dimensions   *prometheus.CounterVec
 }
 
 func NewMetrics(prom *monitoring.PrometheusMetrics) *Metrics {
@@ -27,6 +28,7 @@ func NewMetrics(prom *monitoring.PrometheusMetrics) *Metrics {
 
 	return &Metrics{
 		queriesCount: prom.QueriesCount,
+		dimensions:   prom.QueryDimensions,
 	}
 }
 
@@ -72,4 +74,20 @@ func (m *Metrics) QueriesGetDec(className string) {
 		"class_name": className,
 		"query_type": "get_graphql",
 	}).Dec()
+}
+
+func (m *Metrics) AddGetDimensions(className, operation string, dims int) {
+	m.dimensions.With(prometheus.Labels{
+		"class_name": className,
+		"operation":  operation,
+		"query_type": "get_graphql",
+	}).Add(float64(dims))
+}
+
+func (m *Metrics) AddExploreDimensions(className, operation string, dims int) {
+	m.dimensions.With(prometheus.Labels{
+		"class_name": className,
+		"operation":  operation,
+		"query_type": "explore_graphql",
+	}).Add(float64(dims))
 }

--- a/usecases/traverser/traverser.go
+++ b/usecases/traverser/traverser.go
@@ -59,7 +59,7 @@ type VectorSearcher interface {
 
 type explorer interface {
 	GetClass(ctx context.Context, params GetParams) ([]interface{}, error)
-	Concepts(ctx context.Context, params ExploreParams) ([]search.Result, error)
+	CrossClassVectorSearch(ctx context.Context, params ExploreParams) ([]search.Result, error)
 }
 
 // NewTraverser to traverse the knowledge graph

--- a/usecases/traverser/traverser_explore_concepts.go
+++ b/usecases/traverser/traverser_explore_concepts.go
@@ -41,7 +41,7 @@ func (t *Traverser) Explore(ctx context.Context,
 		return nil, err
 	}
 
-	return t.explorer.Concepts(ctx, params)
+	return t.explorer.CrossClassVectorSearch(ctx, params)
 }
 
 // ExploreParams are the parameters used by the GraphQL `Explore { }` API

--- a/usecases/traverser/traverser_explore_concepts_test.go
+++ b/usecases/traverser/traverser_explore_concepts_test.go
@@ -31,7 +31,7 @@ func Test_ExploreConcepts(t *testing.T) {
 		logger, _ := test.NewNullLogger()
 		vectorSearcher := &fakeVectorSearcher{}
 		log, _ := test.NewNullLogger()
-		explorer := NewExplorer(vectorSearcher, log, getFakeModulesProvider())
+		explorer := NewExplorer(vectorSearcher, log, getFakeModulesProvider(), nil)
 		schemaGetter := &fakeSchemaGetter{}
 		traverser := NewTraverser(&config.WeaviateConfig{}, locks, logger, authorizer,
 			vectorSearcher, explorer, schemaGetter, getFakeModulesProvider(), nil)
@@ -47,7 +47,7 @@ func Test_ExploreConcepts(t *testing.T) {
 		logger, _ := test.NewNullLogger()
 		vectorSearcher := &fakeVectorSearcher{}
 		log, _ := test.NewNullLogger()
-		explorer := NewExplorer(vectorSearcher, log, getFakeModulesProvider())
+		explorer := NewExplorer(vectorSearcher, log, getFakeModulesProvider(), nil)
 		schemaGetter := &fakeSchemaGetter{}
 		traverser := NewTraverser(&config.WeaviateConfig{}, locks, logger, authorizer,
 			vectorSearcher, explorer, schemaGetter, nil, nil)
@@ -67,7 +67,7 @@ func Test_ExploreConcepts(t *testing.T) {
 		logger, _ := test.NewNullLogger()
 		vectorSearcher := &fakeVectorSearcher{}
 		log, _ := test.NewNullLogger()
-		explorer := NewExplorer(vectorSearcher, log, getFakeModulesProvider())
+		explorer := NewExplorer(vectorSearcher, log, getFakeModulesProvider(), nil)
 		schemaGetter := &fakeSchemaGetter{}
 		traverser := NewTraverser(&config.WeaviateConfig{}, locks, logger, authorizer,
 			vectorSearcher, explorer, schemaGetter, getFakeModulesProvider(), nil)
@@ -123,7 +123,7 @@ func Test_ExploreConcepts(t *testing.T) {
 		logger, _ := test.NewNullLogger()
 		vectorSearcher := &fakeVectorSearcher{}
 		log, _ := test.NewNullLogger()
-		explorer := NewExplorer(vectorSearcher, log, getFakeModulesProvider())
+		explorer := NewExplorer(vectorSearcher, log, getFakeModulesProvider(), nil)
 		schemaGetter := &fakeSchemaGetter{}
 		traverser := NewTraverser(&config.WeaviateConfig{}, locks, logger, authorizer,
 			vectorSearcher, explorer, schemaGetter, nil, nil)
@@ -177,7 +177,7 @@ func Test_ExploreConcepts(t *testing.T) {
 		logger, _ := test.NewNullLogger()
 		vectorSearcher := &fakeVectorSearcher{}
 		log, _ := test.NewNullLogger()
-		explorer := NewExplorer(vectorSearcher, log, getFakeModulesProvider())
+		explorer := NewExplorer(vectorSearcher, log, getFakeModulesProvider(), nil)
 		schemaGetter := &fakeSchemaGetter{}
 		traverser := NewTraverser(&config.WeaviateConfig{}, locks, logger, authorizer,
 			vectorSearcher, explorer, schemaGetter, nil, nil)
@@ -237,7 +237,7 @@ func Test_ExploreConcepts(t *testing.T) {
 		logger, _ := test.NewNullLogger()
 		vectorSearcher := &fakeVectorSearcher{}
 		log, _ := test.NewNullLogger()
-		explorer := NewExplorer(vectorSearcher, log, getFakeModulesProvider())
+		explorer := NewExplorer(vectorSearcher, log, getFakeModulesProvider(), nil)
 		schemaGetter := &fakeSchemaGetter{}
 		traverser := NewTraverser(&config.WeaviateConfig{}, locks, logger, authorizer,
 			vectorSearcher, explorer, schemaGetter, nil, nil)
@@ -297,7 +297,7 @@ func Test_ExploreConcepts(t *testing.T) {
 		logger, _ := test.NewNullLogger()
 		vectorSearcher := &fakeVectorSearcher{}
 		log, _ := test.NewNullLogger()
-		explorer := NewExplorer(vectorSearcher, log, getFakeModulesProvider())
+		explorer := NewExplorer(vectorSearcher, log, getFakeModulesProvider(), nil)
 		schemaGetter := &fakeSchemaGetter{}
 		traverser := NewTraverser(&config.WeaviateConfig{}, locks, logger, authorizer,
 			vectorSearcher, explorer, schemaGetter, getFakeModulesProvider(), nil)
@@ -337,7 +337,7 @@ func Test_ExploreConcepts(t *testing.T) {
 		logger, _ := test.NewNullLogger()
 		vectorSearcher := &fakeVectorSearcher{}
 		log, _ := test.NewNullLogger()
-		explorer := NewExplorer(vectorSearcher, log, getFakeModulesProvider())
+		explorer := NewExplorer(vectorSearcher, log, getFakeModulesProvider(), nil)
 		schemaGetter := &fakeSchemaGetter{}
 		traverser := NewTraverser(&config.WeaviateConfig{}, locks, logger, authorizer,
 			vectorSearcher, explorer, schemaGetter, getFakeModulesProvider(), nil)
@@ -374,7 +374,7 @@ func Test_ExploreConcepts(t *testing.T) {
 		logger, _ := test.NewNullLogger()
 		vectorSearcher := &fakeVectorSearcher{}
 		log, _ := test.NewNullLogger()
-		explorer := NewExplorer(vectorSearcher, log, getFakeModulesProvider())
+		explorer := NewExplorer(vectorSearcher, log, getFakeModulesProvider(), nil)
 		schemaGetter := &fakeSchemaGetter{}
 		traverser := NewTraverser(&config.WeaviateConfig{}, locks, logger, authorizer,
 			vectorSearcher, explorer, schemaGetter, getFakeModulesProvider(), nil)
@@ -402,7 +402,7 @@ func Test_ExploreConcepts(t *testing.T) {
 		logger, _ := test.NewNullLogger()
 		vectorSearcher := &fakeVectorSearcher{}
 		log, _ := test.NewNullLogger()
-		explorer := NewExplorer(vectorSearcher, log, getFakeModulesProvider())
+		explorer := NewExplorer(vectorSearcher, log, getFakeModulesProvider(), nil)
 		schemaGetter := &fakeSchemaGetter{}
 		traverser := NewTraverser(&config.WeaviateConfig{}, locks, logger, authorizer,
 			vectorSearcher, explorer, schemaGetter, getFakeModulesProvider(), nil)
@@ -439,7 +439,7 @@ func Test_ExploreConcepts(t *testing.T) {
 		logger, _ := test.NewNullLogger()
 		vectorSearcher := &fakeVectorSearcher{}
 		log, _ := test.NewNullLogger()
-		explorer := NewExplorer(vectorSearcher, log, getFakeModulesProvider())
+		explorer := NewExplorer(vectorSearcher, log, getFakeModulesProvider(), nil)
 		schemaGetter := &fakeSchemaGetter{}
 		traverser := NewTraverser(&config.WeaviateConfig{}, locks, logger, authorizer,
 			vectorSearcher, explorer, schemaGetter, getFakeModulesProvider(), nil)
@@ -506,7 +506,7 @@ func Test_ExploreConcepts(t *testing.T) {
 		logger, _ := test.NewNullLogger()
 		vectorSearcher := &fakeVectorSearcher{}
 		log, _ := test.NewNullLogger()
-		explorer := NewExplorer(vectorSearcher, log, getFakeModulesProvider())
+		explorer := NewExplorer(vectorSearcher, log, getFakeModulesProvider(), nil)
 		schemaGetter := &fakeSchemaGetter{}
 		traverser := NewTraverser(&config.WeaviateConfig{}, locks, logger, authorizer,
 			vectorSearcher, explorer, schemaGetter, getFakeModulesProvider(), nil)

--- a/usecases/traverser/traverser_explore_concepts_test.go
+++ b/usecases/traverser/traverser_explore_concepts_test.go
@@ -31,7 +31,8 @@ func Test_ExploreConcepts(t *testing.T) {
 		logger, _ := test.NewNullLogger()
 		vectorSearcher := &fakeVectorSearcher{}
 		log, _ := test.NewNullLogger()
-		explorer := NewExplorer(vectorSearcher, log, getFakeModulesProvider(), nil)
+		metrics := &fakeMetrics{}
+		explorer := NewExplorer(vectorSearcher, log, getFakeModulesProvider(), metrics)
 		schemaGetter := &fakeSchemaGetter{}
 		traverser := NewTraverser(&config.WeaviateConfig{}, locks, logger, authorizer,
 			vectorSearcher, explorer, schemaGetter, getFakeModulesProvider(), nil)
@@ -47,7 +48,8 @@ func Test_ExploreConcepts(t *testing.T) {
 		logger, _ := test.NewNullLogger()
 		vectorSearcher := &fakeVectorSearcher{}
 		log, _ := test.NewNullLogger()
-		explorer := NewExplorer(vectorSearcher, log, getFakeModulesProvider(), nil)
+		metrics := &fakeMetrics{}
+		explorer := NewExplorer(vectorSearcher, log, getFakeModulesProvider(), metrics)
 		schemaGetter := &fakeSchemaGetter{}
 		traverser := NewTraverser(&config.WeaviateConfig{}, locks, logger, authorizer,
 			vectorSearcher, explorer, schemaGetter, nil, nil)
@@ -67,7 +69,8 @@ func Test_ExploreConcepts(t *testing.T) {
 		logger, _ := test.NewNullLogger()
 		vectorSearcher := &fakeVectorSearcher{}
 		log, _ := test.NewNullLogger()
-		explorer := NewExplorer(vectorSearcher, log, getFakeModulesProvider(), nil)
+		metrics := &fakeMetrics{}
+		explorer := NewExplorer(vectorSearcher, log, getFakeModulesProvider(), metrics)
 		schemaGetter := &fakeSchemaGetter{}
 		traverser := NewTraverser(&config.WeaviateConfig{}, locks, logger, authorizer,
 			vectorSearcher, explorer, schemaGetter, getFakeModulesProvider(), nil)
@@ -84,14 +87,18 @@ func Test_ExploreConcepts(t *testing.T) {
 				ID:        "123-456-789",
 				Certainty: 0.5,
 				Dist:      0.5,
+				Dims:      128,
 			},
 			{
 				ClassName: "AnAction",
 				ID:        "987-654-321",
 				Certainty: 0.5,
 				Dist:      0.5,
+				Dims:      128,
 			},
 		}
+
+		metrics.On("AddUsageDimensions", "n/a", "explore_graphql", "nearCustomText", 128)
 
 		res, err := traverser.Explore(context.Background(), nil, params)
 		require.Nil(t, err)
@@ -102,6 +109,7 @@ func Test_ExploreConcepts(t *testing.T) {
 				Beacon:    "weaviate://localhost/BestClass/123-456-789",
 				Certainty: 0.5,
 				Dist:      0.5,
+				Dims:      128,
 			},
 			{
 				ClassName: "AnAction",
@@ -109,6 +117,7 @@ func Test_ExploreConcepts(t *testing.T) {
 				Beacon:    "weaviate://localhost/AnAction/987-654-321",
 				Certainty: 0.5,
 				Dist:      0.5,
+				Dims:      128,
 			},
 		}, res)
 
@@ -123,7 +132,8 @@ func Test_ExploreConcepts(t *testing.T) {
 		logger, _ := test.NewNullLogger()
 		vectorSearcher := &fakeVectorSearcher{}
 		log, _ := test.NewNullLogger()
-		explorer := NewExplorer(vectorSearcher, log, getFakeModulesProvider(), nil)
+		metrics := &fakeMetrics{}
+		explorer := NewExplorer(vectorSearcher, log, getFakeModulesProvider(), metrics)
 		schemaGetter := &fakeSchemaGetter{}
 		traverser := NewTraverser(&config.WeaviateConfig{}, locks, logger, authorizer,
 			vectorSearcher, explorer, schemaGetter, nil, nil)
@@ -138,15 +148,18 @@ func Test_ExploreConcepts(t *testing.T) {
 				ID:        "123-456-789",
 				Certainty: 0.5,
 				Dist:      0.5,
+				Dims:      128,
 			},
 			{
 				ClassName: "AnAction",
 				ID:        "987-654-321",
 				Certainty: 0.5,
 				Dist:      0.5,
+				Dims:      128,
 			},
 		}
 
+		metrics.On("AddUsageDimensions", "n/a", "explore_graphql", "nearVector", 128)
 		res, err := traverser.Explore(context.Background(), nil, params)
 		require.Nil(t, err)
 		assert.Equal(t, []search.Result{
@@ -156,6 +169,7 @@ func Test_ExploreConcepts(t *testing.T) {
 				Beacon:    "weaviate://localhost/BestClass/123-456-789",
 				Certainty: 0.5,
 				Dist:      0.5,
+				Dims:      128,
 			},
 			{
 				ClassName: "AnAction",
@@ -163,6 +177,7 @@ func Test_ExploreConcepts(t *testing.T) {
 				Beacon:    "weaviate://localhost/AnAction/987-654-321",
 				Certainty: 0.5,
 				Dist:      0.5,
+				Dims:      128,
 			},
 		}, res)
 
@@ -177,7 +192,8 @@ func Test_ExploreConcepts(t *testing.T) {
 		logger, _ := test.NewNullLogger()
 		vectorSearcher := &fakeVectorSearcher{}
 		log, _ := test.NewNullLogger()
-		explorer := NewExplorer(vectorSearcher, log, getFakeModulesProvider(), nil)
+		metrics := &fakeMetrics{}
+		explorer := NewExplorer(vectorSearcher, log, getFakeModulesProvider(), metrics)
 		schemaGetter := &fakeSchemaGetter{}
 		traverser := NewTraverser(&config.WeaviateConfig{}, locks, logger, authorizer,
 			vectorSearcher, explorer, schemaGetter, nil, nil)
@@ -199,15 +215,18 @@ func Test_ExploreConcepts(t *testing.T) {
 				ID:        "bd3d1560-3f0e-4b39-9d62-38b4a3c4f23a",
 				Certainty: 0.5,
 				Dist:      0.5,
+				Dims:      128,
 			},
 			{
 				ClassName: "AnAction",
 				ID:        "bd3d1560-3f0e-4b39-9d62-38b4a3c4f23b",
 				Certainty: 0.5,
 				Dist:      0.5,
+				Dims:      128,
 			},
 		}
 
+		metrics.On("AddUsageDimensions", "n/a", "explore_graphql", "nearObject", 128)
 		res, err := traverser.Explore(context.Background(), nil, params)
 		require.Nil(t, err)
 		assert.Equal(t, []search.Result{
@@ -217,6 +236,7 @@ func Test_ExploreConcepts(t *testing.T) {
 				Beacon:    "weaviate://localhost/BestClass/bd3d1560-3f0e-4b39-9d62-38b4a3c4f23a",
 				Certainty: 0.5,
 				Dist:      0.5,
+				Dims:      128,
 			},
 			{
 				ClassName: "AnAction",
@@ -224,6 +244,7 @@ func Test_ExploreConcepts(t *testing.T) {
 				Beacon:    "weaviate://localhost/AnAction/bd3d1560-3f0e-4b39-9d62-38b4a3c4f23b",
 				Certainty: 0.5,
 				Dist:      0.5,
+				Dims:      128,
 			},
 		}, res)
 
@@ -237,7 +258,8 @@ func Test_ExploreConcepts(t *testing.T) {
 		logger, _ := test.NewNullLogger()
 		vectorSearcher := &fakeVectorSearcher{}
 		log, _ := test.NewNullLogger()
-		explorer := NewExplorer(vectorSearcher, log, getFakeModulesProvider(), nil)
+		metrics := &fakeMetrics{}
+		explorer := NewExplorer(vectorSearcher, log, getFakeModulesProvider(), metrics)
 		schemaGetter := &fakeSchemaGetter{}
 		traverser := NewTraverser(&config.WeaviateConfig{}, locks, logger, authorizer,
 			vectorSearcher, explorer, schemaGetter, nil, nil)
@@ -259,15 +281,18 @@ func Test_ExploreConcepts(t *testing.T) {
 				ID:        "bd3d1560-3f0e-4b39-9d62-38b4a3c4f23a",
 				Certainty: 0.5,
 				Dist:      0.5,
+				Dims:      128,
 			},
 			{
 				ClassName: "AnAction",
 				ID:        "bd3d1560-3f0e-4b39-9d62-38b4a3c4f23b",
 				Certainty: 0.5,
 				Dist:      0.5,
+				Dims:      128,
 			},
 		}
 
+		metrics.On("AddUsageDimensions", "n/a", "explore_graphql", "nearObject", 128)
 		res, err := traverser.Explore(context.Background(), nil, params)
 		require.Nil(t, err)
 		assert.Equal(t, []search.Result{
@@ -277,6 +302,7 @@ func Test_ExploreConcepts(t *testing.T) {
 				Beacon:    "weaviate://localhost/BestClass/bd3d1560-3f0e-4b39-9d62-38b4a3c4f23a",
 				Certainty: 0.5,
 				Dist:      0.5,
+				Dims:      128,
 			},
 			{
 				ClassName: "AnAction",
@@ -284,6 +310,7 @@ func Test_ExploreConcepts(t *testing.T) {
 				Beacon:    "weaviate://localhost/AnAction/bd3d1560-3f0e-4b39-9d62-38b4a3c4f23b",
 				Certainty: 0.5,
 				Dist:      0.5,
+				Dims:      128,
 			},
 		}, res)
 
@@ -297,7 +324,8 @@ func Test_ExploreConcepts(t *testing.T) {
 		logger, _ := test.NewNullLogger()
 		vectorSearcher := &fakeVectorSearcher{}
 		log, _ := test.NewNullLogger()
-		explorer := NewExplorer(vectorSearcher, log, getFakeModulesProvider(), nil)
+		metrics := &fakeMetrics{}
+		explorer := NewExplorer(vectorSearcher, log, getFakeModulesProvider(), metrics)
 		schemaGetter := &fakeSchemaGetter{}
 		traverser := NewTraverser(&config.WeaviateConfig{}, locks, logger, authorizer,
 			vectorSearcher, explorer, schemaGetter, getFakeModulesProvider(), nil)
@@ -314,14 +342,17 @@ func Test_ExploreConcepts(t *testing.T) {
 				ClassName: "BestClass",
 				ID:        "123-456-789",
 				Dist:      0.4,
+				Dims:      128,
 			},
 			{
 				ClassName: "AnAction",
 				ID:        "987-654-321",
 				Dist:      0.4,
+				Dims:      128,
 			},
 		}
 
+		metrics.On("AddUsageDimensions", "n/a", "explore_graphql", "nearVector", 128)
 		res, err := traverser.Explore(context.Background(), nil, params)
 		require.Nil(t, err)
 		assert.Equal(t, []search.Result{}, res) // certainty not matched
@@ -337,7 +368,8 @@ func Test_ExploreConcepts(t *testing.T) {
 		logger, _ := test.NewNullLogger()
 		vectorSearcher := &fakeVectorSearcher{}
 		log, _ := test.NewNullLogger()
-		explorer := NewExplorer(vectorSearcher, log, getFakeModulesProvider(), nil)
+		metrics := &fakeMetrics{}
+		explorer := NewExplorer(vectorSearcher, log, getFakeModulesProvider(), metrics)
 		schemaGetter := &fakeSchemaGetter{}
 		traverser := NewTraverser(&config.WeaviateConfig{}, locks, logger, authorizer,
 			vectorSearcher, explorer, schemaGetter, getFakeModulesProvider(), nil)
@@ -352,13 +384,16 @@ func Test_ExploreConcepts(t *testing.T) {
 			{
 				ClassName: "BestClass",
 				ID:        "123-456-789",
+				Dims:      128,
 			},
 			{
 				ClassName: "AnAction",
 				ID:        "987-654-321",
+				Dims:      128,
 			},
 		}
 
+		metrics.On("AddUsageDimensions", "n/a", "explore_graphql", "nearVector", 128)
 		res, err := traverser.Explore(context.Background(), nil, params)
 		require.Nil(t, err)
 		assert.Equal(t, []search.Result{}, res) // certainty not matched
@@ -374,7 +409,8 @@ func Test_ExploreConcepts(t *testing.T) {
 		logger, _ := test.NewNullLogger()
 		vectorSearcher := &fakeVectorSearcher{}
 		log, _ := test.NewNullLogger()
-		explorer := NewExplorer(vectorSearcher, log, getFakeModulesProvider(), nil)
+		metrics := &fakeMetrics{}
+		explorer := NewExplorer(vectorSearcher, log, getFakeModulesProvider(), metrics)
 		schemaGetter := &fakeSchemaGetter{}
 		traverser := NewTraverser(&config.WeaviateConfig{}, locks, logger, authorizer,
 			vectorSearcher, explorer, schemaGetter, getFakeModulesProvider(), nil)
@@ -402,7 +438,8 @@ func Test_ExploreConcepts(t *testing.T) {
 		logger, _ := test.NewNullLogger()
 		vectorSearcher := &fakeVectorSearcher{}
 		log, _ := test.NewNullLogger()
-		explorer := NewExplorer(vectorSearcher, log, getFakeModulesProvider(), nil)
+		metrics := &fakeMetrics{}
+		explorer := NewExplorer(vectorSearcher, log, getFakeModulesProvider(), metrics)
 		schemaGetter := &fakeSchemaGetter{}
 		traverser := NewTraverser(&config.WeaviateConfig{}, locks, logger, authorizer,
 			vectorSearcher, explorer, schemaGetter, getFakeModulesProvider(), nil)
@@ -418,13 +455,16 @@ func Test_ExploreConcepts(t *testing.T) {
 			{
 				ClassName: "BestClass",
 				ID:        "123-456-789",
+				Dims:      128,
 			},
 			{
 				ClassName: "AnAction",
 				ID:        "987-654-321",
+				Dims:      128,
 			},
 		}
 
+		metrics.On("AddUsageDimensions", "n/a", "explore_graphql", "nearCustomText", 128)
 		res, err := traverser.Explore(context.Background(), nil, params)
 		require.Nil(t, err)
 		assert.Equal(t, []search.Result{}, res, "empty result because certainty is not met")
@@ -439,7 +479,8 @@ func Test_ExploreConcepts(t *testing.T) {
 		logger, _ := test.NewNullLogger()
 		vectorSearcher := &fakeVectorSearcher{}
 		log, _ := test.NewNullLogger()
-		explorer := NewExplorer(vectorSearcher, log, getFakeModulesProvider(), nil)
+		metrics := &fakeMetrics{}
+		explorer := NewExplorer(vectorSearcher, log, getFakeModulesProvider(), metrics)
 		schemaGetter := &fakeSchemaGetter{}
 		traverser := NewTraverser(&config.WeaviateConfig{}, locks, logger, authorizer,
 			vectorSearcher, explorer, schemaGetter, getFakeModulesProvider(), nil)
@@ -465,15 +506,18 @@ func Test_ExploreConcepts(t *testing.T) {
 				ID:        "123-456-789",
 				Certainty: 0.5,
 				Dist:      0.5,
+				Dims:      128,
 			},
 			{
 				ClassName: "AnAction",
 				ID:        "987-654-321",
 				Certainty: 0.5,
 				Dist:      0.5,
+				Dims:      128,
 			},
 		}
 
+		metrics.On("AddUsageDimensions", "n/a", "explore_graphql", "nearCustomText", 128)
 		res, err := traverser.Explore(context.Background(), nil, params)
 		require.Nil(t, err)
 		assert.Equal(t, []search.Result{
@@ -483,6 +527,7 @@ func Test_ExploreConcepts(t *testing.T) {
 				Beacon:    "weaviate://localhost/BestClass/123-456-789",
 				Certainty: 0.5,
 				Dist:      0.5,
+				Dims:      128,
 			},
 			{
 				ClassName: "AnAction",
@@ -490,6 +535,7 @@ func Test_ExploreConcepts(t *testing.T) {
 				Beacon:    "weaviate://localhost/AnAction/987-654-321",
 				Certainty: 0.5,
 				Dist:      0.5,
+				Dims:      128,
 			},
 		}, res)
 
@@ -506,7 +552,8 @@ func Test_ExploreConcepts(t *testing.T) {
 		logger, _ := test.NewNullLogger()
 		vectorSearcher := &fakeVectorSearcher{}
 		log, _ := test.NewNullLogger()
-		explorer := NewExplorer(vectorSearcher, log, getFakeModulesProvider(), nil)
+		metrics := &fakeMetrics{}
+		explorer := NewExplorer(vectorSearcher, log, getFakeModulesProvider(), metrics)
 		schemaGetter := &fakeSchemaGetter{}
 		traverser := NewTraverser(&config.WeaviateConfig{}, locks, logger, authorizer,
 			vectorSearcher, explorer, schemaGetter, getFakeModulesProvider(), nil)
@@ -549,29 +596,35 @@ func Test_ExploreConcepts(t *testing.T) {
 				ID:        "123-456-789",
 				Certainty: 0.5,
 				Dist:      0.5,
+				Dims:      128,
 			},
 			{
 				ClassName: "AnAction",
 				ID:        "987-654-321",
 				Certainty: 0.5,
 				Dist:      0.5,
+				Dims:      128,
 			},
 		}
 		searchRes1 := search.Result{
 			ClassName: "BestClass",
 			ID:        "e9c12c22-766f-4bde-b140-d4cf8fd6e041",
+			Dims:      128,
 		}
 		searchRes2 := search.Result{
 			ClassName: "BestClass",
 			ID:        "e9c12c22-766f-4bde-b140-d4cf8fd6e042",
+			Dims:      128,
 		}
 		searchRes3 := search.Result{
 			ClassName: "BestClass",
 			ID:        "e9c12c22-766f-4bde-b140-d4cf8fd6e043",
+			Dims:      128,
 		}
 		searchRes4 := search.Result{
 			ClassName: "BestClass",
 			ID:        "e9c12c22-766f-4bde-b140-d4cf8fd6e044",
+			Dims:      128,
 		}
 
 		vectorSearcher.
@@ -587,6 +640,7 @@ func Test_ExploreConcepts(t *testing.T) {
 			On("ObjectByID", strfmt.UUID("e9c12c22-766f-4bde-b140-d4cf8fd6e044")).
 			Return(&searchRes4, nil)
 
+		metrics.On("AddUsageDimensions", "n/a", "explore_graphql", "nearCustomText", 128)
 		res, err := traverser.Explore(context.Background(), nil, params)
 		require.Nil(t, err)
 		assert.Equal(t, []search.Result{
@@ -596,6 +650,7 @@ func Test_ExploreConcepts(t *testing.T) {
 				Beacon:    "weaviate://localhost/BestClass/123-456-789",
 				Certainty: 0.5,
 				Dist:      0.5,
+				Dims:      128,
 			},
 			{
 				ClassName: "AnAction",
@@ -603,6 +658,7 @@ func Test_ExploreConcepts(t *testing.T) {
 				Beacon:    "weaviate://localhost/AnAction/987-654-321",
 				Certainty: 0.5,
 				Dist:      0.5,
+				Dims:      128,
 			},
 		}, res)
 


### PR DESCRIPTION
## New Additions
This PR extends the Prometheus monitoring with usage metrics for all read requests that involve vectors, including:

* GraphQL Get with `near<Any>`
* GraphQL Get without vector search but with explicit `_additional { vector }`
* All GraphQL Explore requests (as they always involve a vector search)
* All REST GET requests that involve `?incude=vector`

Stakeholder: SeMI WCS Team

## Refactoring

Some method names in the `usecases/traverser` package didn't make sense any more. For example `explorer.Concepts` is really an `explorer.CrossClassVectorSearch`. This PR renames this.

## Out of Scope
* This PR only adds the metrics, it does not show them on the sample dashboard yet. This is something we can add later. For now the WCS team just needs the metrics.

## Jira
WEAVIATE-232