### PR TITLE
Fix multiple aggregation edge cases

### DIFF
--- a/adapters/handlers/graphql/local/aggregate/aggregate.go
+++ b/adapters/handlers/graphql/local/aggregate/aggregate.go
@@ -79,13 +79,6 @@ func classFields(databaseSchema []*models.Class,
 func classField(class *models.Class, description string,
 	config config.Config, modulesProvider ModulesProvider,
 ) (*graphql.Field, error) {
-	if len(class.Properties) == 0 {
-		// if we don't have class properties, we can't build this particular class,
-		// as it would not have any fields. So we have to return (without an
-		// error), so as not to block the creation of other classes
-		return nil, nil
-	}
-
 	metaClassName := fmt.Sprintf("Aggregate%s", class.Class)
 
 	fields := graphql.ObjectConfig{

--- a/adapters/repos/db/aggregator/aggregator.go
+++ b/adapters/repos/db/aggregator/aggregator.go
@@ -97,7 +97,7 @@ func (a *Aggregator) aggTypeOfProperty(
 	case schema.DataTypeText, schema.DataTypeString, schema.DataTypeTextArray,
 		schema.DataTypeStringArray:
 		return aggregation.PropertyTypeText, dt, nil
-	case schema.DataTypeDate:
+	case schema.DataTypeDate, schema.DataTypeDateArray:
 		return aggregation.PropertyTypeDate, dt, nil
 	case schema.DataTypeGeoCoordinates:
 		return "", "", fmt.Errorf("dataType geoCoordinates can't be aggregated")

--- a/adapters/repos/db/aggregator/filtered.go
+++ b/adapters/repos/db/aggregator/filtered.go
@@ -135,38 +135,111 @@ func (fa *filteredAggregator) analyzeObject(ctx context.Context,
 func (fa *filteredAggregator) addPropValue(prop propAgg, value interface{}) error {
 	switch prop.aggType {
 	case aggregation.PropertyTypeBoolean:
-		asBool, ok := value.(bool)
-		if !ok {
-			return fmt.Errorf("expected property type boolean, received %T", value)
+		analyzeBool := func(value interface{}) error {
+			asBool, ok := value.(bool)
+			if !ok {
+				return fmt.Errorf("expected property type boolean, received %T", value)
+			}
+			if err := prop.boolAgg.AddBool(asBool); err != nil {
+				return err
+			}
+			return nil
 		}
-		if err := prop.boolAgg.AddBool(asBool); err != nil {
-			return err
+		switch prop.dataType {
+		case schema.DataTypeBoolean:
+			if err := analyzeBool(value); err != nil {
+				return err
+			}
+		case schema.DataTypeBooleanArray:
+			valueStruct := value.([]interface{})
+			for _, val := range valueStruct {
+				if err := analyzeBool(val); err != nil {
+					return err
+				}
+			}
+		default:
+			return fmt.Errorf("unknown datatype %v for aggregation %v", prop.dataType, aggregation.PropertyTypeText)
 		}
 	case aggregation.PropertyTypeNumerical:
-		asFloat, ok := value.(float64)
-		if !ok {
-			return fmt.Errorf("expected property type float64, received %T", value)
+		analyzeFloat := func(value interface{}) error {
+			asFloat, ok := value.(float64)
+			if !ok {
+				return fmt.Errorf("expected property type float64, received %T", value)
+			}
+			if err := prop.numericalAgg.AddFloat64(asFloat); err != nil {
+				return err
+			}
+			return nil
 		}
-		if err := prop.numericalAgg.AddFloat64(asFloat); err != nil {
-			return err
+		switch prop.dataType {
+		case schema.DataTypeNumber, schema.DataTypeInt:
+			if err := analyzeFloat(value); err != nil {
+				return err
+			}
+		case schema.DataTypeNumberArray, schema.DataTypeIntArray:
+			valueStruct := value.([]interface{})
+			for _, val := range valueStruct {
+				if err := analyzeFloat(val); err != nil {
+					return err
+				}
+			}
+		default:
+			return fmt.Errorf("unknown datatype %v for aggregation %v", prop.dataType, aggregation.PropertyTypeText)
 		}
 	case aggregation.PropertyTypeText:
-		asString, ok := value.(string)
-		if !ok {
-			return fmt.Errorf("expected property type string, received %T", value)
+		analyzeString := func(value interface{}) error {
+			asString, ok := value.(string)
+			if !ok {
+				return fmt.Errorf("expected property type string, received %T", value)
+			}
+			if err := prop.textAgg.AddText(asString); err != nil {
+				return err
+			}
+			return nil
 		}
-		if err := prop.textAgg.AddText(asString); err != nil {
-			return err
+		switch prop.dataType {
+		case schema.DataTypeText, schema.DataTypeString:
+			if err := analyzeString(value); err != nil {
+				return err
+			}
+		case schema.DataTypeTextArray, schema.DataTypeStringArray:
+			valueStruct := value.([]interface{})
+			for _, val := range valueStruct {
+				if err := analyzeString(val); err != nil {
+					return err
+				}
+			}
+		default:
+			return fmt.Errorf("unknown datatype %v for aggregation %v", prop.dataType, aggregation.PropertyTypeText)
 		}
 	case aggregation.PropertyTypeDate:
-		asString, ok := value.(string)
-		if !ok {
-			return fmt.Errorf("expected property type date, received %T", value)
+		analyzeDate := func(value interface{}) error {
+			asString, ok := value.(string)
+			if !ok {
+				return fmt.Errorf("expected property type date, received %T", value)
+			}
+			if err := prop.dateAgg.AddTimestamp(asString); err != nil {
+				return err
+			}
+			return nil
 		}
-		if err := prop.dateAgg.AddTimestamp(asString); err != nil {
-			return err
+		switch prop.dataType {
+		case schema.DataTypeDate:
+			if err := analyzeDate(value); err != nil {
+				return err
+			}
+		case schema.DataTypeDateArray:
+			valueStruct := value.([]interface{})
+			for _, val := range valueStruct {
+				if err := analyzeDate(val); err != nil {
+					return err
+				}
+			}
+		default:
+			return fmt.Errorf("unknown datatype %v for aggregation %v", prop.dataType, aggregation.PropertyTypeText)
 		}
 	default:
+
 	}
 
 	return nil

--- a/adapters/repos/db/aggregator/filtered.go
+++ b/adapters/repos/db/aggregator/filtered.go
@@ -151,7 +151,10 @@ func (fa *filteredAggregator) addPropValue(prop propAgg, value interface{}) erro
 				return err
 			}
 		case schema.DataTypeBooleanArray:
-			valueStruct := value.([]interface{})
+			valueStruct, ok := value.([]interface{})
+			if !ok {
+				return fmt.Errorf("expected property type []boolean, received %T", valueStruct)
+			}
 			for _, val := range valueStruct {
 				if err := analyzeBool(val); err != nil {
 					return err
@@ -177,7 +180,10 @@ func (fa *filteredAggregator) addPropValue(prop propAgg, value interface{}) erro
 				return err
 			}
 		case schema.DataTypeNumberArray, schema.DataTypeIntArray:
-			valueStruct := value.([]interface{})
+			valueStruct, ok := value.([]interface{})
+			if !ok {
+				return fmt.Errorf("expected property type []float* or []int*, received %T", valueStruct)
+			}
 			for _, val := range valueStruct {
 				if err := analyzeFloat(val); err != nil {
 					return err
@@ -203,7 +209,10 @@ func (fa *filteredAggregator) addPropValue(prop propAgg, value interface{}) erro
 				return err
 			}
 		case schema.DataTypeTextArray, schema.DataTypeStringArray:
-			valueStruct := value.([]interface{})
+			valueStruct, ok := value.([]interface{})
+			if !ok {
+				return fmt.Errorf("expected property type []text or []string, received %T", valueStruct)
+			}
 			for _, val := range valueStruct {
 				if err := analyzeString(val); err != nil {
 					return err
@@ -229,7 +238,10 @@ func (fa *filteredAggregator) addPropValue(prop propAgg, value interface{}) erro
 				return err
 			}
 		case schema.DataTypeDateArray:
-			valueStruct := value.([]interface{})
+			valueStruct, ok := value.([]interface{})
+			if !ok {
+				return fmt.Errorf("expected property type []date, received %T", valueStruct)
+			}
 			for _, val := range valueStruct {
 				if err := analyzeDate(val); err != nil {
 					return err

--- a/adapters/repos/db/sorter/fakes_for_test.go
+++ b/adapters/repos/db/sorter/fakes_for_test.go
@@ -84,6 +84,18 @@ func getMyFavoriteClassSchemaForTests() schema.Schema {
 							DataType: []string{string(schema.DataTypeString)},
 						},
 						{
+							Name:     "emptyBoolProp",
+							DataType: []string{string(schema.DataTypeBoolean)},
+						},
+						{
+							Name:     "emptyNumberProp",
+							DataType: []string{string(schema.DataTypeNumber)},
+						},
+						{
+							Name:     "emptyIntProp",
+							DataType: []string{string(schema.DataTypeInt)},
+						},
+						{
 							Name:     "crefProp",
 							DataType: []string{string(schema.DataTypeCRef)},
 						},

--- a/adapters/repos/db/sorter/lsm_value_extractor.go
+++ b/adapters/repos/db/sorter/lsm_value_extractor.go
@@ -34,6 +34,11 @@ func newPropertyExtractor(className schema.ClassName,
 
 func (e *lsmPropertyExtractor) getProperty(v []byte) interface{} {
 	prop, success, _ := storobj.ParseAndExtractProperty(v, e.property)
+
+	// in case the property does not exist for the object return nil
+	if len(prop) == 0 {
+		return nil
+	}
 	if success {
 		if e.property == "id" || e.property == "_id" {
 			// handle special ID property

--- a/adapters/repos/db/sorter/lsm_value_extractor.go
+++ b/adapters/repos/db/sorter/lsm_value_extractor.go
@@ -34,7 +34,6 @@ func newPropertyExtractor(className schema.ClassName,
 
 func (e *lsmPropertyExtractor) getProperty(v []byte) interface{} {
 	prop, success, _ := storobj.ParseAndExtractProperty(v, e.property)
-
 	// in case the property does not exist for the object return nil
 	if len(prop) == 0 {
 		return nil

--- a/adapters/repos/db/sorter/lsm_value_extractor_test.go
+++ b/adapters/repos/db/sorter/lsm_value_extractor_test.go
@@ -170,6 +170,21 @@ func Test_lsmPropertyExtractor_getProperty(t *testing.T) {
 			want:     nil,
 		},
 		{
+			name:     "emptyBoolProp",
+			property: "emptyBoolProp",
+			want:     nil,
+		},
+		{
+			name:     "emptyNumberProp",
+			property: "emptyNumberProp",
+			want:     nil,
+		},
+		{
+			name:     "emptyIntProp",
+			property: "emptyIntProp",
+			want:     nil,
+		},
+		{
 			name:     "crefProp",
 			property: "crefProp",
 			want:     nil,

--- a/entities/storobj/parse_single_object.go
+++ b/entities/storobj/parse_single_object.go
@@ -63,7 +63,11 @@ func parseAndExtractValueProp(data []byte, propName string, valueFn func(value [
 	}
 
 	val, t, _, err := jsonparser.Get(propsBytes, propName)
+	// Some objects can have nil as value for the property, in this case skip the object
 	if err != nil {
+		if err.Error() == "Key path not found" {
+			return nil
+		}
 		return err
 	}
 

--- a/entities/storobj/storage_object_test.go
+++ b/entities/storobj/storage_object_test.go
@@ -76,6 +76,13 @@ func TestStorageObjectMarshalling(t *testing.T) {
 		require.NotEmpty(t, prop)
 		assert.Equal(t, "MyName", prop[0])
 	})
+
+	t.Run("extract non-existing text prop", func(t *testing.T) {
+		prop, ok, err := ParseAndExtractTextProp(asBinary, "IDoNotExist")
+		require.Nil(t, err)
+		require.True(t, ok)
+		require.Empty(t, prop)
+	})
 }
 
 func TestStorageObjectUnmarshallingSpecificProps(t *testing.T) {

--- a/test/acceptance/graphql_resolvers/local_aggregate_groupby_nearobject_test.go
+++ b/test/acceptance/graphql_resolvers/local_aggregate_groupby_nearobject_test.go
@@ -49,7 +49,7 @@ func aggregatesArrayClassWithGroupingAndNearObject(t *testing.T) {
 		},
 		{
 			name:     "dates",
-			property: "dates",
+			property: "datesAsStrings",
 			expected: map[string]string{
 				"2022-06-01T22:18:59.640162Z": "3",
 				"2022-06-02T22:18:59.640162Z": "2",

--- a/test/acceptance/graphql_resolvers/local_aggregate_sanity_check_test.go
+++ b/test/acceptance/graphql_resolvers/local_aggregate_sanity_check_test.go
@@ -69,21 +69,21 @@ func runningAggregateArrayClassSanityCheck(t *testing.T) {
 			{
 				name: "without filters",
 			},
-			//{
-			//	name:    "with where filter",
-			//	filters: `( where:{operator: Like path:["id"] valueString:"*"} )`,
-			//},
-			//{
-			//	name:    "with nearObject filter",
-			//	filters: `( nearObject:{id: "cfa3b21e-ca5f-4db7-a412-5fc6a23c534a" certainty: 0.9} )`,
-			//},
-			//{
-			//	name: "with where and nearObject filter",
-			//	filters: `(
-			//		where:{operator: Like path:["id"] valueString:"*"}
-			//		nearObject:{id: "cfa3b21e-ca5f-4db7-a412-5fc6a23c534a" certainty: 0.9}
-			//	)`,
-			//},
+			{
+				name:    "with where filter",
+				filters: `( where:{operator: Like path:["id"] valueString:"*"} )`,
+			},
+			{
+				name:    "with nearObject filter",
+				filters: `( nearObject:{id: "cfa3b21e-ca5f-4db7-a412-5fc6a23c534a" certainty: 0.9} )`,
+			},
+			{
+				name: "with where and nearObject filter",
+				filters: `(
+					where:{operator: Like path:["id"] valueString:"*"}
+					nearObject:{id: "cfa3b21e-ca5f-4db7-a412-5fc6a23c534a" certainty: 0.9}
+				)`,
+			},
 		}
 		for _, tt := range tests {
 			t.Run(tt.name, func(t *testing.T) {

--- a/test/acceptance/graphql_resolvers/local_aggregate_sanity_check_test.go
+++ b/test/acceptance/graphql_resolvers/local_aggregate_sanity_check_test.go
@@ -77,20 +77,20 @@ func runningAggregateArrayClassSanityCheck(t *testing.T) {
 			},
 			{
 				name:    "with nearObject filter",
-				filters: `( nearObject:{id: "cfa3b21e-ca5f-4db7-a412-5fc6a23c534a" certainty: 0.9} )`,
+				filters: `( nearObject:{id: "cfa3b21e-ca5f-4db7-a412-5fc6a23c534a" certainty: 0.1} )`,
 			},
 			{
 				name: "with where and nearObject filter",
 				filters: `(
 					where:{operator: Like path:["id"] valueString:"*"}
-					nearObject:{id: "cfa3b21e-ca5f-4db7-a412-5fc6a23c534a" certainty: 0.9}
+					nearObject:{id: "cfa3b21e-ca5f-4db7-a412-5fc6a23c534a" certainty: 0.1}
 				)`,
 			},
 		}
 		for _, tt := range tests {
 			t.Run(tt.name, func(t *testing.T) {
 				result := graphqlhelper.AssertGraphQL(t, helper.RootAuth, fmt.Sprintf(query, tt.filters))
-				assert.Equal(t, json.Number("3"), getCount(result, "ArrayClass", "meta"))
+				assert.Equal(t, json.Number("4"), getCount(result, "ArrayClass", "meta"))
 				assert.Equal(t, json.Number("6"), getCount(result, "ArrayClass", "booleans"))
 				assert.Equal(t, json.Number("6"), getCount(result, "ArrayClass", "datesAsStrings"))
 				assert.Equal(t, json.Number("6"), getCount(result, "ArrayClass", "dates"))
@@ -106,7 +106,7 @@ func runningAggregateArrayClassSanityCheck(t *testing.T) {
 		query := `
 			{
 			  Aggregate {
-				City 
+				City
 				%s
 				{
 				  meta {

--- a/test/acceptance/graphql_resolvers/local_aggregate_sanity_check_test.go
+++ b/test/acceptance/graphql_resolvers/local_aggregate_sanity_check_test.go
@@ -33,7 +33,10 @@ func runningAggregateArrayClassSanityCheck(t *testing.T) {
 						booleans{
 							count
 						}
-						meta {
+						meta{
+							count
+						}
+						datesAsStrings{
 							count
 						}
 						dates{
@@ -66,29 +69,29 @@ func runningAggregateArrayClassSanityCheck(t *testing.T) {
 			{
 				name: "without filters",
 			},
-			{
-				name:    "with where filter",
-				filters: `( where:{operator: Like path:["id"] valueString:"*"} )`,
-			},
-			{
-				name:    "with nearObject filter",
-				filters: `( nearObject:{id: "cfa3b21e-ca5f-4db7-a412-5fc6a23c534a" certainty: 0.9} )`,
-			},
-			{
-				name: "with where and nearObject filter",
-				filters: `(
-					where:{operator: Like path:["id"] valueString:"*"}
-					nearObject:{id: "cfa3b21e-ca5f-4db7-a412-5fc6a23c534a" certainty: 0.9}
-				)`,
-			},
+			//{
+			//	name:    "with where filter",
+			//	filters: `( where:{operator: Like path:["id"] valueString:"*"} )`,
+			//},
+			//{
+			//	name:    "with nearObject filter",
+			//	filters: `( nearObject:{id: "cfa3b21e-ca5f-4db7-a412-5fc6a23c534a" certainty: 0.9} )`,
+			//},
+			//{
+			//	name: "with where and nearObject filter",
+			//	filters: `(
+			//		where:{operator: Like path:["id"] valueString:"*"}
+			//		nearObject:{id: "cfa3b21e-ca5f-4db7-a412-5fc6a23c534a" certainty: 0.9}
+			//	)`,
+			//},
 		}
 		for _, tt := range tests {
 			t.Run(tt.name, func(t *testing.T) {
 				result := graphqlhelper.AssertGraphQL(t, helper.RootAuth, fmt.Sprintf(query, tt.filters))
 				assert.Equal(t, json.Number("3"), getCount(result, "ArrayClass", "meta"))
 				assert.Equal(t, json.Number("6"), getCount(result, "ArrayClass", "booleans"))
-				// TODO: support dates
-				// assert.Equal(t, json.Number("6"), getCount(result, "ArrayClass", "dates"))
+				assert.Equal(t, json.Number("6"), getCount(result, "ArrayClass", "datesAsStrings"))
+				assert.Equal(t, json.Number("6"), getCount(result, "ArrayClass", "dates"))
 				assert.Equal(t, json.Number("6"), getCount(result, "ArrayClass", "numbers"))
 				assert.Equal(t, json.Number("6"), getCount(result, "ArrayClass", "strings"))
 				assert.Equal(t, json.Number("6"), getCount(result, "ArrayClass", "texts"))

--- a/test/acceptance/graphql_resolvers/local_aggregate_sanity_check_test.go
+++ b/test/acceptance/graphql_resolvers/local_aggregate_sanity_check_test.go
@@ -1,0 +1,99 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2022 SeMI Technologies B.V. All rights reserved.
+//
+//  CONTACT: hello@semi.technology
+//
+
+package test
+
+import (
+	"encoding/json"
+	"fmt"
+	"testing"
+
+	"github.com/semi-technologies/weaviate/test/helper"
+	graphqlhelper "github.com/semi-technologies/weaviate/test/helper/graphql"
+	"github.com/stretchr/testify/assert"
+)
+
+// run by setup_test.go
+func runningAggregateArrayClassSanityCheck(t *testing.T) {
+	t.Run("running Aggregate against ArrayClass", func(t *testing.T) {
+		query := `
+			{
+				Aggregate {
+					ArrayClass
+					%s
+					{
+						booleans{
+							count
+						}
+						meta {
+							count
+						}
+						dates{
+							count
+						}
+						numbers{
+							count
+						}
+						strings{
+							count
+						}
+						texts{
+							count
+						}
+						ints{
+							count
+						}
+					}
+				}
+			}
+		`
+		getCount := func(result *graphqlhelper.GraphQLResult, className, property string) interface{} {
+			meta := result.Get("Aggregate", className).AsSlice()[0].(map[string]interface{})[property]
+			return meta.(map[string]interface{})["count"]
+		}
+		tests := []struct {
+			name    string
+			filters string
+		}{
+			{
+				name: "without filters",
+			},
+			{
+				name:    "with where filter",
+				filters: `( where:{operator: Like path:["id"] valueString:"*"} )`,
+			},
+			{
+				name:    "with nearObject filter",
+				filters: `( nearObject:{id: "cfa3b21e-ca5f-4db7-a412-5fc6a23c534a" certainty: 0.9} )`,
+			},
+			{
+				name: "with where and nearObject filter",
+				filters: `(
+					where:{operator: Like path:["id"] valueString:"*"}
+					nearObject:{id: "cfa3b21e-ca5f-4db7-a412-5fc6a23c534a" certainty: 0.9}
+				)`,
+			},
+		}
+		for _, tt := range tests {
+			t.Run(tt.name, func(t *testing.T) {
+				result := graphqlhelper.AssertGraphQL(t, helper.RootAuth, fmt.Sprintf(query, tt.filters))
+				assert.Equal(t, json.Number("3"), getCount(result, "ArrayClass", "meta"))
+				assert.Equal(t, json.Number("6"), getCount(result, "ArrayClass", "booleans"))
+				// TODO: support dates
+				// assert.Equal(t, json.Number("6"), getCount(result, "ArrayClass", "dates"))
+				assert.Equal(t, json.Number("6"), getCount(result, "ArrayClass", "numbers"))
+				assert.Equal(t, json.Number("6"), getCount(result, "ArrayClass", "strings"))
+				assert.Equal(t, json.Number("6"), getCount(result, "ArrayClass", "texts"))
+				assert.Equal(t, json.Number("6"), getCount(result, "ArrayClass", "ints"))
+			})
+		}
+	})
+}

--- a/test/acceptance/graphql_resolvers/local_aggregate_test.go
+++ b/test/acceptance/graphql_resolvers/local_aggregate_test.go
@@ -308,12 +308,12 @@ func aggregatesArrayClassWithoutGroupingOrFilters(t *testing.T) {
 	t.Run("meta count", func(t *testing.T) {
 		meta := result.Get("Aggregate", "ArrayClass").AsSlice()[0].(map[string]interface{})["meta"]
 		count := meta.(map[string]interface{})["count"]
-		expected := json.Number("3")
+		expected := json.Number("4")
 		assert.Equal(t, expected, count)
 	})
 
 	t.Run("int[]/number[] props", func(t *testing.T) {
-		isCapital := result.Get("Aggregate", "ArrayClass").AsSlice()[0].(map[string]interface{})["numbers"]
+		numbers := result.Get("Aggregate", "ArrayClass").AsSlice()[0].(map[string]interface{})["numbers"]
 		expected := map[string]interface{}{
 			"mean":    json.Number("1.6666666666666667"),
 			"count":   json.Number("6"),
@@ -322,7 +322,7 @@ func aggregatesArrayClassWithoutGroupingOrFilters(t *testing.T) {
 			"sum":     json.Number("10"),
 			"type":    "number[]",
 		}
-		assert.Equal(t, expected, isCapital)
+		assert.Equal(t, expected, numbers)
 	})
 
 	t.Run("string[]/text[] prop", func(t *testing.T) {

--- a/test/acceptance/graphql_resolvers/setup_test.go
+++ b/test/acceptance/graphql_resolvers/setup_test.go
@@ -987,7 +987,7 @@ func addTestDataArrayClasses(t *testing.T) {
 	})
 	assertGetObjectEventually(t, arrayClassID3)
 
-	// objects with null objects
+	// object without properties
 	createObject(t, &models.Object{
 		Class: "ArrayClass",
 		ID:    arrayClassID4,

--- a/test/acceptance/graphql_resolvers/setup_test.go
+++ b/test/acceptance/graphql_resolvers/setup_test.go
@@ -76,6 +76,7 @@ func Test_GraphQL(t *testing.T) {
 	t.Run("aggregates local meta with objectLimit and nearMedia filters", localMetaWithObjectLimit)
 	t.Run("aggregates on date fields", aggregatesOnDateFields)
 	t.Run("expected aggregate failures with invalid conditions", aggregatesWithExpectedFailures)
+	t.Run("aggregate sanity checks", runningAggregateArrayClassSanityCheck)
 
 	// tear down
 	deleteObjectClass(t, "Person")

--- a/test/acceptance/graphql_resolvers/setup_test.go
+++ b/test/acceptance/graphql_resolvers/setup_test.go
@@ -893,6 +893,7 @@ func addTestDataArrayClasses(t *testing.T) {
 		arrayClassID1 strfmt.UUID = "cfa3b21e-ca5f-4db7-a412-5fc6a23c534a"
 		arrayClassID2 strfmt.UUID = "cfa3b21e-ca5f-4db7-a412-5fc6a23c534b"
 		arrayClassID3 strfmt.UUID = "cfa3b21e-ca5f-4db7-a412-5fc6a23c534c"
+		arrayClassID4 strfmt.UUID = "cfa3b21e-ca5f-4db7-a412-5fc6a23c534d"
 	)
 	createObject(t, &models.Object{
 		Class: "ArrayClass",
@@ -956,6 +957,13 @@ func addTestDataArrayClasses(t *testing.T) {
 		},
 	})
 	assertGetObjectEventually(t, arrayClassID3)
+
+	// objects with null objects
+	createObject(t, &models.Object{
+		Class: "ArrayClass",
+		ID:    arrayClassID4,
+	})
+	assertGetObjectEventually(t, arrayClassID4)
 }
 
 func addTestDataRansomNotes(t *testing.T) {

--- a/test/acceptance/graphql_resolvers/setup_test.go
+++ b/test/acceptance/graphql_resolvers/setup_test.go
@@ -46,6 +46,7 @@ func Test_GraphQL(t *testing.T) {
 	t.Run("import test data (multi shard)", addTestDataMultiShard)
 	t.Run("import test data (date field class)", addDateFieldClass)
 	t.Run("import test data (custom vector class)", addTestDataCVC)
+	t.Run("import test data (class without properties)", addTestDataNoProperties)
 
 	// explore tests
 	t.Run("expected explore failures with invalid conditions", exploreWithExpectedFailures)
@@ -89,6 +90,7 @@ func Test_GraphQL(t *testing.T) {
 	deleteObjectClass(t, "RansomNote")
 	deleteObjectClass(t, "MultiShard")
 	deleteObjectClass(t, "HasDateField")
+	deleteObjectClass(t, "ClassWithoutProperties")
 
 	// only run after everything else is deleted, this way, we can also run an
 	// all-class Explore since all vectors which are now left have the same
@@ -481,6 +483,15 @@ func addTestSchema(t *testing.T) {
 			{
 				Name:     "name",
 				DataType: []string{"string"},
+			},
+		},
+	})
+
+	createObjectClass(t, &models.Class{
+		Class: "ClassWithoutProperties",
+		ModuleConfig: map[string]interface{}{
+			"text2vec-contextionary": map[string]interface{}{
+				"vectorizeClassName": true,
 			},
 		},
 	})
@@ -886,6 +897,24 @@ func addTestDataCVC(t *testing.T) {
 		},
 	})
 	assertGetObjectEventually(t, cvc3)
+}
+
+func addTestDataNoProperties(t *testing.T) {
+	var (
+		EmptyID1 strfmt.UUID = "cfa3b21e-ca5f-4db7-a412-5fc6a23c534a"
+		EmptyID2 strfmt.UUID = "cfa3b21e-ca5f-4db7-a412-5fc6a23c534b"
+	)
+	createObject(t, &models.Object{
+		Class: "ClassWithoutProperties",
+		ID:    EmptyID1,
+	})
+	assertGetObjectEventually(t, EmptyID1)
+
+	createObject(t, &models.Object{
+		Class: "ClassWithoutProperties",
+		ID:    EmptyID2,
+	})
+	assertGetObjectEventually(t, EmptyID2)
 }
 
 func addTestDataArrayClasses(t *testing.T) {

--- a/test/acceptance/graphql_resolvers/setup_test.go
+++ b/test/acceptance/graphql_resolvers/setup_test.go
@@ -400,7 +400,7 @@ func addTestSchema(t *testing.T) {
 				DataType: []string{"boolean[]"},
 			},
 			{
-				Name:     "dates",
+				Name:     "datesAsStrings",
 				DataType: []string{"date[]"},
 			},
 		},
@@ -903,10 +903,15 @@ func addTestDataArrayClasses(t *testing.T) {
 			"numbers":  []float64{1.0, 2.0, 3.0},
 			"ints":     []int{1, 2, 3},
 			"booleans": []bool{true, true},
-			"dates": []string{
+			"datesAsStrings": []string{
 				"2022-06-01T22:18:59.640162Z",
 				"2022-06-02T22:18:59.640162Z",
 				"2022-06-03T22:18:59.640162Z",
+			},
+			"dates": []time.Time{
+				time.Date(1234, 5, 6, 7, 8, 9, 10, time.UTC),
+				time.Date(1235, 6, 7, 8, 9, 10, 11, time.UTC),
+				time.Date(1236, 7, 8, 9, 10, 11, 12, time.UTC),
 			},
 		},
 	})
@@ -921,9 +926,13 @@ func addTestDataArrayClasses(t *testing.T) {
 			"numbers":  []float64{1.0, 2.0},
 			"ints":     []int{1, 2},
 			"booleans": []bool{false, false},
-			"dates": []string{
+			"datesAsStrings": []string{
 				"2022-06-01T22:18:59.640162Z",
 				"2022-06-02T22:18:59.640162Z",
+			},
+			"dates": []time.Time{
+				time.Date(1235, 6, 7, 8, 9, 10, 11, time.UTC),
+				time.Date(2012, 7, 8, 9, 10, 11, 12, time.UTC),
 			},
 		},
 	})
@@ -938,8 +947,11 @@ func addTestDataArrayClasses(t *testing.T) {
 			"numbers":  []float64{1.0},
 			"ints":     []int{1.0},
 			"booleans": []bool{true, false},
-			"dates": []string{
+			"datesAsStrings": []string{
 				"2022-06-01T22:18:59.640162Z",
+			},
+			"dates": []time.Time{
+				time.Date(467, 6, 7, 8, 9, 10, 11, time.UTC),
 			},
 		},
 	})

--- a/usecases/objects/add.go
+++ b/usecases/objects/add.go
@@ -92,6 +92,9 @@ func (m *Manager) addObjectToConnectorAndSchema(ctx context.Context, principal *
 	now := m.timeSource.Now()
 	object.CreationTimeUnix = now
 	object.LastUpdateTimeUnix = now
+	if object.Properties == nil {
+		object.Properties = map[string]interface{}{}
+	}
 
 	err = m.vectorizeAndPutObject(ctx, object, principal)
 	if err != nil {

--- a/usecases/objects/batch_add.go
+++ b/usecases/objects/batch_add.go
@@ -142,6 +142,9 @@ func (b *BatchManager) validateObject(ctx context.Context, principal *models.Pri
 		object.Properties = concept.Properties
 	}
 
+	if object.Properties == nil {
+		object.Properties = map[string]interface{}{}
+	}
 	now := unixNow()
 	if _, ok := fieldsToKeep["creationTimeUnix"]; ok {
 		object.CreationTimeUnix = now


### PR DESCRIPTION
This PR contains fixes + tests for 5 different edge cases where aggregation would fail. Each fix and the corresponding tests are in one commit and can be reviewed commit by commit.

1. Fix aggregation with dates as string
2. Fix filtered aggegration with arrays
3. Fix aggregation with empty/non-existent text properties (fixes https://github.com/semi-technologies/weaviate/issues/1675)
4. Fix aggregate for objects with empty properties
5. Fix aggregation for classes without properties

Chaos pipeline passed: https://github.com/semi-technologies/weaviate-chaos-engineering/runs/8086646367