### PR TITLE
Document user-facing CRUD methods of lsmkv.Store and Bucket

### DIFF
--- a/adapters/repos/db/lsmkv/bucket.go
+++ b/adapters/repos/db/lsmkv/bucket.go
@@ -64,6 +64,12 @@ type Bucket struct {
 	pauseTimer *prometheus.Timer // Times the pause
 }
 
+// NewBucket initializes a new bucket. It either loads the state from disk if
+// it exists, or initializes new state.
+//
+// You do not need to ever call NewBucket() yourself, if you are using a
+// [Store]. In this case the [Store] can manage buckets for you, using methods
+// such as CreateOrLoadBucket().
 func NewBucket(ctx context.Context, dir, rootDir string, logger logrus.FieldLogger,
 	metrics *Metrics, opts ...BucketOption,
 ) (*Bucket, error) {
@@ -122,6 +128,14 @@ func (b *Bucket) SetMemtableThreshold(size uint64) {
 	b.memTableThreshold = size
 }
 
+// Get retrieves the single value for the given key.
+//
+// Get is specific to ReplaceStrategy and cannot be used with any of the other
+// strategies. Use [Bucket.SetList] or [Bucket.MapList] instead.
+//
+// Get uses the regular or "primary" key for an object. If a bucket has
+// secondary indexes, use [Bucket.GetBySecondary] to retrieve an object using
+// its secondary key
 func (b *Bucket) Get(key []byte) ([]byte, error) {
 	b.flushLock.RLock()
 	defer b.flushLock.RUnlock()
@@ -163,6 +177,17 @@ func (b *Bucket) Get(key []byte) ([]byte, error) {
 	return b.disk.get(key)
 }
 
+// GetBySecondary retrieves an object using one of its secondary keys. A bucket
+// can have an infinite number of secondary keys. Specify the secondary key
+// position as the first argument.
+//
+// A real-life example of secondary keys is the Weaviate object store. Objects
+// are stored with the user-facing ID as their primary key and with the doc-id
+// (an ever-increasing uint64) as the secondary key.
+//
+// Similar to [Bucket.Get], GetBySecondary is limited to ReplaceStrategy. No
+// equivalent exists for Set and Map, as those do not support secondary
+// indexes.
 func (b *Bucket) GetBySecondary(pos int, key []byte) ([]byte, error) {
 	b.flushLock.RLock()
 	defer b.flushLock.RUnlock()
@@ -204,6 +229,10 @@ func (b *Bucket) GetBySecondary(pos int, key []byte) ([]byte, error) {
 	return b.disk.getBySecondary(pos, key)
 }
 
+// SetList returns all Set entries for a given key.
+//
+// SetList is specific to the Set Strategy, for Map use [Bucket.MapList], and
+// for Replace use [Bucket.Get].
 func (b *Bucket) SetList(key []byte) ([][]byte, error) {
 	b.flushLock.RLock()
 	defer b.flushLock.RUnlock()
@@ -243,6 +272,25 @@ func (b *Bucket) SetList(key []byte) ([][]byte, error) {
 	return newSetDecoder().Do(out), nil
 }
 
+// Put creates or replaces a single value for a given key.
+//
+//	err := bucket.Put([]byte("my_key"), []byte("my_value"))
+//	 if err != nil {
+//		/* do something */
+//	}
+//
+// If a bucket has a secondary index configured, you can also specify one or
+// more secondary keys, like so:
+//
+//	err := bucket.Put([]byte("my_key"), []byte("my_value"),
+//		WithSecondaryKey(0, []byte("my_alternative_key")),
+//	)
+//	 if err != nil {
+//		/* do something */
+//	}
+//
+// Put is limited to ReplaceStrategy, use [Bucket.SetAdd] for Set or
+// [Bucket.MapSet] and [Bucket.MapSetMulti].
 func (b *Bucket) Put(key, value []byte, opts ...SecondaryKeyOption) error {
 	b.flushLock.RLock()
 	defer b.flushLock.RUnlock()
@@ -250,6 +298,21 @@ func (b *Bucket) Put(key, value []byte, opts ...SecondaryKeyOption) error {
 	return b.active.put(key, value, opts...)
 }
 
+// SetAdd adds one or more Set-Entries to a Set for the given key. SetAdd is
+// entirely agnostic of existing entries, it acts as append-only. This also
+// makes it agnostic of whether the key already exists or not.
+//
+// Example to add two entries to a set:
+//
+//	err := bucket.SetAdd([]byte("my_key"), [][]byte{
+//		[]byte("one-set-element"), []byte("another-set-element"),
+//	})
+//	if err != nil {
+//		/* do something */
+//	}
+//
+// SetAdd is specific to the Set strategy. For Replace, use [Bucket.Put], for
+// Map use either [Bucket.MapSet] or [Bucket.MapSetMulti].
 func (b *Bucket) SetAdd(key []byte, values [][]byte) error {
 	b.flushLock.RLock()
 	defer b.flushLock.RUnlock()
@@ -257,6 +320,18 @@ func (b *Bucket) SetAdd(key []byte, values [][]byte) error {
 	return b.active.append(key, newSetEncoder().Do(values))
 }
 
+// SetDeleteSingle removes one Set element from the given key. Note that LSM
+// stores are append only, thus internally this action appends a tombstone. The
+// entry will not be removed until a compaction has run, and even then a
+// compaction does not guarantee the removal of the data right away. This is
+// because an entry could have been created in an older segment than those
+// present in the compaction. This can be seen as an implementation detail,
+// unless the caller expects to free disk space by calling this method. Such
+// freeing is not guaranteed.
+//
+// SetDeleteSingle is specific to the Set Strategy. For Replace, you can use
+// [Bucket.Delete] to delete the entire row, for Maps use [Bucket.MapDeleteKey]
+// to delete a single map entry.
 func (b *Bucket) SetDeleteSingle(key []byte, valueToDelete []byte) error {
 	b.flushLock.RLock()
 	defer b.flushLock.RUnlock()
@@ -288,6 +363,13 @@ func MapListLegacySortingRequired() MapListOption {
 	}
 }
 
+// MapList returns all map entries for a given row key. The order of map pairs
+// has no specific meaning. For efficient merge operations, pair entries are
+// stored sorted on disk, however that is an implementation detail and not a
+// caller-facing guarantee.
+//
+// MapList is specific to the Map strategy, for Sets use [Bucket.SetList], for
+// Replace use [Bucket.Get].
 func (b *Bucket) MapList(key []byte, cfgs ...MapListOption) ([]MapPair, error) {
 	b.flushLock.RLock()
 	defer b.flushLock.RUnlock()
@@ -360,6 +442,20 @@ func (b *Bucket) MapList(key []byte, cfgs ...MapListOption) ([]MapPair, error) {
 	return newSortedMapMerger().do(segments)
 }
 
+// MapSet writes one [MapPair] into the map for the given row key. It is
+// agnostic of whether the row key already exists, as well as agnostic of
+// whether the map key already exists. In both cases it will create the entry
+// if it does not exist or override if it does.
+//
+// Example to add a new MapPair:
+//
+//	pair := MapPair{Key: []byte("Jane"), Value: []byte("Backend")}
+//	err := bucket.MapSet([]byte("developers"), pair)
+//	if err != nil {
+//		/* do something */
+//	}
+//
+// MapSet is specific to the Map Strategy, for Replace use [Bucket.Put], and for Set use [Bucket.SetAdd] instead.
 func (b *Bucket) MapSet(rowKey []byte, kv MapPair) error {
 	b.flushLock.RLock()
 	defer b.flushLock.RUnlock()
@@ -367,6 +463,8 @@ func (b *Bucket) MapSet(rowKey []byte, kv MapPair) error {
 	return b.active.appendMapSorted(rowKey, kv)
 }
 
+// MapSetMulti is the same as [Bucket.MapSet], except that it takes in multiple
+// [MapPair] objects at the same time.
 func (b *Bucket) MapSetMulti(rowKey []byte, kvs []MapPair) error {
 	b.flushLock.RLock()
 	defer b.flushLock.RUnlock()
@@ -380,6 +478,17 @@ func (b *Bucket) MapSetMulti(rowKey []byte, kvs []MapPair) error {
 	return nil
 }
 
+// MapDeleteKey removes one key-value pair from the given map row. Note that
+// LSM stores are append only, thus internally this action appends a tombstone.
+// The entry will not be removed until a compaction has run, and even then a
+// compaction does not guarantee the removal of the data right away. This is
+// because an entry could have been created in an older segment than those
+// present in the compaction. This can be seen as an implementation detail,
+// unless the caller expects to free disk space by calling this method. Such
+// freeing is not guaranteed.
+//
+// MapDeleteKey is specific to the Map Strategy. For Replace, you can use
+// [Bucket.Delete] to delete the entire row, for Sets use [Bucket.SetDeleteSingle] to delete a single set element.
 func (b *Bucket) MapDeleteKey(rowKey, mapKey []byte) error {
 	b.flushLock.RLock()
 	defer b.flushLock.RUnlock()
@@ -392,6 +501,17 @@ func (b *Bucket) MapDeleteKey(rowKey, mapKey []byte) error {
 	return b.active.appendMapSorted(rowKey, pair)
 }
 
+// Delete removes the given row. Note that LSM stores are append only, thus
+// internally this action appends a tombstone.  The entry will not be removed
+// until a compaction has run, and even then a compaction does not guarantee
+// the removal of the data right away. This is because an entry could have been
+// created in an older segment than those present in the compaction. This can
+// be seen as an implementation detail, unless the caller expects to free disk
+// space by calling this method. Such freeing is not guaranteed.
+//
+// Delete is specific to the Replace Strategy. For Maps, you can use
+// [Bucket.MapDeleteKey] to delete a single key-value pair, for Sets use
+// [Bucket.SetDeleteSingle] to delete a single set element.
 func (b *Bucket) Delete(key []byte, opts ...SecondaryKeyOption) error {
 	b.flushLock.RLock()
 	defer b.flushLock.RUnlock()

--- a/adapters/repos/db/lsmkv/doc.go
+++ b/adapters/repos/db/lsmkv/doc.go
@@ -62,6 +62,14 @@ different usecase for a [Bucket].
 
     The same performance-considerations as for sets apply.
 
+# Navigate around these docs
+
+Good entrypoints to learn more about how this package works include [Store]
+with [New] and [Store.CreateOrLoadBucket], as well as [Bucket] with
+[Bucket.Get], [Bucket.GetBySecondary], [Bucket.Put], etc.
+
+Each strategy also supports cursor types: [CursorReplace] can be created using [Bucket.Cursor], [CursorSet] can be created with [Bucket.SetCursor] , and [CursorMap] can be created with [Bucket.MapCursor].
+
 [LSM Stores]: https://en.wikipedia.org/wiki/Log-structured_merge-tree
 */
 package lsmkv

--- a/adapters/repos/db/lsmkv/store.go
+++ b/adapters/repos/db/lsmkv/store.go
@@ -37,6 +37,9 @@ type Store struct {
 	bucketAccessLock sync.RWMutex
 }
 
+// New initializes a new [Store] based on the root dir. If state is present on
+// disk, it is loaded, if the folder is empty a new store is initialized in
+// there.
 func New(dir, rootDir string, logger logrus.FieldLogger,
 	metrics *Metrics,
 ) (*Store, error) {
@@ -92,6 +95,17 @@ func (s *Store) bucketDir(bucketName string) string {
 	return path.Join(s.dir, bucketName)
 }
 
+// CreateOrLoadBucket registers a bucket with the given name. If state on disk
+// exists for this bucket it is loaded, otherwise created. Pass [BucketOptions]
+// to configure the strategy of a bucket. The strategy defaults to "replace".
+// For example, to load or create a map-type bucket, do:
+//
+//	ctx := context.Background()
+//	err := store.CreateOrLoadBucket(ctx, "my_bucket_name", WithStrategy(StrategyReplace))
+//	if err != nil { /* handle error */ }
+//
+//	// you can now access the bucket using store.Bucket()
+//	b := store.Bucket("my_bucket_name")
 func (s *Store) CreateOrLoadBucket(ctx context.Context, bucketName string,
 	opts ...BucketOption,
 ) error {


### PR DESCRIPTION
This documentation PR puts a lot of effort into linking between methods. For example, if the user is looking at a method that is specific to one strategy, there are links to equivalents of the other strategies whenever possible. 