### PR TITLE
Fix potential nil-pointer panic in HNSW with "partially cleaned up nodes"

### DIFF
--- a/adapters/repos/db/vector/hnsw/search.go
+++ b/adapters/repos/db/vector/hnsw/search.go
@@ -407,9 +407,12 @@ func (h *hnsw) knnSearchByVector(searchVec []float32, k int,
 		// that particular level, so instead we're keeping whatever entrypoint we
 		// had before (i.e. either from a previous level or even the main
 		// entrypoint)
+		//
+		// If we do, however, have results, any candidate that's not nil (not
+		// deleted), and not under maintenance is a viable candidate
 		for res.Len() > 0 {
 			cand := res.Pop()
-			if !h.nodeByID(cand.ID).isUnderMaintenance() {
+			if n := h.nodeByID(cand.ID); n != nil && !n.isUnderMaintenance() {
 				entryPointID = cand.ID
 				entryPointDistance = cand.Dist
 				break

--- a/adapters/repos/db/vector/hnsw/search_test.go
+++ b/adapters/repos/db/vector/hnsw/search_test.go
@@ -1,0 +1,77 @@
+package hnsw
+
+import (
+	"context"
+	"testing"
+
+	"github.com/semi-technologies/weaviate/adapters/repos/db/vector/hnsw/distancer"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// prevents a regression of
+// https://github.com/semi-technologies/weaviate/issues/2155
+func TestNilCheckOnPartiallyCleanedNode(t *testing.T) {
+	vectors := [][]float32{
+		{100, 100}, // first to import makes this the EP, it is far from any query which means it will be replaced.
+		{2, 2},     // a good potential entrypoint, but we will corrupt it later on
+		{1, 1},     // the perfect search result
+	}
+
+	var vectorIndex *hnsw
+
+	t.Run("import", func(*testing.T) {
+		index, err := New(Config{
+			RootPath:              "doesnt-matter-as-committlogger-is-mocked-out",
+			ID:                    "bug-2155",
+			MakeCommitLoggerThunk: MakeNoopCommitLogger,
+			DistanceProvider:      distancer.NewL2SquaredProvider(),
+			VectorForIDThunk: func(ctx context.Context, id uint64) ([]float32, error) {
+				return vectors[int(id)], nil
+			},
+		}, UserConfig{
+			MaxConnections: 30,
+			EFConstruction: 128,
+
+			// The actual size does not matter for this test, but if it defaults to
+			// zero it will constantly think it's full and needs to be deleted - even
+			// after just being deleted, so make sure to use a positive number here.
+			VectorCacheMaxObjects: 100000,
+		})
+		require.Nil(t, err)
+		vectorIndex = index
+	})
+
+	t.Run("manually add the nodes", func(t *testing.T) {
+		vectorIndex.entryPointID = 0
+		vectorIndex.currentMaximumLayer = 1
+		vectorIndex.nodes = []*vertex{
+			{
+				// must be on a non-zero layer for this bug to occur
+				level: 1,
+				connections: [][]uint64{
+					{1, 2},
+					{1},
+				},
+			},
+			nil, // corrupt node
+			{
+				level: 0,
+				connections: [][]uint64{
+					{0, 1, 2},
+				},
+			},
+		}
+	})
+
+	t.Run("run a search that would typically find the new ep", func(t *testing.T) {
+		res, _, err := vectorIndex.SearchByVector([]float32{1.7, 1.7}, 20, nil)
+		require.Nil(t, err)
+		assert.Equal(t, []uint64{2, 0}, res, "right results are found")
+	})
+
+	t.Run("the corrupt node is now marked deleted", func(t *testing.T) {
+		_, ok := vectorIndex.tombstones[1]
+		assert.True(t, ok)
+	})
+}


### PR DESCRIPTION
If a delete clean-up cycle gets interrupted (for example because of a crash), we can be left with partially cleaned nodes. Generally, Weaviate is very accepting of this partial state as it just considers any "partially deleted' node fully deleted. There was, however, one edge case that was not yet covered: When an entry point is replaced on a level higher than zero, we did not check if the node was nil and tried to access a mutex on it. This led to a panic.

This PR:
* Adds the missing nil-pointer check
* Marks the partially deleted node with a tombstone, so it can be properly cleaned up in the next cycle
* Adds a test that reproduces the scenario by hand-assembling a tiny HNSW index :-) 

closes #2155 