### PR TITLE
Fix total of 6 bugs related to indexing into LSM Store and HNSW index

### DIFF
--- a/adapters/repos/db/batch_integration_test.go
+++ b/adapters/repos/db/batch_integration_test.go
@@ -543,7 +543,6 @@ func testBatchImportGeoObjects(repo *DB) func(t *testing.T) {
 						return
 					}
 					recall := float32(relevant) / float32(retrieved)
-					fmt.Printf("recall is %f\n", recall)
 					assert.True(t, recall >= 0.99)
 				})
 			}

--- a/adapters/repos/db/inverted/objects.go
+++ b/adapters/repos/db/inverted/objects.go
@@ -149,7 +149,7 @@ func (a *Analyzer) extendPropertiesWithArrayType(properties *[]Property,
 	var err error
 	value, err = typedSliceToUntyped(value)
 	if err != nil {
-		return err
+		return fmt.Errorf("extend properties with array type: %w", err)
 	}
 
 	values, ok := value.([]interface{})
@@ -514,36 +514,24 @@ func typedSliceToUntyped(in interface{}) ([]interface{}, error) {
 		// nothing to do
 		return typed, nil
 	case []string:
-		out := make([]interface{}, len(typed))
-		for i := range out {
-			out[i] = typed[i]
-		}
-		return out, nil
+		return convertToUntyped[string](typed), nil
 	case []int:
-		out := make([]interface{}, len(typed))
-		for i := range out {
-			out[i] = typed[i]
-		}
-		return out, nil
+		return convertToUntyped[int](typed), nil
 	case []time.Time:
-		out := make([]interface{}, len(typed))
-		for i := range out {
-			out[i] = typed[i]
-		}
-		return out, nil
+		return convertToUntyped[time.Time](typed), nil
 	case []bool:
-		out := make([]interface{}, len(typed))
-		for i := range out {
-			out[i] = typed[i]
-		}
-		return out, nil
+		return convertToUntyped[bool](typed), nil
 	case []float64:
-		out := make([]interface{}, len(typed))
-		for i := range out {
-			out[i] = typed[i]
-		}
-		return out, nil
+		return convertToUntyped[float64](typed), nil
 	default:
-		return nil, errors.Errorf("unrecognized slice type %T", in)
+		return nil, errors.Errorf("unsupported type %T", in)
 	}
+}
+
+func convertToUntyped[T comparable](in []T) []interface{} {
+	out := make([]interface{}, len(in))
+	for i := range out {
+		out[i] = in[i]
+	}
+	return out
 }

--- a/adapters/repos/db/inverted/objects.go
+++ b/adapters/repos/db/inverted/objects.go
@@ -368,9 +368,9 @@ func (a *Analyzer) analyzePrimitiveProp(prop *models.Property, value interface{}
 			value = int64(asFloat)
 		}
 
