### PR TITLE
Bugfix: Deleting a referenced class panics on GQL schema rebuild

### DIFF
--- a/adapters/handlers/graphql/local/local_component_test.go
+++ b/adapters/handlers/graphql/local/local_component_test.go
@@ -21,6 +21,7 @@ import (
 	"github.com/semi-technologies/weaviate/entities/schema"
 	"github.com/semi-technologies/weaviate/usecases/config"
 	"github.com/semi-technologies/weaviate/usecases/modules"
+	logrus "github.com/sirupsen/logrus/hooks/test"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -35,7 +36,7 @@ import (
 // (i.e. get, getmeta, aggreagate, etc.).  Additionally we have (a few) e2e
 // tests.
 
-func Test_GraphQLNetworkBuild(t *testing.T) {
+func TestBuild_GraphQLNetwork(t *testing.T) {
 	tests := testCases{
 		// This tests asserts that an action-only schema doesn't lead to errors.
 		testCase{
@@ -102,6 +103,98 @@ func Test_GraphQLNetworkBuild(t *testing.T) {
 	tests.AssertNoError(t)
 }
 
+func TestBuild_RefProps(t *testing.T) {
+	t.Run("expected failure", func(t *testing.T) {
+		tests := testCases{
+			{
+				name: "build class with nonexistent ref prop",
+				localSchema: schema.Schema{
+					Objects: &models.Schema{
+						Classes: []*models.Class{
+							{
+								Class: "ThisClassExists",
+								Properties: []*models.Property{
+									{
+										DataType: []string{"ThisClassDoesNotExist"},
+										Name:     "ofNonexistentClass",
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		}
+
+		expectedLogMsg := "ignoring class \"ThisClassExists\", " +
+			"because it contains ref prop \"ofNonexistentClass\" " +
+			"to nonexistent class [\"ThisClassDoesNotExist\"]"
+
+		tests.AssertErrorLogs(t, expectedLogMsg)
+	})
+
+	t.Run("expected success", func(t *testing.T) {
+		tests := testCases{
+			{
+				name: "build class with existing non-circular ref prop",
+				localSchema: schema.Schema{
+					Objects: &models.Schema{
+						Classes: []*models.Class{
+							{
+								Class: "ThisClassExists",
+								Properties: []*models.Property{
+									{
+										DataType: []string{"ThisClassAlsoExists"},
+										Name:     "ofExistingClass",
+									},
+								},
+							},
+							{
+								Class: "ThisClassAlsoExists",
+								Properties: []*models.Property{
+									{
+										DataType: []string{"string"},
+										Name:     "stringProp",
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			{
+				name: "build class with existing circular ref prop",
+				localSchema: schema.Schema{
+					Objects: &models.Schema{
+						Classes: []*models.Class{
+							{
+								Class: "ThisClassExists",
+								Properties: []*models.Property{
+									{
+										DataType: []string{"ThisClassAlsoExists"},
+										Name:     "ofExistingClass",
+									},
+								},
+							},
+							{
+								Class: "ThisClassAlsoExists",
+								Properties: []*models.Property{
+									{
+										DataType: []string{"ThisClassExists"},
+										Name:     "ofExistingClass",
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		}
+
+		tests.AssertNoError(t)
+	})
+}
+
 type testCase struct {
 	name        string
 	localSchema schema.Schema
@@ -135,6 +228,38 @@ func (tests testCases) AssertNoError(t *testing.T) {
 			}()
 
 			assert.Nil(t, err, test.name)
+		})
+	}
+}
+
+func (tests testCases) AssertErrorLogs(t *testing.T, expectedMsg string) {
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			modules := modules.NewProvider()
+			logger, logsHook := logrus.NewNullLogger()
+			localSchema, err := Build(&test.localSchema, logger, config.Config{}, modules)
+			require.Nil(t, err, test.name)
+
+			schemaObject := graphql.ObjectConfig{
+				Name:        "WeaviateObj",
+				Description: "Location of the root query",
+				Fields:      localSchema,
+			}
+
+			func() {
+				defer func() {
+					if r := recover(); r != nil {
+						err = fmt.Errorf("%v at %s", r, debug.Stack())
+					}
+				}()
+
+				_, err = graphql.NewSchema(graphql.SchemaConfig{
+					Query: graphql.NewObject(schemaObject),
+				})
+			}()
+
+			last := logsHook.LastEntry()
+			assert.Contains(t, last.Message, expectedMsg)
 		})
 	}
 }

--- a/entities/schema/backward_compat.go
+++ b/entities/schema/backward_compat.go
@@ -29,17 +29,6 @@ type WeaviateSchema struct {
 	ThingSchema  schemaProperties
 }
 
-const (
-	// ErrorNoSuchClass message
-	ErrorNoSuchClass string = "no such class with name '%s' found in the schema. Check your schema files for which classes are available"
-	// ErrorNoSuchProperty message
-	ErrorNoSuchProperty string = "no such prop with name '%s' found in class '%s' in the schema. Check your schema files for which properties in this class are available"
-	// ErrorNoSuchDatatype message
-	ErrorNoSuchDatatype string = "given value-DataType does not exist."
-	// ErrorInvalidRefType message
-	ErrorInvalidRefType string = "given ref type is not valid"
-)
-
 // GetClassByName returns the class by its name
 func GetClassByName(s *models.Schema, className string) (*models.Class, error) {
 	if s == nil {

--- a/entities/schema/data_types.go
+++ b/entities/schema/data_types.go
@@ -199,7 +199,7 @@ func (s *Schema) FindPropertyDataTypeWithRefs(
 
 			if !relaxCrossRefValidation {
 				if s.FindClassByName(className) == nil {
-					return nil, fmt.Errorf("SingleRef class name '%s' does not exist", className)
+					return nil, errors.New(ErrRefToNonexistentClass)
 				}
 			}
 

--- a/entities/schema/data_types_test.go
+++ b/entities/schema/data_types_test.go
@@ -48,6 +48,8 @@ func TestNonExistingClassSingleRef(t *testing.T) {
 		t.Fatal("Should have error")
 	}
 
+	assert.EqualError(t, err, ErrRefToNonexistentClass)
+
 	if pdt != nil {
 		t.Fatal("Should return nil result")
 	}

--- a/entities/schema/errors.go
+++ b/entities/schema/errors.go
@@ -1,0 +1,8 @@
+package schema
+
+const (
+	ErrRefToNonexistentClass string = "reference property to nonexistent class"
+	ErrorNoSuchClass         string = "no such class with name '%s' found in the schema. Check your schema files for which classes are available"
+	ErrorNoSuchProperty      string = "no such prop with name '%s' found in class '%s' in the schema. Check your schema files for which properties in this class are available"
+	ErrorNoSuchDatatype      string = "given value-DataType does not exist."
+)


### PR DESCRIPTION
When a class is deleted from weaviate, which exists as a ref prop type for another class, and the graphql schema is rebuilt, it is currently handled poorly, with a panic.

### What's being changed:

- Added error `ErrRefToNonexistentClass` so the local get builder knows with certainty when the `*Schema.FindPropertyDataType` is failing for this reason
- When this error is encountered, the GQL rebuilding doesn't panic, resulting in a total loss of GQL provider, but skips the class with the offending property and continues building the schema
- Log a warning in the event of this situation, explaining which class was skipped, the name of the invalid property, and the name of the class that the property references
- Added tests

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [x] All new code is covered by tests where it is reasonable.
- [x] Performance tests have been run or not necessary.
