### PR TITLE
Add gofumpt precommit hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,8 @@
+repos:
+- repo: local
+  hooks:
+    - id: gofumpt
+      name: gofumpt
+      entry: gofumpt -w
+      language: system
+      types: [go]


### PR DESCRIPTION
Adds a precommit hook to run gofumpt -w on each file that is changed with a commit. When a file is not formatted correctly it automatically reformats the file and then aborts the commit. You can just add the file(s) again and commit again without waiting for the CI to complain.

To use:
- install precommit, (on mac use `brew install pre-commit`)
- execute `pre-commit install` in the weaviate directory

To not use:
- Just do nothing, it has no effect

This is how it looks when it fails:
<img width="602" alt="image" src="https://user-images.githubusercontent.com/5353192/187276115-4a965e23-56c2-41ae-a0a9-0d38301a0a19.png">