-		if asFloat, ok := value.(int); ok {
+		if asInt, ok := value.(int); ok {
 			// when merging an existing object we may retrieve an untyped int
-			value = int64(asFloat)
+			value = int64(asInt)
 		}
 
 		asInt, ok := value.(int64)

--- a/adapters/repos/db/inverted/objects.go
+++ b/adapters/repos/db/inverted/objects.go
@@ -227,6 +227,14 @@ func (a *Analyzer) analyzeArrayProp(prop *models.Property, values []interface{})
 		hasFrequency = HasFrequency(dt)
 		in := make([]int64, len(values))
 		for i, value := range values {
+			if asJsonNumber, ok := value.(json.Number); ok {
+				var err error
+				value, err = asJsonNumber.Float64()
+				if err != nil {
+					return nil, err
+				}
+			}
+
 			if asFloat, ok := value.(float64); ok {
 				// unmarshaling from json into a dynamic schema will assume every number
 				// is a float64
@@ -249,6 +257,14 @@ func (a *Analyzer) analyzeArrayProp(prop *models.Property, values []interface{})
 		hasFrequency = HasFrequency(dt)
 		in := make([]float64, len(values))
 		for i, value := range values {
+			if asJsonNumber, ok := value.(json.Number); ok {
+				var err error
+				value, err = asJsonNumber.Float64()
+				if err != nil {
+					return nil, err
+				}
+			}
+
 			asFloat, ok := value.(float64)
 			if !ok {
 				return nil, fmt.Errorf("expected property %s to be of type float64, but got %T", prop.Name, value)

--- a/adapters/repos/db/lsmkv/binary_search_tree_test.go
+++ b/adapters/repos/db/lsmkv/binary_search_tree_test.go
@@ -42,7 +42,7 @@ func TestInsertNetAdditions_Replace(t *testing.T) {
 		rand.Read(key)
 		rand.Read(val)
 
-		n := tree.insert(key, val, nil)
+		n, _ := tree.insert(key, val, nil)
 		require.Equal(t, len(key)+len(val), n)
 	})
 
@@ -60,7 +60,8 @@ func TestInsertNetAdditions_Replace(t *testing.T) {
 			rand.Read(key)
 			rand.Read(val)
 
-			n += tree.insert(key, val, nil)
+			newAdditions, _ := tree.insert(key, val, nil)
+			n += newAdditions
 		}
 
 		require.Equal(t, amount*size*2, n)
@@ -93,7 +94,8 @@ func TestInsertNetAdditions_Replace(t *testing.T) {
 
 		// make initial inserts
 		for i := range keys {
-			netAdditions += tree.insert(keys[i], vals[i], nil)
+			currentNetAddition, _ := tree.insert(keys[i], vals[i], nil)
+			netAdditions += currentNetAddition
 		}
 
 		// change the values of the existing keys
@@ -106,7 +108,8 @@ func TestInsertNetAdditions_Replace(t *testing.T) {
 		}
 
 		for i := 0; i < amount; i++ {
-			netAdditions += tree.insert(keys[i], vals[i], nil)
+			currentNetAddition, _ := tree.insert(keys[i], vals[i], nil)
+			netAdditions += currentNetAddition
 		}
 
 		// Formulas for calculating the total net additions after

--- a/adapters/repos/db/lsmkv/memtable.go
+++ b/adapters/repos/db/lsmkv/memtable.go
@@ -149,9 +149,13 @@ func (l *Memtable) put(key, value []byte, opts ...SecondaryKeyOption) error {
 		return errors.Wrap(err, "write into commit log")
 	}
 
-	netAdditions := l.key.insert(key, value, secondaryKeys)
+	netAdditions, previousKeys := l.key.insert(key, value, secondaryKeys)
 	l.size += uint64(netAdditions)
 	l.metrics.size(l.size)
+
+	for i, sec := range previousKeys {
+		l.secondaryToPrimary[i][string(sec)] = nil
+	}
 
 	for i, sec := range secondaryKeys {
 		l.secondaryToPrimary[i][string(sec)] = key

--- a/adapters/repos/db/lsmkv/memtable_test.go
+++ b/adapters/repos/db/lsmkv/memtable_test.go
@@ -54,6 +54,6 @@ func Test_MemtableSecondaryKeyBug(t *testing.T) {
 	t.Run("retrieve by initial secondary - should not find anything", func(t *testing.T) {
 		val, err := m.getBySecondary(0, []byte("secondary-key-initial"))
 		assert.Equal(t, NotFound, err)
-		assert.Equal(t, nil, val)
+		assert.Nil(t, val)
 	})
 }

--- a/adapters/repos/db/lsmkv/memtable_test.go
+++ b/adapters/repos/db/lsmkv/memtable_test.go
@@ -1,0 +1,59 @@
+package lsmkv
+
+import (
+	"path"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// This test prevents a regression on
+// https://www.youtube.com/watch?v=OS8taasZl8k
+func Test_MemtableSecondaryKeyBug(t *testing.T) {
+	dir := t.TempDir()
+	m, err := newMemtable(path.Join(dir, "will-never-flush"), StrategyReplace, 1, nil)
+	require.Nil(t, err)
+
+	t.Run("add initial value", func(t *testing.T) {
+		err = m.put([]byte("my-key"), []byte("my-value"),
+			WithSecondaryKey(0, []byte("secondary-key-initial")))
+		require.Nil(t, err)
+	})
+
+	t.Run("retrieve by primary", func(t *testing.T) {
+		val, err := m.get([]byte("my-key"))
+		require.Nil(t, err)
+		assert.Equal(t, []byte("my-value"), val)
+	})
+
+	t.Run("retrieve by initial secondary", func(t *testing.T) {
+		val, err := m.getBySecondary(0, []byte("secondary-key-initial"))
+		require.Nil(t, err)
+		assert.Equal(t, []byte("my-value"), val)
+	})
+
+	t.Run("update value with different secondary key", func(t *testing.T) {
+		err = m.put([]byte("my-key"), []byte("my-value-updated"),
+			WithSecondaryKey(0, []byte("different-secondary-key")))
+		require.Nil(t, err)
+	})
+
+	t.Run("retrieve by primary again", func(t *testing.T) {
+		val, err := m.get([]byte("my-key"))
+		require.Nil(t, err)
+		assert.Equal(t, []byte("my-value-updated"), val)
+	})
+
+	t.Run("retrieve by updated secondary", func(t *testing.T) {
+		val, err := m.getBySecondary(0, []byte("different-secondary-key"))
+		require.Nil(t, err)
+		assert.Equal(t, []byte("my-value-updated"), val)
+	})
+
+	t.Run("retrieve by initial secondary - should not find anything", func(t *testing.T) {
+		val, err := m.getBySecondary(0, []byte("secondary-key-initial"))
+		assert.Equal(t, NotFound, err)
+		assert.Equal(t, nil, val)
+	})
+}

--- a/adapters/repos/db/merge_integration_test.go
+++ b/adapters/repos/db/merge_integration_test.go
@@ -382,7 +382,7 @@ func Test_MergingObjects(t *testing.T) {
 // merge (and therefore only loaded from disk) failed during the
 // inverted-indexing for the new doc id. This was then hidden by the fact that
 // error handling was broken inside the inverted.Analyzer. This test tries to
-// make sure that every possible property type stays in tact if untouched
+// make sure that every possible property type stays intact if untouched
 // during a Merge operation
 //
 // To achieve this, every prop in this class exists twice, once with the prefix

--- a/adapters/repos/db/merge_integration_test.go
+++ b/adapters/repos/db/merge_integration_test.go
@@ -22,13 +22,16 @@ import (
 	"time"
 
 	"github.com/go-openapi/strfmt"
+	"github.com/google/uuid"
 	"github.com/semi-technologies/weaviate/adapters/repos/db/vector/hnsw"
 	"github.com/semi-technologies/weaviate/entities/additional"
+	"github.com/semi-technologies/weaviate/entities/filters"
 	"github.com/semi-technologies/weaviate/entities/models"
 	"github.com/semi-technologies/weaviate/entities/schema"
 	"github.com/semi-technologies/weaviate/entities/schema/crossref"
 	"github.com/semi-technologies/weaviate/usecases/config"
 	"github.com/semi-technologies/weaviate/usecases/objects"
+	"github.com/semi-technologies/weaviate/usecases/traverser"
 	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -370,4 +373,292 @@ func Test_MergingObjects(t *testing.T) {
 
 		assert.Equal(t, expectedSchema, orig.Schema)
 	})
+}
+
+// This prevents a regression on
+// https://github.com/semi-technologies/weaviate/issues/2193
+//
+// Prior to the fix it was possible that a prop that was not touched during the
+// merge (and therefore only loaded from disk) failed during the
+// inverted-indexing for the new doc id. This was then hidden by the fact that
+// error handling was broken inside the inverted.Analyzer. This test tries to
+// make sure that every possible property type stays in tact if untouched
+// during a Merge operation
+//
+// To achieve this, every prop in this class exists twice, once with the prefix
+// 'touched_' and once with 'untouched_'. In the initial insert both properties
+// contain the same value, but then during the patch merge, the 'touched_'
+// properties are updated to a different value while the 'untouched_'
+// properties are left untouched. Then we try to retrieve the object through a
+// filter matching each property. The 'untouched_' properties are matched with
+// the original value, the 'touched_' props are matched with the updated ones
+func Test_Merge_UntouchedPropsCorrectlyIndexed(t *testing.T) {
+	dirName := t.TempDir()
+
+	logger := logrus.New()
+	schemaGetter := &fakeSchemaGetter{shardState: singleShardState()}
+	repo := New(logger, Config{
+		RootPath:                  dirName,
+		DiskUseWarningPercentage:  config.DefaultDiskUseWarningPercentage,
+		DiskUseReadOnlyPercentage: config.DefaultDiskUseReadonlyPercentage,
+		MaxImportGoroutinesFactor: 1,
+		QueryMaximumResults:       10000,
+	}, &fakeRemoteClient{}, &fakeNodeResolver{}, nil)
+	repo.SetSchemaGetter(schemaGetter)
+	err := repo.WaitForStartup(testCtx())
+	require.Nil(t, err)
+	defer repo.Shutdown(context.Background())
+	migrator := NewMigrator(repo, logger)
+	hnswConfig := hnsw.NewDefaultUserConfig()
+	hnswConfig.Skip = true
+	schema := schema.Schema{
+		Objects: &models.Schema{
+			Classes: []*models.Class{
+				{
+					Class:               "TestClass",
+					VectorIndexConfig:   hnswConfig,
+					InvertedIndexConfig: invertedConfig(),
+					Properties: []*models.Property{ // tries to have "one of each property type"
+						{
+							Name: "untouched_string", Tokenization: "word",
+							DataType: []string{"string"},
+						},
+						{
+							Name: "touched_string", Tokenization: "word",
+							DataType: []string{"string"},
+						},
+						{
+							Name: "untouched_string_array", Tokenization: "word",
+							DataType: []string{"string[]"},
+						},
+						{
+							Name: "touched_string_array", Tokenization: "word",
+							DataType: []string{"string[]"},
+						},
+						{
+							Name: "untouched_text", Tokenization: "word",
+							DataType: []string{"text"},
+						},
+						{
+							Name: "touched_text", Tokenization: "word",
+							DataType: []string{"text"},
+						},
+						{
+							Name: "untouched_text_array", Tokenization: "word",
+							DataType: []string{"text[]"},
+						},
+						{
+							Name: "touched_text_array", Tokenization: "word",
+							DataType: []string{"text[]"},
+						},
+						{Name: "untouched_number", DataType: []string{"number"}},
+						{Name: "touched_number", DataType: []string{"number"}},
+						{Name: "untouched_number_array", DataType: []string{"number[]"}},
+						{Name: "touched_number_array", DataType: []string{"number[]"}},
+						{Name: "untouched_int", DataType: []string{"int"}},
+						{Name: "touched_int", DataType: []string{"int"}},
+						{Name: "untouched_int_array", DataType: []string{"int[]"}},
+						{Name: "touched_int_array", DataType: []string{"int[]"}},
+						{Name: "untouched_date", DataType: []string{"date"}},
+						{Name: "touched_date", DataType: []string{"date"}},
+						{Name: "untouched_date_array", DataType: []string{"date[]"}},
+						{Name: "touched_date_array", DataType: []string{"date[]"}},
+						{Name: "untouched_geo", DataType: []string{"geoCoordinates"}},
+						{Name: "touched_geo", DataType: []string{"geoCoordinates"}},
+					},
+				},
+			},
+		},
+	}
+
+	t.Run("add required classes", func(t *testing.T) {
+		for _, class := range schema.Objects.Classes {
+			t.Run(fmt.Sprintf("add %s", class.Class), func(t *testing.T) {
+				err := migrator.AddClass(context.Background(), class, schemaGetter.shardState)
+				require.Nil(t, err)
+			})
+		}
+	})
+
+	schemaGetter.schema = schema
+
+	t.Run("add initial object", func(t *testing.T) {
+		id := 0
+		err := repo.PutObject(context.Background(), &models.Object{
+			ID:    uuidFromInt(id),
+			Class: "TestClass",
+			Properties: map[string]interface{}{
+				"untouched_number":       float64(id),
+				"untouched_number_array": []interface{}{float64(id)},
+				"untouched_int":          id,
+				"untouched_int_array":    []interface{}{int64(id)},
+				"untouched_string":       fmt.Sprintf("%d", id),
+				"untouched_string_array": []string{fmt.Sprintf("%d", id)},
+				"untouched_text":         fmt.Sprintf("%d", id),
+				"untouched_text_array":   []string{fmt.Sprintf("%d", id)},
+				"untouched_date":         time.Unix(0, 0).Add(time.Duration(id) * time.Hour),
+				"untouched_date_array":   []time.Time{time.Unix(0, 0).Add(time.Duration(id) * time.Hour)},
+				"untouched_geo": &models.GeoCoordinates{
+					ptFloat32(float32(id)), ptFloat32(float32(id)),
+				},
+
+				"touched_number":       float64(id),
+				"touched_number_array": []interface{}{float64(id)},
+				"touched_int":          id,
+				"touched_int_array":    []interface{}{int64(id)},
+				"touched_string":       fmt.Sprintf("%d", id),
+				"touched_string_array": []string{fmt.Sprintf("%d", id)},
+				"touched_text":         fmt.Sprintf("%d", id),
+				"touched_text_array":   []string{fmt.Sprintf("%d", id)},
+				"touched_date":         time.Unix(0, 0).Add(time.Duration(id) * time.Hour),
+				"touched_date_array":   []time.Time{time.Unix(0, 0).Add(time.Duration(id) * time.Hour)},
+				"touched_geo": &models.GeoCoordinates{
+					ptFloat32(float32(id)), ptFloat32(float32(id)),
+				},
+			},
+			CreationTimeUnix:   int64(id),
+			LastUpdateTimeUnix: int64(id),
+		}, []float32{0.5})
+		require.Nil(t, err)
+	})
+
+	t.Run("patch half the props (all that contain 'touched')", func(t *testing.T) {
+		updateID := 28
+		md := objects.MergeDocument{
+			Class: "TestClass",
+			ID:    uuidFromInt(0),
+			PrimitiveSchema: map[string]interface{}{
+				"touched_number":       float64(updateID),
+				"touched_number_array": []interface{}{float64(updateID)},
+				"touched_int":          updateID,
+				"touched_int_array":    []interface{}{int64(updateID)},
+				"touched_string":       fmt.Sprintf("%d", updateID),
+				"touched_string_array": []string{fmt.Sprintf("%d", updateID)},
+				"touched_text":         fmt.Sprintf("%d", updateID),
+				"touched_text_array":   []string{fmt.Sprintf("%d", updateID)},
+				"touched_date":         time.Unix(0, 0).Add(time.Duration(updateID) * time.Hour),
+				"touched_date_array":   []time.Time{time.Unix(0, 0).Add(time.Duration(updateID) * time.Hour)},
+				"touched_geo": &models.GeoCoordinates{
+					ptFloat32(float32(updateID)), ptFloat32(float32(updateID)),
+				},
+			},
+			References: nil,
+		}
+		err = repo.Merge(context.Background(), md)
+		assert.Nil(t, err)
+	})
+
+	t.Run("retrieve by each individual prop", func(t *testing.T) {
+		retrieve := func(prefix string, id int) func(t *testing.T) {
+			return func(t *testing.T) {
+				type test struct {
+					name   string
+					filter *filters.LocalFilter
+				}
+
+				tests := []test{
+					{
+						name: "string filter",
+						filter: buildFilter(
+							fmt.Sprintf("%s_string", prefix),
+							fmt.Sprintf("%d", id),
+							eq,
+							dtString),
+					},
+					{
+						name: "string array filter",
+						filter: buildFilter(
+							fmt.Sprintf("%s_string_array", prefix),
+							fmt.Sprintf("%d", id),
+							eq,
+							dtString),
+					},
+					{
+						name: "text filter",
+						filter: buildFilter(
+							fmt.Sprintf("%s_text", prefix),
+							fmt.Sprintf("%d", id),
+							eq,
+							dtText),
+					},
+					{
+						name: "text array filter",
+						filter: buildFilter(
+							fmt.Sprintf("%s_text_array", prefix),
+							fmt.Sprintf("%d", id),
+							eq,
+							dtText),
+					},
+					{
+						name: "int filter",
+						filter: buildFilter(
+							fmt.Sprintf("%s_int", prefix), id, eq, dtInt),
+					},
+					{
+						name: "int array filter",
+						filter: buildFilter(
+							fmt.Sprintf("%s_int_array", prefix), id, eq, dtInt),
+					},
+					{
+						name: "number filter",
+						filter: buildFilter(
+							fmt.Sprintf("%s_number", prefix), float64(id), eq, dtNumber),
+					},
+					{
+						name: "number array filter",
+						filter: buildFilter(
+							fmt.Sprintf("%s_number_array", prefix), float64(id), eq, dtNumber),
+					},
+					{
+						name: "date filter",
+						filter: buildFilter(
+							fmt.Sprintf("%s_date", prefix),
+							time.Unix(0, 0).Add(time.Duration(id)*time.Hour),
+							eq, dtDate),
+					},
+					{
+						name: "date array filter",
+						filter: buildFilter(
+							fmt.Sprintf("%s_date_array", prefix),
+							time.Unix(0, 0).Add(time.Duration(id)*time.Hour),
+							eq, dtDate),
+					},
+					{
+						name: "geoFilter filter",
+						filter: buildFilter(
+							fmt.Sprintf("%s_geo", prefix),
+							filters.GeoRange{
+								GeoCoordinates: &models.GeoCoordinates{
+									ptFloat32(float32(id)), ptFloat32(float32(id)),
+								},
+								Distance: 2,
+							},
+							wgr, dtGeoCoordinates),
+					},
+				}
+
+				for _, tc := range tests {
+					t.Run(tc.name, func(t *testing.T) {
+						params := traverser.GetParams{
+							ClassName:  "TestClass",
+							Pagination: &filters.Pagination{Limit: 5},
+							Filters:    tc.filter,
+						}
+						res, err := repo.ClassSearch(context.Background(), params)
+						require.Nil(t, err)
+						require.Len(t, res, 1)
+
+						// hard-code the only uuid
+						assert.Equal(t, uuidFromInt(0), res[0].ID)
+					})
+				}
+			}
+		}
+		t.Run("using untouched", retrieve("untouched", 0))
+		t.Run("using touched", retrieve("touched", 28))
+	})
+}
+
+func uuidFromInt(in int) strfmt.UUID {
+	return strfmt.UUID(uuid.MustParse(fmt.Sprintf("%032d", in)).String())
 }

--- a/adapters/repos/db/shard_geo_props.go
+++ b/adapters/repos/db/shard_geo_props.go
@@ -51,7 +51,7 @@ func (s *Shard) makeCoordinatesForID(propName string) geo.CoordinatesForID {
 	return func(ctx context.Context, id uint64) (*models.GeoCoordinates, error) {
 		obj, err := s.objectByIndexID(ctx, id, true)
 		if err != nil {
-			return nil, errors.Wrap(err, "retrieve object")
+			return nil, storobj.NewErrNotFoundf(id, "retrieve object")
 		}
 
 		if obj.Properties() == nil {

--- a/adapters/repos/db/shard_read.go
+++ b/adapters/repos/db/shard_read.go
@@ -155,7 +155,7 @@ func (s *Shard) vectorByIndexID(ctx context.Context, indexID uint64) ([]float32,
 
 	if bytes == nil {
 		return nil, storobj.NewErrNotFoundf(indexID,
-			"uuid found for docID, but object is nil")
+			"no object for doc id, it could have been deleted")
 	}
 
 	return storobj.VectorFromBinary(bytes)

--- a/adapters/repos/db/shard_write_merge.go
+++ b/adapters/repos/db/shard_write_merge.go
@@ -42,6 +42,10 @@ func (s *Shard) mergeObject(ctx context.Context, merge objects.MergeDocument) er
 		return errors.Wrap(err, "update vector index")
 	}
 
+	if err := s.updatePropertySpecificIndices(next, status); err != nil {
+		return errors.Wrap(err, "update property-specific indices")
+	}
+
 	if err := s.store.WriteWALs(); err != nil {
 		return errors.Wrap(err, "flush all buffered WALs")
 	}

--- a/adapters/repos/db/vector/hnsw/delete.go
+++ b/adapters/repos/db/vector/hnsw/delete.go
@@ -308,7 +308,8 @@ func (h *hnsw) reassignNeighbor(neighbor uint64, deleteList helpers.AllowList, b
 		if h.isOnlyNode(&vertex{id: neighbor}, deleteList) {
 			neighborNode.Lock()
 			// delete all existing connections before re-assigning
-			neighborNode.connections = make([][]uint64, neighborNode.level+1)
+			neighborLevel = neighborNode.level
+			neighborNode.connections = make([][]uint64, neighborLevel+1)
 			neighborNode.Unlock()
 
 			if err := h.commitLog.ClearLinks(neighbor); err != nil {
@@ -322,7 +323,13 @@ func (h *hnsw) reassignNeighbor(neighbor uint64, deleteList helpers.AllowList, b
 
 		alternative, level := h.findNewLocalEntrypoint(tmpDenyList, currentMaximumLayer,
 			entryPointID)
-		neighborLevel = level // reduce in case no neighbor is at our level
+		if level > neighborLevel {
+			neighborNode.Lock()
+			// reset connections according to level
+			neighborNode.connections = make([][]uint64, level+1)
+			neighborNode.Unlock()
+		}
+		neighborLevel = level
 		entryPointID = alternative
 	}
 

--- a/adapters/repos/db/vector/hnsw/delete.go
+++ b/adapters/repos/db/vector/hnsw/delete.go
@@ -27,6 +27,9 @@ type breakCleanUpTombstonedNodesFunc func() bool
 // Delete attaches a tombstone to an item so it can be periodically cleaned up
 // later and the edges reassigned
 func (h *hnsw) Delete(id uint64) error {
+	h.deleteVsInsertLock.Lock()
+	defer h.deleteVsInsertLock.Unlock()
+
 	h.deleteLock.Lock()
 	defer h.deleteLock.Unlock()
 

--- a/adapters/repos/db/vector/hnsw/delete_test.go
+++ b/adapters/repos/db/vector/hnsw/delete_test.go
@@ -19,6 +19,7 @@ import (
 
 	"github.com/semi-technologies/weaviate/adapters/repos/db/helpers"
 	"github.com/semi-technologies/weaviate/adapters/repos/db/vector/hnsw/distancer"
+	"github.com/semi-technologies/weaviate/entities/storobj"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -994,4 +995,67 @@ func bruteForceCosine(vectors [][]float32, query []float32, k int) []uint64 {
 
 func neverStop() bool {
 	return false
+}
+
+// This test simulates what happens when the EP is removed from the
+// VectorForID-serving store
+func Test_DeleteEPVecInUnderlyingObjectStore(t *testing.T) {
+	var vectorIndex *hnsw
+
+	vectors := [][]float32{
+		{1, 1},
+		{2, 2},
+		{3, 3},
+	}
+
+	vectorErrors := []error{
+		nil,
+		nil,
+		nil,
+	}
+
+	t.Run("import the test vectors", func(t *testing.T) {
+		index, err := New(Config{
+			RootPath:              "doesnt-matter-as-committlogger-is-mocked-out",
+			ID:                    "delete-ep-in-underlying-store-test",
+			MakeCommitLoggerThunk: MakeNoopCommitLogger,
+			DistanceProvider:      distancer.NewL2SquaredProvider(),
+			VectorForIDThunk: func(ctx context.Context, id uint64) ([]float32, error) {
+				fmt.Printf("vec for pos=%d is %v\n", id, vectors[int(id)])
+				return vectors[int(id)], vectorErrors[int(id)]
+			},
+		}, UserConfig{
+			MaxConnections: 30,
+			EFConstruction: 128,
+
+			// The actual size does not matter for this test, but if it defaults to
+			// zero it will constantly think it's full and needs to be deleted - even
+			// after just being deleted, so make sure to use a positive number here.
+			VectorCacheMaxObjects: 100000,
+		})
+		require.Nil(t, err)
+		vectorIndex = index
+
+		for i, vec := range vectors {
+			err := vectorIndex.Add(uint64(i), vec)
+			require.Nil(t, err)
+		}
+
+		fmt.Printf("ep is %d\n", vectorIndex.entryPointID)
+	})
+
+	t.Run("simulate ep vec deletion in object store", func(t *testing.T) {
+		vectors[0] = nil
+		vectorErrors[0] = storobj.NewErrNotFoundf(0, "deleted")
+		vectorIndex.cache.delete(context.Background(), 0)
+	})
+
+	t.Run("try to insert a fourth vector", func(t *testing.T) {
+		vectors = append(vectors, []float32{4, 4})
+		vectorErrors = append(vectorErrors, nil)
+
+		pos := len(vectors) - 1
+		err := vectorIndex.Add(uint64(pos), vectors[pos])
+		require.Nil(t, err)
+	})
 }

--- a/adapters/repos/db/vector/hnsw/index.go
+++ b/adapters/repos/db/vector/hnsw/index.go
@@ -120,6 +120,9 @@ type hnsw struct {
 	insertMetrics *insertMetrics
 
 	randFunc func() float64 // added to temporarily get rid on flakiness in tombstones related tests. to be removed after fixing WEAVIATE-179
+
+	// TODO: validate that this is not a performance problem
+	deleteVsInsertLock sync.RWMutex
 }
 
 type CommitLogger interface {
@@ -153,7 +156,7 @@ type MakeCommitLogger func() (CommitLogger, error)
 
 type (
 	VectorForID      func(ctx context.Context, id uint64) ([]float32, error)
-	MultiVectorForID func(ctx context.Context, ids []uint64) ([][]float32, error)
+	MultiVectorForID func(ctx context.Context, ids []uint64) ([][]float32, []error)
 )
 
 // New creates a new HNSW index, the commit logger is provided through a thunk

--- a/adapters/repos/db/vector/hnsw/index.go
+++ b/adapters/repos/db/vector/hnsw/index.go
@@ -121,7 +121,24 @@ type hnsw struct {
 
 	randFunc func() float64 // added to temporarily get rid on flakiness in tombstones related tests. to be removed after fixing WEAVIATE-179
 
-	// TODO: validate that this is not a performance problem
+	// The deleteVsInsertLock makes sure that there are no concurrent delete and
+	// insert operations happening. It uses an RW-Mutex with:
+	//
+	// RLock -> Insert operations, this means any number of import operations can
+	// happen concurrently.
+	//
+	// Lock -> Delete operation. This means only a single delete operation can
+	// occur at a time, no insert operation can occur simultaneously with a
+	// delete. Since the delete is cheap (just marking the node as deleted), the
+	// single-threadedness of deletes is not a big problem.
+	//
+	// This lock was introduced as part of
+	// https://github.com/semi-technologies/weaviate/issues/2194
+	//
+	// See
+	// https://github.com/semi-technologies/weaviate/pull/2191#issuecomment-1242726787
+	// where we ran performance tests to make sure introducing this lock has no
+	// negative impact on performance.
 	deleteVsInsertLock sync.RWMutex
 }
 

--- a/adapters/repos/db/vector/hnsw/insert.go
+++ b/adapters/repos/db/vector/hnsw/insert.go
@@ -72,6 +72,9 @@ func (h *hnsw) insertInitialElement(node *vertex, nodeVec []float32) error {
 }
 
 func (h *hnsw) insert(node *vertex, nodeVec []float32) error {
+	h.deleteVsInsertLock.RLock()
+	defer h.deleteVsInsertLock.RUnlock()
+
 	before := time.Now()
 
 	wasFirst := false

--- a/adapters/repos/db/vector/hnsw/neighbor_connections.go
+++ b/adapters/repos/db/vector/hnsw/neighbor_connections.go
@@ -141,6 +141,10 @@ func (n *neighborFinderConnector) connectNeighborAtLevel(neighborID uint64,
 
 	neighbor.Lock()
 	defer neighbor.Unlock()
+	if level > neighbor.level {
+		// upgrade neighbor level if the level is out of sync due to a delete re-assign
+		neighbor.upgradeToLevelNoLock(level)
+	}
 	currentConnections := neighbor.connectionsAtLevelNoLock(level)
 
 	maximumConnections := n.maximumConnections(level)

--- a/adapters/repos/db/vector/hnsw/neighbor_connections.go
+++ b/adapters/repos/db/vector/hnsw/neighbor_connections.go
@@ -62,8 +62,9 @@ func (n *neighborFinderConnector) Do() error {
 		return errors.Wrapf(err, "calculate distance between insert node and final entrypoint")
 	}
 	if !ok {
-		return errors.Errorf("initial: entrypoint was deleted in the object store, " +
-			"it has been flagged for cleanup and should be fixed in the next cleanup cycle")
+		if err := n.replaceEntrypointsIfUnderMaintenance(); err != nil {
+			return err
+		}
 	}
 
 	n.entryPointDist = dist

--- a/adapters/repos/db/vector/hnsw/neighbor_connections.go
+++ b/adapters/repos/db/vector/hnsw/neighbor_connections.go
@@ -12,6 +12,7 @@
 package hnsw
 
 import (
+	"context"
 	"time"
 
 	"github.com/pkg/errors"
@@ -57,18 +58,6 @@ func newNeighborFinderConnector(graph *hnsw, node *vertex, entryPointID uint64,
 }
 
 func (n *neighborFinderConnector) Do() error {
-	dist, ok, err := n.graph.distBetweenNodeAndVec(n.entryPointID, n.nodeVec)
-	if err != nil {
-		return errors.Wrapf(err, "calculate distance between insert node and final entrypoint")
-	}
-	if !ok {
-		if err := n.replaceEntrypointsIfUnderMaintenance(); err != nil {
-			return err
-		}
-	}
-
-	n.entryPointDist = dist
-
 	for level := min(n.targetLevel, n.currentMaxLevel); level >= 0; level-- {
 		err := n.doAtLevel(level)
 		if err != nil {
@@ -81,8 +70,8 @@ func (n *neighborFinderConnector) Do() error {
 
 func (n *neighborFinderConnector) doAtLevel(level int) error {
 	before := time.Now()
-	if err := n.replaceEntrypointsIfUnderMaintenance(); err != nil {
-		return errors.Wrap(err, "replace ep under maintenance")
+	if err := n.pickEntrypoint(); err != nil {
+		return errors.Wrap(err, "pick entrypoint at level beginning")
 	}
 
 	eps := priorityqueue.NewMin(1)
@@ -136,46 +125,9 @@ func (n *neighborFinderConnector) doAtLevel(level int) error {
 		}
 
 		n.entryPointID = nextEntryPointID
-		dist, ok, err := n.graph.distBetweenNodeAndVec(n.entryPointID, n.nodeVec)
-		if err != nil {
-			return errors.Wrapf(err, "calculate distance between insert node and final entrypoint")
-		}
-		if !ok {
-			return errors.Errorf("entrypoint was deleted in the object store, " +
-				"it has been flagged for cleanup and should be fixed in the next cleanup cycle")
-		}
-
-		n.entryPointDist = dist
 	}
 
 	n.graph.insertMetrics.findAndConnectUpdateConnections(before)
-	return nil
-}
-
-func (n *neighborFinderConnector) replaceEntrypointsIfUnderMaintenance() error {
-	node := n.graph.nodeByID(n.entryPointID)
-	if node == nil || node.isUnderMaintenance() {
-		alternativeEP := n.graph.entryPointID
-		if alternativeEP == n.node.id || alternativeEP == n.entryPointID {
-			tmpDenyList := n.denyList.DeepCopy()
-			tmpDenyList.Insert(alternativeEP)
-
-			alternative, _ := n.graph.findNewLocalEntrypoint(tmpDenyList, n.graph.currentMaximumLayer,
-				n.entryPointID)
-			alternativeEP = alternative
-		}
-		dist, ok, err := n.graph.distBetweenNodeAndVec(alternativeEP, n.nodeVec)
-		if err != nil {
-			return errors.Wrapf(err, "calculate distance between insert node and final entrypoint")
-		}
-		if !ok {
-			return errors.Errorf("replace entrypoint: entrypoint was deleted in the object store, " +
-				"it has been flagged for cleanup and should be fixed in the next cleanup cycle")
-		}
-		n.entryPointID = alternativeEP
-		n.entryPointDist = dist
-	}
-
 	return nil
 }
 
@@ -276,4 +228,76 @@ func (n *neighborFinderConnector) maximumConnections(level int) int {
 	}
 
 	return n.graph.maximumConnections
+}
+
+func (n *neighborFinderConnector) pickEntrypoint() error {
+	// the neighborFinderConnector always has a suggestion for an entrypoint that
+	// it got from the outside, most of the times we can use this, but in some
+	// cases we can't. To see if we can use it, three conditions need to be met:
+	//
+	// 1. it needs to exist in the graph, i.e. be not nil
+	//
+	// 2. it can't be under maintenance
+	//
+	// 3. we need to be able to obtain a vector for it
+
+	localDeny := n.denyList.DeepCopy()
+	candidate := n.entryPointID
+
+	// make sure the loop cannot block forever. In most cases, results should be
+	// found within micro to milliseconds, this is just a last resort to handle
+	// the unknown somewhat gracefully, for example if there is a bug in the
+	// underlying object store and we cannot retrieve the vector in time, etc.
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	defer cancel()
+
+	for {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+
+		success, err := n.tryEpCandidate(candidate)
+		if err != nil {
+			return err
+		}
+
+		if success {
+			return nil
+		}
+
+		// no success so far, we need to keep going and find a better candidate
+		// make sure we never visit this candidate again
+		localDeny.Insert(candidate)
+		// now find a new one
+
+		alternative, _ := n.graph.findNewLocalEntrypoint(localDeny,
+			n.graph.currentMaximumLayer, candidate)
+		candidate = alternative
+	}
+}
+
+func (n *neighborFinderConnector) tryEpCandidate(candidate uint64) (bool, error) {
+	node := n.graph.nodeByID(candidate)
+	if node == nil {
+		return false, nil
+	}
+
+	if node.isUnderMaintenance() {
+		return false, nil
+	}
+
+	dist, ok, err := n.graph.distBetweenNodeAndVec(candidate, n.nodeVec)
+	if err != nil {
+		// not an error we could recover from - fail!
+		return false, errors.Wrapf(err,
+			"calculate distance between insert node and entrypoint")
+	}
+	if !ok {
+		return false, nil
+	}
+
+	// we were able to calculate a distance, we're good
+	n.entryPointDist = dist
+	n.entryPointID = candidate
+	return true, nil
 }

--- a/adapters/repos/db/vector/hnsw/search.go
+++ b/adapters/repos/db/vector/hnsw/search.go
@@ -198,6 +198,14 @@ func (h *hnsw) searchLayerByVector(queryVector []float32,
 		}
 
 		candidateNode.Lock()
+		if candidateNode.level < level {
+			// a node level could have been downgraded as part of a delete-reassign,
+			// but the connections pointing to it not yet cleaned up. In this case
+			// the node doesn't have any outgoing connections at this level and we
+			// must discard it.
+			candidateNode.Unlock()
+			continue
+		}
 
 		var connections *[]uint64
 

--- a/adapters/repos/db/vector/hnsw/vertex.go
+++ b/adapters/repos/db/vector/hnsw/vertex.go
@@ -46,6 +46,13 @@ func (v *vertex) connectionsAtLevelNoLock(level int) []uint64 {
 	return v.connections[level]
 }
 
+func (v *vertex) upgradeToLevelNoLock(level int) {
+	newConnections := make([][]uint64, level+1)
+	copy(newConnections, v.connections)
+	v.level = level
+	v.connections = newConnections
+}
+
 func (v *vertex) setConnectionsAtLevel(level int, connections []uint64) {
 	v.Lock()
 	defer v.Unlock()


### PR DESCRIPTION
This PR fixes the following bugs in chronological order of discovery:

* ### Fix an issue where LSM memtable returned values for since-changed secondary keys
  This was discovered as part of another investigation. It was impossible to add vectors if there were objects that previously had a vector, but it got remove through an update. The vector index would fail with "distance calculation: 0 vs 128". Because of the memtable issue, it was possible to partially retrieve an object that no longer existed, thus leading to `nil` vectors. Fixes #2190. New tests were added to the memtable itself that reproduced the problem before and are now green.

* ### Fix issue where PATCH could break some props
  This issue popped up after fixing #2190, because it was hidden by the broken behavior. If PATCH updated some props, but left overs untouched, the untouched props could be messed up in the inverted index, thus leading to failed searches afterwards. This was due to incorrect type assertions in combination with broken error handling in the `inverted` package.   Fixes #2193. A new elaborate test was added that makes uses of both untouched and touched props and makes sure the object is retrievable through each of them.

* ### Fix issue where concurrent HNSW. insert and delete operations led to issues
  With #2190 fixed this showed up. The fix is relatively simple: There is a new lock that prevents concurrent indexing and deleting. This is the biggest performance risk in this PR. Luckily it has no negative impact – as can be seen by the performance test runs below. Fixes #2194. No new tests were added as the existing test suite already showed this issue with the other issues fixed.
  
* ### Fix issue where PATCH would not update geoProps
  This was a purely serendipitous find. As part of the new tests to prove that #2193 is fixed, also geo props were added. This showed that while there was not an update with untouched props, the whole update operation was never reflected. Fixes #2195. The test as part of #2193 is only green with this fix in, no separate test was deemed necessary.

* ### Fix "entry point deleted - will be cleaned up in next cycle"
  This showed up in the chaos pipeline because of the fixes in #2190 which now makes it much more likely to run into an entry point that no longer exists and needs to be updated. The existing logic to replace entry points was a bit hard to read and not very robust. It was spread out over too many places and just made one attempt to replace the EP. If the replacement was then also deleted in the object store before a distance to it could be calculated, the user would see the above error. The new logic is much cleaner, there is a single `pickEntrypoint()` method that is called from only a single place. Within the method, there are two noteable changes: 1. it takes all criteria into account, making it impossible for the logic to find an alternative and that alternative to then fail in the next step. 2. it makes more than a single attempt, it runs in a loop until it finds an alternative. A new context is spawned to make this logic fail after 60s. It is highly unlikely that the logic would ever spend this much time in there, but I wanted some sort of a circuit breaker in case the underlying object store was buggy or super slow to prevent the cascading blocking and getting stuck in this loop forever. Fixes #2198. A new test was added that reproduced the issue in one case. Other cases were reproduced by the chaos pipeline.

* ### Fix potential out-of-range panics in HNSW delete logic
  For this one, I'm not 100% sure where this comes from. My suspicion is that this bug was introduced by #2146, but it was super unlikely to occur because #2190 hid the need for cases where the entry point was properly replaced in the delete cleanup. This was fixed by making the connection logic a bit more robust. If level expectations weren't met, the object is adapted correctly. Fixes #2197. This is the only one of the fixes that have no explicit test in Weaviate as the chaos pipeline clearly reproduced this issue with all the other issues fixed. It's not 100% ideal to only rely on the chaos pipeline because of the late feedback, but I couldn't think of a "good" way to write a test for this that doesn't run for ages, and also this PR that was supposed to be 50 lines, has grown substantially because of all the other bugs that were discovered and fixed.


### Review checklist

- [ ] ~~Documentation has been updated, if necessary. Link to changed documentation:~~ only fixes
- [x] Chaos pipeline run or not necessary. Link to pipeline: See comment below
- [x] All new code is covered by tests where it is reasonable. Various new tests, see description above
- [x] Performance tests have been run or not necessary: See comment below
