### PR TITLE
rename snapshot.json to backup.json and return location of backup instead of url/snapshot.json

### DIFF
--- a/entities/modulecapabilities/snapshot.go
+++ b/entities/modulecapabilities/snapshot.go
@@ -16,7 +16,8 @@ import (
 )
 
 type SnapshotStorage interface {
-	DestinationPath(snapshotID string) string // TODO: might be change it to something like DestDir because meta.json is now specified by the user
+	// HomeDir is the home directory of all backup files
+	HomeDir(snapshotID string) string
 
 	// GetObject giving snapshotID and key
 	GetObject(ctx context.Context, snapshotID, key string) ([]byte, error)

--- a/modules/storage-aws-s3/s3/s3.go
+++ b/modules/storage-aws-s3/s3/s3.go
@@ -65,9 +65,9 @@ func (s *s3) makeObjectName(parts ...string) string {
 	return path.Join(s.config.SnapshotRoot(), base)
 }
 
-func (s *s3) DestinationPath(snapshotID string) string {
+func (s *s3) HomeDir(snapshotID string) string {
 	return "s3://" + path.Join(s.config.BucketName(),
-		s.makeObjectName(snapshotID, "snapshot.json"))
+		s.makeObjectName(snapshotID))
 }
 
 func (s *s3) GetObject(ctx context.Context, snapshotID, key string) ([]byte, error) {

--- a/modules/storage-aws-s3/snapshot.go
+++ b/modules/storage-aws-s3/snapshot.go
@@ -20,8 +20,8 @@ import (
 	"github.com/semi-technologies/weaviate/modules/storage-aws-s3/s3"
 )
 
-func (m *StorageS3Module) DestinationPath(snapshotID string) string {
-	return m.storageProvider.DestinationPath(snapshotID)
+func (m *StorageS3Module) HomeDir(snapshotID string) string {
+	return m.storageProvider.HomeDir(snapshotID)
 }
 
 func (m *StorageS3Module) GetObject(ctx context.Context, snapshotID, key string) ([]byte, error) {

--- a/modules/storage-filesystem/module.go
+++ b/modules/storage-filesystem/module.go
@@ -65,8 +65,8 @@ func (m *StorageFileSystemModule) Init(ctx context.Context,
 	return nil
 }
 
-func (m *StorageFileSystemModule) DestinationPath(snapshotID string) string {
-	return path.Join(m.makeSnapshotDirPath(snapshotID), "snapshot.json")
+func (m *StorageFileSystemModule) HomeDir(snapshotID string) string {
+	return path.Join(m.makeSnapshotDirPath(snapshotID))
 }
 
 func (m *StorageFileSystemModule) RootHandler() http.Handler {

--- a/modules/storage-gcs/gcs/gcs.go
+++ b/modules/storage-gcs/gcs/gcs.go
@@ -86,9 +86,9 @@ func (g *gcs) getObject(ctx context.Context, bucket *storage.BucketHandle,
 	return content, nil
 }
 
-func (g *gcs) DestinationPath(snapshotID string) string {
+func (g *gcs) HomeDir(snapshotID string) string {
 	return "gs://" + path.Join(g.config.BucketName(),
-		g.makeObjectName(snapshotID, "snapshot.json"))
+		g.makeObjectName(snapshotID))
 }
 
 func (g *gcs) findBucket(ctx context.Context) (*storage.BucketHandle, error) {

--- a/modules/storage-gcs/snapshot.go
+++ b/modules/storage-gcs/snapshot.go
@@ -19,8 +19,8 @@ import (
 	"github.com/semi-technologies/weaviate/modules/storage-gcs/gcs"
 )
 
-func (m *StorageGCSModule) DestinationPath(snapshotID string) string {
-	return m.storageProvider.DestinationPath(snapshotID)
+func (m *StorageGCSModule) HomeDir(snapshotID string) string {
+	return m.storageProvider.HomeDir(snapshotID)
 }
 
 func (m *StorageGCSModule) GetObject(ctx context.Context, snapshotID, key string) ([]byte, error) {

--- a/test/modules/storage-aws-s3/backup_storage_test.go
+++ b/test/modules/storage-aws-s3/backup_storage_test.go
@@ -106,8 +106,8 @@ func moduleLevelStoreBackupMeta(t *testing.T) {
 			err = s3.PutObject(testCtx, backupID, metadataFilename, b)
 			require.Nil(t, err)
 
-			dest := s3.DestinationPath(backupID)
-			expected := fmt.Sprintf("s3://%s/%s/snapshot.json", bucketName, backupID)
+			dest := s3.HomeDir(backupID)
+			expected := fmt.Sprintf("s3://%s/%s", bucketName, backupID)
 			assert.Equal(t, expected, dest)
 		})
 

--- a/test/modules/storage-filesystem/backup_storage_test.go
+++ b/test/modules/storage-filesystem/backup_storage_test.go
@@ -89,8 +89,8 @@ func moduleLevelStoreBackupMeta(t *testing.T) {
 			err = fs.PutObject(testCtx, backupID, metadataFilename, b)
 			require.Nil(t, err)
 
-			dest := fs.DestinationPath(backupID)
-			expected := fmt.Sprintf("%s/%s/snapshot.json", backupDir, backupID)
+			dest := fs.HomeDir(backupID)
+			expected := fmt.Sprintf("%s/%s", backupDir, backupID)
 			assert.Equal(t, expected, dest)
 		})
 	})

--- a/test/modules/storage-gcs/backup_storage_test.go
+++ b/test/modules/storage-gcs/backup_storage_test.go
@@ -105,8 +105,8 @@ func moduleLevelStoreBackupMeta(t *testing.T) {
 			err = gcs.PutObject(testCtx, backupID, metadataFilename, b)
 			require.Nil(t, err)
 
-			dest := gcs.DestinationPath(backupID)
-			expected := fmt.Sprintf("gs://%s/%s/snapshot.json", bucketName, backupID)
+			dest := gcs.HomeDir(backupID)
+			expected := fmt.Sprintf("gs://%s/%s", bucketName, backupID)
 			assert.Equal(t, expected, dest)
 		})
 

--- a/usecases/backup/backuper_test.go
+++ b/usecases/backup/backuper_test.go
@@ -80,7 +80,7 @@ func TestBackStatus(t *testing.T) {
 		storage := &fakeStorage{}
 		bytes := marshalMeta(backup.BackupDescriptor{Status: string(backup.Transferring)})
 		storage.On("GetObject", ctx, id, MetaDataFilename).Return(bytes, nil)
-		storage.On("DestinationPath", mock.Anything).Return(path)
+		storage.On("HomeDir", mock.Anything).Return(path)
 		m := createManager(nil, storage, nil)
 		got, err := m.BackupStatus(ctx, nil, storageType, id)
 		assert.Nil(t, err)
@@ -206,7 +206,7 @@ func TestBackupManager_CreateBackup(t *testing.T) {
 		sourcer.On("Backupable", ctx, classes).Return(nil)
 
 		storage := &fakeStorage{}
-		storage.On("DestinationPath", mock.Anything).Return(path)
+		storage.On("HomeDir", mock.Anything).Return(path)
 
 		storage.On("GetObject", ctx, snapshotID, MetaDataFilename).Return(nil, errors.New("can not be read"))
 		bm := createManager(sourcer, storage, nil)
@@ -231,7 +231,7 @@ func TestBackupManager_CreateBackup(t *testing.T) {
 		desc := backup.BackupDescriptor{}
 		bytes, _ := json.Marshal(desc)
 		storage := &fakeStorage{}
-		storage.On("DestinationPath", mock.Anything).Return(path)
+		storage.On("HomeDir", mock.Anything).Return(path)
 
 		storage.On("GetObject", ctx, snapshotID, MetaDataFilename).Return(bytes, nil)
 
@@ -262,7 +262,7 @@ func TestBackupManager_CreateBackup(t *testing.T) {
 		storage.On("GetObject", ctx, snapshotID, MetaDataFilename).Return(nil, backup.NewErrNotFound(errors.New("not found")))
 		storage.On("GetObject", ctx, snapshotID2, MetaDataFilename).Return(nil, backup.NewErrNotFound(errors.New("not found")))
 		storage.On("Initialize", ctx, mock.Anything).Return(nil)
-		storage.On("DestinationPath", mock.Anything).Return(path)
+		storage.On("HomeDir", mock.Anything).Return(path)
 		storage.On("SetMetaStatus", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil)
 		storage.On("StoreSnapshot", mock.Anything, mock.Anything).Return(nil)
 		bm := createManager(sourcer, storage, nil)
@@ -309,7 +309,7 @@ func TestBackupManager_CreateBackup(t *testing.T) {
 		sourcer := &fakeSourcer{}
 		sourcer.On("Backupable", ctx, classes).Return(nil)
 		storage := &fakeStorage{}
-		storage.On("DestinationPath", mock.Anything).Return(path)
+		storage.On("HomeDir", mock.Anything).Return(path)
 		storage.On("GetObject", ctx, snapshotID, MetaDataFilename).Return(nil, backup.NewErrNotFound(errors.New("not found")))
 		storage.On("Initialize", ctx, snapshotID).Return(errors.New("init meta failed"))
 		bm := createManager(sourcer, storage, nil)
@@ -337,7 +337,7 @@ func TestBackupManager_CreateBackup(t *testing.T) {
 		storage := &fakeStorage{}
 		storage.On("GetObject", ctx, snapshotID, MetaDataFilename).Return(nil, backup.NewErrNotFound(errors.New("not found")))
 		storage.On("Initialize", ctx, snapshotID).Return(nil)
-		storage.On("DestinationPath", snapshotID).Return(path)
+		storage.On("HomeDir", snapshotID).Return(path)
 		storage.On("SetMetaStatus", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil)
 		storage.On("StoreSnapshot", mock.Anything, mock.Anything).Return(nil)
 		bm := createManager(sourcer, storage, nil)
@@ -367,7 +367,7 @@ func TestBackupManager_CreateBackup(t *testing.T) {
 		storage := &fakeStorage{}
 		storage.On("GetMeta", ctx, "", snapshotID).Return(nil, backup.NewErrNotFound(errors.New("not found")))
 		storage.On("Initialize", ctx, snapshotID).Return(nil)
-		storage.On("DestinationPath", snapshotID).Return(path)
+		storage.On("HomeDir", snapshotID).Return(path)
 		storage.On("SetMetaStatus", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil)
 		storage.On("StoreSnapshot", mock.Anything, mock.Anything).Return(nil)
 		bm := createManager(sourcer, storage, nil)
@@ -475,7 +475,7 @@ func TestBackupManager_CreateBackup(t *testing.T) {
 // 		storage := &fakeStorage{getMetaStatusSleep: 50 * time.Millisecond, restoreSnapshotSleep: 50 * time.Millisecond}
 // 		storage.On("GetMeta", ctx, className, snapshotID).Return(&backup.Snapshot{Status: string(backup.CreateSuccess)}, nil)
 // 		storage.On("GetMeta", ctx, className, snapshotID2).Return(&backup.Snapshot{Status: string(backup.CreateSuccess)}, nil)
-// 		storage.On("DestinationPath", className, snapshotID).Return(path)
+// 		storage.On("HomeDir", className, snapshotID).Return(path)
 // 		storage.On("RestoreSnapshot", mock.Anything, className, snapshotID).Return(&backup.Snapshot{}, nil).Once()
 // 		bm := createManager(nil, storage)
 
@@ -510,7 +510,7 @@ func TestBackupManager_CreateBackup(t *testing.T) {
 // 	t.Run("successfully starts", func(t *testing.T) {
 // 		storage := &fakeStorage{}
 // 		storage.On("GetMeta", ctx, className, snapshotID).Return(&backup.Snapshot{Status: string(backup.CreateSuccess)}, nil)
-// 		storage.On("DestinationPath", className, snapshotID).Return(path)
+// 		storage.On("HomeDir", className, snapshotID).Return(path)
 // 		storage.On("RestoreSnapshot", mock.Anything, mock.Anything, mock.Anything).Return(&backup.Snapshot{}, nil).Once()
 // 		bm := createManager(nil, storage, nil)
 
@@ -529,8 +529,8 @@ func TestBackupManager_CreateBackup(t *testing.T) {
 // 		storage := &fakeStorage{getMetaStatusSleep: 50 * time.Millisecond, restoreSnapshotSleep: 50 * time.Millisecond}
 // 		storage.On("GetMeta", ctx, className, snapshotID).Return(&backup.Snapshot{Status: string(backup.CreateSuccess)}, nil)
 // 		storage.On("GetMeta", ctx, className2, snapshotID2).Return(&backup.Snapshot{Status: string(backup.CreateSuccess)}, nil)
-// 		storage.On("DestinationPath", className, snapshotID).Return(path)
-// 		storage.On("DestinationPath", className2, snapshotID2).Return(path)
+// 		storage.On("HomeDir", className, snapshotID).Return(path)
+// 		storage.On("HomeDir", className2, snapshotID2).Return(path)
 // 		storage.On("RestoreSnapshot", mock.Anything, mock.Anything, mock.Anything).Return(&backup.Snapshot{}, nil).Twice()
 // 		bm := createManager(nil, storage, nil, nil)
 
@@ -623,7 +623,7 @@ func TestBackupManager_CreateBackup(t *testing.T) {
 // 	t.Run("successfully gets status", func(t *testing.T) {
 // 		storage := &fakeStorage{}
 // 		storage.On("GetMeta", ctx, className, snapshotID).Return(&backup.Snapshot{Status: "SOME_STATUS"}, nil)
-// 		storage.On("DestinationPath", className, snapshotID).Return(path)
+// 		storage.On("HomeDir", className, snapshotID).Return(path)
 // 		bm := createManager(storage, nil)
 
 // 		meta, err := bm.CreateBackupStatus(ctx, nil, className, storageName, snapshotID)
@@ -640,14 +640,14 @@ func TestBackupManager_CreateBackup(t *testing.T) {
 //func TestBackupManager_DestinationPath(t *testing.T) {
 //	storageError := errors.New("I do not exist")
 //	sm := createManager(nil, storageError)
-//	path, err := sm.backups.DestinationPath("storageName", "className", "ID")
+//	path, err := sm.backups.HomeDir("storageName", "className", "ID")
 //	require.NotNil(t, err)
 //	assert.Equal(t, "", path)
 //
 //	storage := &fakeStorage{}
-//	storage.On("DestinationPath", "className", "ID").Return(path)
+//	storage.On("HomeDir", "className", "ID").Return(path)
 //	sm = createManager(storage, nil)
-//	path2, err := sm.backups.DestinationPath("storageName", "className", "ID")
+//	path2, err := sm.backups.HomeDir("storageName", "className", "ID")
 //	require.Nil(t, err)
 //	assert.Equal(t, path, path2)
 //}

--- a/usecases/backup/backupper.go
+++ b/usecases/backup/backupper.go
@@ -92,7 +92,7 @@ func (b *backupper) Backup(ctx context.Context,
 	store objectStore, id string, classes []string,
 ) (*backup.CreateMeta, error) {
 	// make sure there is no active backup
-	if prevID := b.lastBackup.renew(id, time.Now(), store.DestinationPath(id)); prevID != "" {
+	if prevID := b.lastBackup.renew(id, time.Now(), store.HomeDir(id)); prevID != "" {
 		err := fmt.Errorf("backup %s already in progress", prevID)
 		return nil, backup.NewErrUnprocessable(err)
 	}
@@ -114,7 +114,7 @@ func (b *backupper) Backup(ctx context.Context,
 	}()
 
 	return &backup.CreateMeta{
-		Path:   store.DestinationPath(id),
+		Path:   store.HomeDir(id),
 		Status: backup.Started,
 	}, nil
 }
@@ -155,7 +155,7 @@ func (b *backupper) Status(ctx context.Context, storageName, bakID string,
 	// TODO: populate Error field if snapshot failed
 	return &models.BackupCreateStatusResponse{
 		ID:          bakID,
-		Path:        store.DestinationPath(bakID),
+		Path:        store.HomeDir(bakID),
 		Status:      &status,
 		StorageName: storageName,
 	}, nil

--- a/usecases/backup/fakes_test.go
+++ b/usecases/backup/fakes_test.go
@@ -61,7 +61,7 @@ type fakeStorage struct {
 	mock.Mock
 }
 
-func (s *fakeStorage) DestinationPath(snapshotID string) string {
+func (s *fakeStorage) HomeDir(snapshotID string) string {
 	args := s.Called(snapshotID)
 	return args.String(0)
 }

--- a/usecases/backup/handler.go
+++ b/usecases/backup/handler.go
@@ -166,17 +166,18 @@ func (m *Manager) Restore(ctx context.Context, pr *models.Principal,
 		return nil, backup.NewErrUnprocessable(err)
 	}
 	status := string(backup.Started)
+	destPath := store.HomeDir(req.ID)
 	returnData := &models.BackupRestoreResponse{
 		Classes:     cs,
 		ID:          req.ID,
 		StorageName: req.StorageType,
 		Status:      &status,
-		Path:        path,
+		Path:        destPath,
 	}
 	go func() {
 		var err error
 		status := RestoreStatus{
-			Path:      store.DestinationPath(req.ID),
+			Path:      destPath,
 			StartedAt: time.Now().UTC(),
 			Status:    backup.Transferring,
 			Err:       nil,
@@ -251,7 +252,7 @@ func (m *Manager) validateBackupRequest(ctx context.Context, store objectStore, 
 	if err := m.backupper.sourcer.Backupable(ctx, classes); err != nil {
 		return nil, err
 	}
-	destPath := store.DestinationPath(req.ID)
+	destPath := store.HomeDir(req.ID)
 	// there is no snapshot with given id on the storage, regardless of its state (valid or corrupted)
 	_, err := store.Meta(ctx, req.ID)
 	if err == nil {
@@ -270,7 +271,7 @@ func (m *Manager) validateRestoreRequst(ctx context.Context, store objectStore, 
 		err := fmt.Errorf("malformed request: 'include' and 'exclude' cannot be both empty")
 		return nil, backup.NewErrUnprocessable(err)
 	}
-	destPath := store.DestinationPath(req.ID)
+	destPath := store.HomeDir(req.ID)
 	meta, err := store.Meta(ctx, req.ID)
 	if err != nil {
 		err = fmt.Errorf("find backup %s: %w", destPath, err)

--- a/usecases/backup/restorer.go
+++ b/usecases/backup/restorer.go
@@ -49,7 +49,7 @@ func (r *restorer) restoreAll(ctx context.Context,
 ) (err error) {
 	backupID := desc.ID
 	// make sure there is no active restore
-	dst := store.DestinationPath(backupID)
+	dst := store.HomeDir(backupID)
 	if prevID := r.lastStatus.renew(backupID, time.Now(), dst); prevID != "" {
 		err := fmt.Errorf("restore %s already in progress", prevID)
 		return err

--- a/usecases/backup/restorer_test.go
+++ b/usecases/backup/restorer_test.go
@@ -99,7 +99,7 @@ func TestRestoreRequestValidation(t *testing.T) {
 	{ //  fail to get meta data
 		storage := &fakeStorage{}
 		storage.On("GetObject", ctx, id, MetaDataFilename).Return(nil, ErrAny)
-		storage.On("DestinationPath", mock.Anything).Return(path)
+		storage.On("HomeDir", mock.Anything).Return(path)
 		m2 := createManager(nil, storage, nil)
 		_, err = m2.Restore(ctx, nil, req)
 		if err == nil || !strings.Contains(err.Error(), "find") {
@@ -107,7 +107,7 @@ func TestRestoreRequestValidation(t *testing.T) {
 		}
 		// meta data not found
 		storage = &fakeStorage{}
-		storage.On("DestinationPath", mock.Anything).Return(path)
+		storage.On("HomeDir", mock.Anything).Return(path)
 		storage.On("GetObject", ctx, id, MetaDataFilename).Return(nil, backup.ErrNotFound{})
 		m3 := createManager(nil, storage, nil)
 
@@ -121,7 +121,7 @@ func TestRestoreRequestValidation(t *testing.T) {
 		storage := &fakeStorage{}
 		bytes := marshalMeta(backup.BackupDescriptor{Status: string(backup.Failed)})
 		storage.On("GetObject", ctx, id, MetaDataFilename).Return(bytes, nil)
-		storage.On("DestinationPath", mock.Anything).Return(path)
+		storage.On("HomeDir", mock.Anything).Return(path)
 		m2 := createManager(nil, storage, nil)
 		_, err = m2.Restore(ctx, nil, req)
 		if err == nil {
@@ -137,7 +137,7 @@ func TestRestoreRequestValidation(t *testing.T) {
 			},
 		)
 		storage.On("GetObject", ctx, id, MetaDataFilename).Return(bytes, nil)
-		storage.On("DestinationPath", mock.Anything).Return(path)
+		storage.On("HomeDir", mock.Anything).Return(path)
 		m2 := createManager(nil, storage, nil)
 		_, err = m2.Restore(ctx, nil, &BackupRequest{ID: id, Include: []string{"unknown"}})
 		if err == nil || !strings.Contains(err.Error(), "unknown") {
@@ -153,7 +153,7 @@ func TestRestoreRequestValidation(t *testing.T) {
 			},
 		)
 		storage.On("GetObject", ctx, id, MetaDataFilename).Return(bytes, nil)
-		storage.On("DestinationPath", mock.Anything).Return(path)
+		storage.On("HomeDir", mock.Anything).Return(path)
 		m2 := createManager(nil, storage, nil)
 		_, err = m2.Restore(ctx, nil, &BackupRequest{ID: id, Exclude: []string{cls}})
 		if err == nil || !strings.Contains(err.Error(), "empty") {
@@ -171,7 +171,7 @@ func TestRestoreRequestValidation(t *testing.T) {
 			},
 		)
 		storage.On("GetObject", ctx, id, MetaDataFilename).Return(bytes, nil)
-		storage.On("DestinationPath", mock.Anything).Return(path)
+		storage.On("HomeDir", mock.Anything).Return(path)
 		m2 := createManager(sourcer, storage, nil)
 		_, err = m2.Restore(ctx, nil, &BackupRequest{ID: id})
 		if err == nil || !strings.Contains(err.Error(), cls) {

--- a/usecases/backup/storage.go
+++ b/usecases/backup/storage.go
@@ -33,7 +33,7 @@ const (
 )
 
 const (
-	MetaDataFilename = "snapshot.json"
+	MetaDataFilename = "backup.json"
 	TempDirectory    = ".backup.tmp"
 )
 

--- a/usecases/modules/modules_test.go
+++ b/usecases/modules/modules_test.go
@@ -491,7 +491,7 @@ func (m *dummyStorageModuleWithAltNames) Type() modulecapabilities.ModuleType {
 	return modulecapabilities.Storage
 }
 
-func (m *dummyStorageModuleWithAltNames) DestinationPath(snapshotID string) string {
+func (m *dummyStorageModuleWithAltNames) HomeDir(snapshotID string) string {
 	return ""
 }
 


### PR DESCRIPTION
return location of backup instead of url/snapshot.json

### What's being changed:


### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.
