### PR TITLE
Eliminate use of ObjectByID method where possible

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,3 +103,4 @@ You can find [code examples here](https://github.com/semi-technologies/weaviate-
 ## Contributing
 
 - [How to Contribute](https://weaviate.io/developers/contributor-guide/current/)
+

--- a/README.md
+++ b/README.md
@@ -103,4 +103,3 @@ You can find [code examples here](https://github.com/semi-technologies/weaviate-
 ## Contributing
 
 - [How to Contribute](https://weaviate.io/developers/contributor-guide/current/)
-

--- a/adapters/repos/db/crud_integration_test.go
+++ b/adapters/repos/db/crud_integration_test.go
@@ -255,8 +255,11 @@ func TestCRUD(t *testing.T) {
 			},
 			Additional: models.AdditionalProperties{},
 		}
-
 		res, err := repo.ObjectByID(context.Background(), thingID, nil,
+			additional.Properties{})
+		require.Nil(t, err)
+
+		res, err = repo.Object(context.Background(), expected.Class, thingID, nil,
 			additional.Properties{})
 		require.Nil(t, err)
 
@@ -610,6 +613,20 @@ func TestCRUD(t *testing.T) {
 
 	t.Run("searching a thing by ID", func(t *testing.T) {
 		item, err := repo.ObjectByID(context.Background(), thingID, search.SelectProperties{}, additional.Properties{})
+		require.Nil(t, err)
+		require.NotNil(t, item, "must have a result")
+
+		assert.Equal(t, thingID, item.ID, "extracted the ID")
+		assert.Equal(t, "TheBestThingClass", item.ClassName, "matches the class name")
+		schema := item.Schema.(map[string]interface{})
+		assert.Equal(t, "some value", schema["stringProp"], "has correct string prop")
+		assert.Equal(t, &models.GeoCoordinates{ptFloat32(1), ptFloat32(2)}, schema["location"], "has correct geo prop")
+		assert.Equal(t, thingID, schema["id"], "has id in schema as uuid field")
+	})
+
+	// Check the same, but with Object()
+	t.Run("searching a thing by ID", func(t *testing.T) {
+		item, err := repo.Object(context.Background(), "TheBestThingClass", thingID, search.SelectProperties{}, additional.Properties{})
 		require.Nil(t, err)
 		require.NotNil(t, item, "must have a result")
 

--- a/adapters/repos/db/crud_noindex_property_integration_test.go
+++ b/adapters/repos/db/crud_noindex_property_integration_test.go
@@ -111,6 +111,20 @@ func TestCRUD_NoIndexProp(t *testing.T) {
 		assert.Equal(t, expectedSchema, res.Schema)
 	})
 
+	//Same as above, but with Object()
+	t.Run("all props are present when getting by id and class", func(t *testing.T) {
+		res, err := repo.Object(context.Background(), "ThingClassWithNoIndexProps", thingID,
+			search.SelectProperties{}, additional.Properties{})
+		expectedSchema := map[string]interface{}{
+			"stringProp":       "some value",
+			"hiddenStringProp": "some hidden value",
+			"id":               thingID,
+		}
+
+		require.Nil(t, err)
+		assert.Equal(t, expectedSchema, res.Schema)
+	})
+
 	t.Run("class search on the noindex prop errors", func(t *testing.T) {
 		_, err := repo.ClassSearch(context.Background(), traverser.GetParams{
 			ClassName: "ThingClassWithNoIndexProps",

--- a/usecases/objects/auto_schema.go
+++ b/usecases/objects/auto_schema.go
@@ -190,18 +190,14 @@ func (m *autoSchemaManager) determineType(value interface{}) []schema.DataType {
 								if beacon, ok := v.(string); ok {
 									ref, err := crossref.Parse(beacon)
 									if err == nil {
-										if ref.Class != "" {
-											res, err := m.vectorRepo.Object(context.Background(), ref.Class, ref.TargetID,
-												search.SelectProperties{}, additional.Properties{})
-											if err == nil && res != nil {
-												dataType = append(dataType, schema.DataType(res.ClassName))
-											}
-										} else {
+										if ref.Class == "" {
 											res, err := m.vectorRepo.ObjectByID(context.Background(), ref.TargetID,
 												search.SelectProperties{}, additional.Properties{})
 											if err == nil && res != nil {
 												dataType = append(dataType, schema.DataType(res.ClassName))
 											}
+										} else {
+											dataType = append(dataType, schema.DataType(ref.Class))
 										}
 									}
 								}

--- a/usecases/objects/auto_schema.go
+++ b/usecases/objects/auto_schema.go
@@ -190,10 +190,18 @@ func (m *autoSchemaManager) determineType(value interface{}) []schema.DataType {
 								if beacon, ok := v.(string); ok {
 									ref, err := crossref.Parse(beacon)
 									if err == nil {
-										res, err := m.vectorRepo.ObjectByID(context.Background(), ref.TargetID,
-											search.SelectProperties{}, additional.Properties{})
-										if err == nil && res != nil {
-											dataType = append(dataType, schema.DataType(res.ClassName))
+										if ref.Class != "" {
+											res, err := m.vectorRepo.Object(context.Background(), ref.Class, ref.TargetID,
+												search.SelectProperties{}, additional.Properties{})
+											if err == nil && res != nil {
+												dataType = append(dataType, schema.DataType(res.ClassName))
+											}
+										} else {
+											res, err := m.vectorRepo.ObjectByID(context.Background(), ref.TargetID,
+												search.SelectProperties{}, additional.Properties{})
+											if err == nil && res != nil {
+												dataType = append(dataType, schema.DataType(res.ClassName))
+											}
 										}
 									}
 								}


### PR DESCRIPTION
### What's being changed:
This PR takes into account provided `class` information in `beacon` in `auto schema`. This PR changes the behaviour of creating types for reference properties, it invokes `ObjectByID` method only when no `class` information is present in `beacon`.

### Review checklist

- [x] Chaos pipeline run or not necessary. Link to pipeline: https://app.travis-ci.com/github/semi-technologies/weaviate-chaos-engineering/builds/255332325
- [x] All new code is covered by tests where it is reasonable.
