### PR TITLE
Fix seven aggregations bugs

### DIFF
--- a/adapters/repos/db/aggregations_fixtures_for_test.go
+++ b/adapters/repos/db/aggregations_fixtures_for_test.go
@@ -292,7 +292,7 @@ var companyIDs = []strfmt.UUID{
 var arrayTypes = []map[string]interface{}{
 	{
 		"strings": []string{"a", "b", "c"},
-		"numbers": []float64{1.0, 2.0, 3.0},
+		"numbers": []float64{1.0, 2.0, 2.0, 3.0, 3.0},
 	},
 	{
 		"strings": []string{"a"},

--- a/adapters/repos/db/aggregations_integration_test.go
+++ b/adapters/repos/db/aggregations_integration_test.go
@@ -1219,7 +1219,7 @@ func testNumericalAggregationsWithFilters(repo *DB) func(t *testing.T) {
 			require.Equal(t, 1, len(res.Groups))
 			require.Equal(t, 1, len(res.Groups[0].Properties))
 			require.Equal(t, 1, len(res.Groups[0].Properties["dividendYield"].NumericalAggregations))
-			require.Equal(t, uint64(0), res.Groups[0].Properties["dividendYield"].NumericalAggregations["count"].(uint64))
+			require.Equal(t, float64(0), res.Groups[0].Properties["dividendYield"].NumericalAggregations["count"].(float64))
 		})
 	}
 }
@@ -1914,55 +1914,54 @@ func testNumericalAggregationsWithoutGrouping(repo *DB,
 			assert.Equal(t, expectedResult.Groups, res.Groups)
 		})
 
