### PR TITLE
Sanity check: make sure the backup-file matches the backup-id before restoring a backup

### DIFF
--- a/usecases/backup/handler.go
+++ b/usecases/backup/handler.go
@@ -278,6 +278,10 @@ func (m *Manager) validateRestoreRequst(ctx context.Context, store objectStore, 
 		}
 		return nil, backup.NewErrUnprocessable(err)
 	}
+	if meta.ID != req.ID {
+		err = fmt.Errorf("wrong backup file: expected %q got %q", req.ID, meta.ID)
+		return nil, backup.NewErrUnprocessable(err)
+	}
 	if meta.Status != string(backup.Success) {
 		err = fmt.Errorf("invalid backup %s status: %s", destPath, meta.Status)
 		return nil, backup.NewErrUnprocessable(err)


### PR DESCRIPTION
### What's being changed:


### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.