-		// TODO: Flaky median result: https://github.com/semi-technologies/weaviate/issues/1693
-		// t.Run("array types, single aggregator numbers", func(t *testing.T) {
-		// 	params := aggregation.Params{
-		// 		ClassName: schema.ClassName(arrayTypesClass.Class),
-		// 		GroupBy:   nil, // explicitly set to nil
-		// 		Properties: []aggregation.ParamProperty{
-		// 			aggregation.ParamProperty{
-		// 				Name: schema.PropertyName("numbers"),
-		// 				Aggregators: []aggregation.Aggregator{
-		// 					aggregation.MeanAggregator,
-		// 					aggregation.MaximumAggregator,
-		// 					aggregation.MinimumAggregator,
-		// 					aggregation.SumAggregator,
-		// 					aggregation.ModeAggregator,
-		// 					aggregation.MedianAggregator,
-		// 					aggregation.CountAggregator,
-		// 					aggregation.TypeAggregator, // ignored in the repo, but can't block
-		// 				},
-		// 			},
-		// 		},
-		// 	}
+		t.Run("array types, single aggregator numbers", func(t *testing.T) {
+			params := aggregation.Params{
+				ClassName: schema.ClassName(arrayTypesClass.Class),
+				GroupBy:   nil, // explicitly set to nil
+				Properties: []aggregation.ParamProperty{
+					{
+						Name: schema.PropertyName("numbers"),
+						Aggregators: []aggregation.Aggregator{
+							aggregation.MeanAggregator,
+							aggregation.MaximumAggregator,
+							aggregation.MinimumAggregator,
+							aggregation.SumAggregator,
+							// aggregation.ModeAggregator,
+							// aggregation.MedianAggregator,
+							aggregation.CountAggregator,
+							aggregation.TypeAggregator, // ignored in the repo, but can't block
+						},
+					},
+				},
+			}
 
-		// 	res, err := repo.Aggregate(context.Background(), params)
-		// 	require.Nil(t, err)
+			res, err := repo.Aggregate(context.Background(), params)
+			require.Nil(t, err)
 
-		// 	expectedResult := &aggregation.Result{
-		// 		Groups: []aggregation.Group{
-		// 			aggregation.Group{
-		// 				GroupedBy: nil,
-		// 				Properties: map[string]aggregation.Property{
-		// 					"numbers": aggregation.Property{
-		// 						Type: aggregation.PropertyTypeNumerical,
-		// 						NumericalAggregations: map[string]interface{}{
-		// 							"mean":    1.8,
-		// 							"maximum": 3.0,
-		// 							"minimum": 1.0,
-		// 							"sum":     9.0,
-		// 							"mode":    1.0,
-		// 							"median":  3.0,
-		// 							"count":   5.,
-		// 						},
-		// 					},
-		// 				},
-		// 			},
-		// 		},
-		// 	}
+			expectedResult := &aggregation.Result{
+				Groups: []aggregation.Group{
+					{
+						GroupedBy: nil,
+						Properties: map[string]aggregation.Property{
+							"numbers": {
+								Type: aggregation.PropertyTypeNumerical,
+								NumericalAggregations: map[string]interface{}{
+									"mean":    1.8,
+									"maximum": 3.0,
+									"minimum": 1.0,
+									"sum":     9.0,
+									//"mode":    1.0,
+									//"median":  3.0,
+									"count": 5.,
+								},
+							},
+						},
+					},
+				},
+			}
 
-		// 	assert.Equal(t, expectedResult.Groups, res.Groups)
-		// })
+			assert.Equal(t, expectedResult.Groups, res.Groups)
+		})
 
 		t.Run("array types, single aggregator strings", func(t *testing.T) {
 			if !exact {

--- a/adapters/repos/db/aggregations_integration_test.go
+++ b/adapters/repos/db/aggregations_integration_test.go
@@ -1601,6 +1601,8 @@ func testNumericalAggregationsWithoutGrouping(repo *DB,
 			delete(res.Groups[0].Properties, "dividendYield")
 			actualPrice := res.Groups[0].Properties["price"]
 			delete(res.Groups[0].Properties, "price")
+			actualMakesProduct := res.Groups[0].Properties["makesProduct"]
+			delete(res.Groups[0].Properties, "makesProduct")
 
 			expectedDivYield := aggregation.Property{
 				Type: aggregation.PropertyTypeNumerical,
@@ -1625,6 +1627,13 @@ func testNumericalAggregationsWithoutGrouping(repo *DB,
 					"mode":    70.,
 					"median":  115.,
 					"count":   60.,
+				},
+			}
+
+			expectedMakesProduct := aggregation.Property{
+				Type: aggregation.PropertyTypeReference,
+				ReferenceAggregation: aggregation.Reference{
+					PointingTo: []string{"weaviate://localhost/1295c052-263d-4aae-99dd-920c5a370d06"},
 				},
 			}
 
@@ -1721,6 +1730,9 @@ func testNumericalAggregationsWithoutGrouping(repo *DB,
 				actualDivYield.NumericalAggregations["count"], 0.1)
 			assert.InEpsilon(t, expectedPrice.NumericalAggregations["count"],
 				actualPrice.NumericalAggregations["count"], 0.1)
+
+			assert.Equal(t, expectedMakesProduct.ReferenceAggregation.PointingTo,
+				actualMakesProduct.ReferenceAggregation.PointingTo)
 		})
 
 		t.Run("multiple fields, multiple aggregators, ref filter", func(t *testing.T) {
@@ -1825,6 +1837,10 @@ func testNumericalAggregationsWithoutGrouping(repo *DB,
 					{
 						Count: 10,
 						Properties: map[string]aggregation.Property{
+							"makesProduct": {
+								Type:                 aggregation.PropertyTypeReference,
+								ReferenceAggregation: aggregation.Reference{PointingTo: []string{"weaviate://localhost/1295c052-263d-4aae-99dd-920c5a370d06"}},
+							},
 							"dividendYield": {
 								Type: aggregation.PropertyTypeNumerical,
 								NumericalAggregations: map[string]interface{}{

--- a/adapters/repos/db/aggregations_integration_test.go
+++ b/adapters/repos/db/aggregations_integration_test.go
@@ -1174,7 +1174,7 @@ func testNumericalAggregationsWithGrouping(repo *DB, exact bool) func(t *testing
 						Properties: map[string]aggregation.Property{},
 					},
 					{
-						Count: 2,
+						Count: 3,
 						GroupedBy: &aggregation.GroupedBy{
 							Path:  []string{"numbers"},
 							Value: float64(2.0),
@@ -1182,7 +1182,7 @@ func testNumericalAggregationsWithGrouping(repo *DB, exact bool) func(t *testing
 						Properties: map[string]aggregation.Property{},
 					},
 					{
-						Count: 1,
+						Count: 2,
 						GroupedBy: &aggregation.GroupedBy{
 							Path:  []string{"numbers"},
 							Value: float64(3.0),
@@ -1989,8 +1989,8 @@ func testNumericalAggregationsWithoutGrouping(repo *DB,
 							aggregation.MaximumAggregator,
 							aggregation.MinimumAggregator,
 							aggregation.SumAggregator,
-							// aggregation.ModeAggregator,
-							// aggregation.MedianAggregator,
+							aggregation.ModeAggregator,
+							aggregation.MedianAggregator,
 							aggregation.CountAggregator,
 							aggregation.TypeAggregator, // ignored in the repo, but can't block
 						},
@@ -2009,13 +2009,13 @@ func testNumericalAggregationsWithoutGrouping(repo *DB,
 							"numbers": {
 								Type: aggregation.PropertyTypeNumerical,
 								NumericalAggregations: map[string]interface{}{
-									"mean":    1.8,
+									"mean":    2.0,
 									"maximum": 3.0,
 									"minimum": 1.0,
-									"sum":     9.0,
-									//"mode":    1.0,
-									//"median":  3.0,
-									"count": 5.,
+									"sum":     14.0,
+									"mode":    2.0,
+									"median":  2.0,
+									"count":   7.,
 								},
 							},
 						},

--- a/adapters/repos/db/aggregations_integration_test.go
+++ b/adapters/repos/db/aggregations_integration_test.go
@@ -2065,7 +2065,7 @@ func testDateAggregationsWithGrouping(repo *DB, exact bool) func(t *testing.T) {
 				"count":   int64(10),
 				"minimum": "2022-06-16T17:30:17.231346Z",
 				"maximum": "2022-06-16T17:30:26.451235Z",
-				"median":  "2022-06-16T17:30:20.123546Z",
+				"median":  "2022-06-16T17:30:21.1179905Z",
 				"mode":    "2022-06-16T17:30:17.231346Z",
 			}
 			receivedProperties := res.Groups[0].Properties["timeArrived"].DateAggregations
@@ -2109,7 +2109,7 @@ func testDateAggregationsWithGrouping(repo *DB, exact bool) func(t *testing.T) {
 							DateAggregations: map[string]interface{}{
 								"count":   int64(6),
 								"maximum": "2022-06-16T17:30:25.524536Z",
-								"median":  "2022-06-16T17:30:17.231346Z",
+								"median":  "2022-06-16T17:30:19.6718905Z",
 								"minimum": "2022-06-16T17:30:17.231346Z",
 								"mode":    "2022-06-16T17:30:17.231346Z",
 							},
@@ -2128,7 +2128,7 @@ func testDateAggregationsWithGrouping(repo *DB, exact bool) func(t *testing.T) {
 							DateAggregations: map[string]interface{}{
 								"count":   int64(4),
 								"maximum": "2022-06-16T17:30:26.451235Z",
-								"median":  "2022-06-16T17:30:20.123546Z",
+								"median":  "2022-06-16T17:30:22.224622Z",
 								"minimum": "2022-06-16T17:30:20.123546Z",
 								"mode":    "2022-06-16T17:30:20.123546Z",
 							},

--- a/adapters/repos/db/aggregator/aggregator.go
+++ b/adapters/repos/db/aggregator/aggregator.go
@@ -84,7 +84,7 @@ func (a *Aggregator) aggTypeOfProperty(
 	}
 
 	if schema.IsRefDataType(schemaProp.DataType) {
-		return aggregation.PropertyTypeReference, "", nil
+		return aggregation.PropertyTypeReference, schema.DataTypeCRef, nil
 	}
 
 	dt := schema.DataType(schemaProp.DataType[0])

--- a/adapters/repos/db/aggregator/date.go
+++ b/adapters/repos/db/aggregator/date.go
@@ -152,6 +152,10 @@ func (a *dateAggregator) addRow(ts timestamp, count uint64) error {
 		a.mode = ts
 	}
 
+	currentCount := a.valueCounter[ts]
+	currentCount += count
+	a.valueCounter[ts] = currentCount
+
 	a.pairs = append(a.pairs, timestampCountPair{value: ts, count: count})
 
 	return nil

--- a/adapters/repos/db/aggregator/date.go
+++ b/adapters/repos/db/aggregator/date.go
@@ -29,6 +29,18 @@ func addDateAggregations(prop *aggregation.Property,
 		prop.DateAggregations = map[string]interface{}{}
 	}
 
+	// if there are no elements to aggregate over because a filter does not match anything, calculating median etc. makes
+	// no sense. Non-existent entries evaluate to nil with an interface{} map
+	if agg.count == 0 {
+		for _, entry := range aggs {
+			if entry == aggregation.CountAggregator {
+				prop.DateAggregations["count"] = int64(agg.count)
+				break
+			}
+		}
+		return
+	}
+
 	// when combining the results from different shards, we need the raw dates to recompute the mode and median.
 	// Therefor we add a reference later which needs to be cleared out before returning the results to a user
 	for _, aProp := range aggs {

--- a/adapters/repos/db/aggregator/date_test.go
+++ b/adapters/repos/db/aggregator/date_test.go
@@ -1,0 +1,53 @@
+package aggregator
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+const (
+	DateYearMonthDayHourMinute = "2022-06-16T17:30:"
+	DateNanoSecondsTimeZone    = ".451235Z"
+)
+
+func TestDateAggregator(t *testing.T) {
+	tests := []struct {
+		name           string
+		seconds        []string
+		expectedMedian string
+		expectedMode   string
+	}{
+		{
+			name:           "Single value",
+			seconds:        []string{"17"},
+			expectedMedian: "17",
+			expectedMode:   "17",
+		},
+	}
+	names := []string{"AddTimestamp", "AddRow"}
+	for _, tt := range tests {
+		for i := 0; i < 2; i++ { // test two ways of adding the value to the aggregator
+			t.Run(tt.name+" "+names[i], func(t *testing.T) {
+				agg := newDateAggregator()
+				for _, second := range tt.seconds {
+					fullDate := DateYearMonthDayHourMinute + second + DateNanoSecondsTimeZone
+					if i == 0 {
+						agg.AddTimestamp(fullDate)
+					} else {
+						timeParsed, ok := time.Parse(time.RFC3339, fullDate)
+						assert.Nil(t, ok)
+						ts := newTimestamp(timeParsed.UnixNano())
+						agg.addRow(ts, 1)
+					}
+				}
+				agg.buildPairsFromCounts() // needed to populate all required info
+				assert.Equal(t, DateYearMonthDayHourMinute+tt.expectedMedian+DateNanoSecondsTimeZone, agg.Median())
+				if len(tt.expectedMode) > 0 { // if there is no value that appears more often than other values
+					assert.Equal(t, DateYearMonthDayHourMinute+tt.expectedMode+DateNanoSecondsTimeZone, agg.Mode())
+				}
+			})
+		}
+	}
+}

--- a/adapters/repos/db/aggregator/date_test.go
+++ b/adapters/repos/db/aggregator/date_test.go
@@ -25,21 +25,35 @@ func TestDateAggregator(t *testing.T) {
 			expectedMedian: "17",
 			expectedMode:   "17",
 		},
+		{
+			name:           "Even number of values",
+			seconds:        []string{"18", "18", "20", "25"},
+			expectedMedian: "19",
+			expectedMode:   "18",
+		},
+		{
+			name:           "Uneven number of values",
+			seconds:        []string{"18", "18", "19", "20", "25"},
+			expectedMedian: "19",
+			expectedMode:   "18",
+		},
 	}
 	names := []string{"AddTimestamp", "AddRow"}
 	for _, tt := range tests {
-		for i := 0; i < 2; i++ { // test two ways of adding the value to the aggregator
-			t.Run(tt.name+" "+names[i], func(t *testing.T) {
+		for _, name := range names { // test two ways of adding the value to the aggregator
+			t.Run(tt.name+" "+name, func(t *testing.T) {
 				agg := newDateAggregator()
 				for _, second := range tt.seconds {
 					fullDate := DateYearMonthDayHourMinute + second + DateNanoSecondsTimeZone
-					if i == 0 {
-						agg.AddTimestamp(fullDate)
+					if name == names[0] {
+						err := agg.AddTimestamp(fullDate)
+						assert.Nil(t, err)
 					} else {
-						timeParsed, ok := time.Parse(time.RFC3339, fullDate)
-						assert.Nil(t, ok)
+						timeParsed, err := time.Parse(time.RFC3339, fullDate)
+						assert.Nil(t, err)
 						ts := newTimestamp(timeParsed.UnixNano())
-						agg.addRow(ts, 1)
+						err = agg.addRow(ts, 1)
+						assert.Nil(t, err)
 					}
 				}
 				agg.buildPairsFromCounts() // needed to populate all required info

--- a/adapters/repos/db/aggregator/filtered.go
+++ b/adapters/repos/db/aggregator/filtered.go
@@ -337,19 +337,14 @@ func (pa propAggs) results() (map[string]aggregation.Property, error) {
 		case aggregation.PropertyTypeBoolean:
 			aggProp.BooleanAggregation = prop.boolAgg.Res()
 			out[prop.name.String()] = aggProp
-
 		case aggregation.PropertyTypeText:
 			aggProp.TextAggregation = prop.textAgg.Res()
 			out[prop.name.String()] = aggProp
-
 		case aggregation.PropertyTypeNumerical:
-			prop.numericalAgg.buildPairsFromCounts()
 			addNumericalAggregations(&aggProp, prop.specifiedAggregators,
 				prop.numericalAgg)
 			out[prop.name.String()] = aggProp
-
 		case aggregation.PropertyTypeDate:
-			prop.dateAgg.buildPairsFromCounts()
 			addDateAggregations(&aggProp, prop.specifiedAggregators,
 				prop.dateAgg)
 			out[prop.name.String()] = aggProp
@@ -357,7 +352,6 @@ func (pa propAggs) results() (map[string]aggregation.Property, error) {
 			addReferenceAggregations(&aggProp, prop.specifiedAggregators,
 				prop.refAgg)
 			out[prop.name.String()] = aggProp
-
 		default:
 			return nil, errors.New(string("unknown aggregation type " + prop.aggType))
 		}

--- a/adapters/repos/db/aggregator/filtered.go
+++ b/adapters/repos/db/aggregator/filtered.go
@@ -250,7 +250,34 @@ func (fa *filteredAggregator) addPropValue(prop propAgg, value interface{}) erro
 		default:
 			return fmt.Errorf("unknown datatype %v for aggregation %v", prop.dataType, aggregation.PropertyTypeText)
 		}
+	case aggregation.PropertyTypeReference:
+		if prop.dataType != schema.DataTypeCRef {
+			return errors.New(string("unknown datatype for aggregation type reference: " + prop.dataType))
+		}
+
+		analyzeRef := func(value interface{}) error {
+			referenceList, ok := value.([]interface{})
+			if !ok {
+				return fmt.Errorf("expected property type reference, received %T", value)
+			}
+			if len(referenceList) != 1 {
+				return fmt.Errorf("expected list with length 1, got %T", len(referenceList))
+			}
+			refMap, ok := referenceList[0].(map[string]interface{})
+			if !ok {
+				return fmt.Errorf("expected property type reference, received %T", value)
+			}
+
+			if err := prop.refAgg.AddReference(refMap); err != nil {
+				return err
+			}
+			return nil
+		}
+		if err := analyzeRef(value); err != nil {
+			return err
+		}
 	default:
+		return errors.New(string("Unknown aggregation type " + prop.aggType))
 
 	}
 
@@ -274,6 +301,7 @@ type propAgg struct {
 	textAgg      *textAggregator
 	numericalAgg *numericalAggregator
 	dateAgg      *dateAggregator
+	refAgg       *refAggregator
 }
 
 // propAggs groups propAgg helpers by prop name
@@ -290,7 +318,10 @@ func (pa *propAgg) initAggregator() {
 		pa.numericalAgg = newNumericalAggregator()
 	case aggregation.PropertyTypeDate:
 		pa.dateAgg = newDateAggregator()
+	case aggregation.PropertyTypeReference:
+		pa.refAgg = newRefAggregator()
 	default:
+		panic("Unknown aggregation type: " + pa.aggType)
 	}
 }
 
@@ -322,7 +353,13 @@ func (pa propAggs) results() (map[string]aggregation.Property, error) {
 			addDateAggregations(&aggProp, prop.specifiedAggregators,
 				prop.dateAgg)
 			out[prop.name.String()] = aggProp
+		case aggregation.PropertyTypeReference:
+			addReferenceAggregations(&aggProp, prop.specifiedAggregators,
+				prop.refAgg)
+			out[prop.name.String()] = aggProp
+
 		default:
+			return nil, errors.New(string("unknown aggregation type " + prop.aggType))
 		}
 	}
 

--- a/adapters/repos/db/aggregator/numerical.go
+++ b/adapters/repos/db/aggregator/numerical.go
@@ -165,6 +165,10 @@ func (a *numericalAggregator) AddNumberRow(number float64, count uint64) error {
 		a.mode = number
 	}
 
+	currentCount := a.valueCounter[number]
+	currentCount += count
+	a.valueCounter[number] = currentCount
+
 	a.pairs = append(a.pairs, floatCountPair{value: number, count: count})
 
 	return nil

--- a/adapters/repos/db/aggregator/numerical.go
+++ b/adapters/repos/db/aggregator/numerical.go
@@ -66,7 +66,6 @@ loop:
 			prop.NumericalAggregations[aProp.String()] = agg.Sum()
 		case aggregation.CountAggregator:
 			prop.NumericalAggregations[aProp.String()] = agg.Count()
-
 		default:
 			continue
 		}

--- a/adapters/repos/db/aggregator/numerical_test.go
+++ b/adapters/repos/db/aggregator/numerical_test.go
@@ -22,6 +22,7 @@ func TestNumericalAggregator_MedianCalculation(t *testing.T) {
 		name           string
 		numbers        []float64
 		expectedMedian float64
+		expectedMode   float64
 	}{
 		{
 			name:           "Uneven number of elements",
@@ -30,38 +31,52 @@ func TestNumericalAggregator_MedianCalculation(t *testing.T) {
 		},
 		{
 			name:           "Uneven number of elements with double elements",
-			numbers:        []float64{2, 2, 4, 4, 5, 5, 7},
+			numbers:        []float64{2, 4, 4, 4, 5, 5, 7},
 			expectedMedian: 4,
+			expectedMode:   4,
 		},
 		{
 			name:           "Even number of elements",
-			numbers:        []float64{1, 2, 3, 5, 6, 7},
+			numbers:        []float64{1, 2, 3, 5, 7, 7},
 			expectedMedian: 4,
+			expectedMode:   7,
 		},
 		{
 			name:           "Even number of elements with double elements, median is within double entries",
 			numbers:        []float64{1, 2, 3, 3, 6, 7},
 			expectedMedian: 3,
+			expectedMode:   3,
 		},
 		{
 			name:           "Even number of elements with double elements, median is after double entries",
-			numbers:        []float64{1, 3, 3, 5, 5, 7},
+			numbers:        []float64{3, 3, 3, 5, 5, 7},
 			expectedMedian: 4,
+			expectedMode:   3,
 		},
 		{
 			name:           "Single value",
 			numbers:        []float64{42},
 			expectedMedian: 42,
+			expectedMode:   42,
 		},
 	}
 	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			agg := newNumericalAggregator()
-			for _, num := range tt.numbers {
-				agg.AddFloat64(num)
-			}
-			agg.buildPairsFromCounts() // needed to populate all required info
-			assert.Equal(t, tt.expectedMedian, agg.Median())
-		})
+		for i := 0; i < 2; i++ { // test two ways of adding the value to the aggregator
+			t.Run(tt.name, func(t *testing.T) {
+				agg := newNumericalAggregator()
+				for _, num := range tt.numbers {
+					if i == 0 {
+						agg.AddFloat64(num)
+					} else {
+						agg.AddNumberRow(num, 1)
+					}
+				}
+				agg.buildPairsFromCounts() // needed to populate all required info
+				assert.Equal(t, tt.expectedMedian, agg.Median())
+				if tt.expectedMode > 0 { // if there is no value that appears more often than other values
+					assert.Equal(t, tt.expectedMode, agg.Mode())
+				}
+			})
+		}
 	}
 }

--- a/adapters/repos/db/aggregator/references.go
+++ b/adapters/repos/db/aggregator/references.go
@@ -1,0 +1,53 @@
+package aggregator
+
+import (
+	"errors"
+
+	"github.com/semi-technologies/weaviate/entities/aggregation"
+)
+
+func addReferenceAggregations(prop *aggregation.Property,
+	aggs []aggregation.Aggregator, agg *refAggregator,
+) {
+	prop.ReferenceAggregation = aggregation.Reference{}
+	prop.ReferenceAggregation.PointingTo = agg.PointingTo()
+
+	for _, aProp := range aggs {
+		switch aProp {
+		case aggregation.PointingToAggregator:
+			prop.ReferenceAggregation.PointingTo = agg.PointingTo()
+		default:
+			continue
+		}
+	}
+}
+
+func newRefAggregator() *refAggregator {
+	return &refAggregator{valueCounter: map[string]uint64{}}
+}
+
+type refAggregator struct {
+	count        uint64
+	valueCounter map[string]uint64
+}
+
+func (a *refAggregator) AddReference(ref map[string]interface{}) error {
+	a.count++
+
+	beacon, ok := ref["beacon"].(string)
+	if !ok {
+		return errors.New("not a reference" + beacon)
+	}
+	count := a.valueCounter[beacon]
+	count++
+	a.valueCounter[beacon] = count
+	return nil
+}
+
+func (a *refAggregator) PointingTo() []string {
+	keys := make([]string, 0, len(a.valueCounter))
+	for pointingTo := range a.valueCounter {
+		keys = append(keys, pointingTo)
+	}
+	return keys
+}

--- a/test/acceptance/graphql_resolvers/local_aggregate_test.go
+++ b/test/acceptance/graphql_resolvers/local_aggregate_test.go
@@ -1745,7 +1745,6 @@ func aggregatesOnDateFields(t *testing.T) {
 						minimum
 						maximum
 						median
-						mode
 					}
 				}
 			}
@@ -1760,7 +1759,6 @@ func aggregatesOnDateFields(t *testing.T) {
 					"maximum": "2022-06-16T22:19:11.837473Z",
 					"median":  "2022-06-16T22:19:06.1449075Z",
 					"minimum": "2022-06-16T22:18:59.640162Z",
-					"mode":    "2022-06-16T22:18:59.640162Z",
 				},
 			},
 		}

--- a/test/acceptance/graphql_resolvers/local_aggregate_test.go
+++ b/test/acceptance/graphql_resolvers/local_aggregate_test.go
@@ -1758,7 +1758,7 @@ func aggregatesOnDateFields(t *testing.T) {
 				"timestamp": map[string]interface{}{
 					"count":   json.Number("10"),
 					"maximum": "2022-06-16T22:19:11.837473Z",
-					"median":  "2022-06-16T22:19:05.894857Z",
+					"median":  "2022-06-16T22:19:06.1449075Z",
 					"minimum": "2022-06-16T22:18:59.640162Z",
 					"mode":    "2022-06-16T22:18:59.640162Z",
 				},
@@ -1914,7 +1914,7 @@ func aggregatesOnDateFields(t *testing.T) {
 				"timestamp": map[string]interface{}{
 					"count":   json.Number("10"),
 					"maximum": "2022-06-16T22:19:11.837473Z",
-					"median":  "2022-06-16T22:19:05.894857Z",
+					"median":  "2022-06-16T22:19:06.1449075Z",
 					"minimum": "2022-06-16T22:18:59.640162Z",
 				},
 			},


### PR DESCRIPTION
### What's being changed:

A couple of bugfixes around aggregation. Each fix is in its own commit and this should be reviewed commit by commit.

- Mode calculation fixed for dates and numerical values when doing unfiltered aggregations
- Merging of results from multiple shards for numeric aggregation with Median/Mode/Mean
- Fix median calculation for dates
- Reference aggregation was somewhat present, but in a broken state. Works now and returns the PointingTo aggregation. This is not tested in depth and I mainly made the existing tests pass with some newly added error checking around switch statements.
- Fix filtered date aggregations without results
- Fix flaky aggregation tests. For unfiltered aggregations buildFromPairs wasn't called before calculating median etc and the median algo was running on the unsorted added values. This order was non-deterministic and therefore the results were changing. 

### Review checklist

- [x] Chaos pipeline run or not necessary. Link to pipeline: https://github.com/semi-technologies/weaviate-chaos-engineering/runs/8322224126
- [x] All new code is covered by tests where it is reasonable.
- [x] Performance tests have been run or not necessary.
