### PR TITLE
Normalize Grafana PromQL expressions in example dashboards

### DIFF
--- a/tools/dev/grafana/dashboards/backup.json
+++ b/tools/dev/grafana/dashboards/backup.json
@@ -124,7 +124,7 @@
             "uid": "Prometheus"
           },
           "editorMode": "builder",
-          "expr": "backup_restore_ms_sum",
+          "expr": "backup_restore_ms_sum{}",
           "legendFormat": "__auto",
           "range": true,
           "refId": "A"
@@ -217,7 +217,7 @@
             "uid": "Prometheus"
           },
           "editorMode": "builder",
-          "expr": "backup_store_to_backend_ms_sum",
+          "expr": "backup_store_to_backend_ms_sum{}",
           "legendFormat": "__auto",
           "range": true,
           "refId": "A"
@@ -323,7 +323,7 @@
             "uid": "Prometheus"
           },
           "editorMode": "builder",
-          "expr": "backup_store_data_transferred",
+          "expr": "backup_store_data_transferred{}",
           "legendFormat": "__auto",
           "range": true,
           "refId": "A"
@@ -416,7 +416,7 @@
             "uid": "Prometheus"
           },
           "editorMode": "builder",
-          "expr": "backup_restore_data_transferred",
+          "expr": "backup_restore_data_transferred{}",
           "legendFormat": "__auto",
           "range": true,
           "refId": "A"

--- a/tools/dev/grafana/dashboards/importing.json
+++ b/tools/dev/grafana/dashboards/importing.json
@@ -195,7 +195,7 @@
             "uid": "Prometheus"
           },
           "exemplar": true,
-          "expr": "vector_index_tombstones",
+          "expr": "vector_index_tombstones{}",
           "instant": false,
           "interval": "",
           "intervalFactor": 1,
@@ -260,7 +260,7 @@
             "uid": "Prometheus"
           },
           "exemplar": true,
-          "expr": "sum(vector_index_tombstones)",
+          "expr": "sum(vector_index_tombstones{})",
           "interval": "",
           "legendFormat": "",
           "refId": "A"
@@ -450,7 +450,7 @@
             "uid": "Prometheus"
           },
           "exemplar": true,
-          "expr": "vector_index_tombstone_cleanup_threads",
+          "expr": "vector_index_tombstone_cleanup_threads{}",
           "interval": "",
           "legendFormat": "{{class_name}} - {{shard_name}}",
           "refId": "A"
@@ -513,7 +513,7 @@
             "uid": "Prometheus"
           },
           "exemplar": true,
-          "expr": "sum(vector_index_tombstone_cleanup_threads)",
+          "expr": "sum(vector_index_tombstone_cleanup_threads{})",
           "interval": "",
           "legendFormat": "",
           "refId": "A"
@@ -575,7 +575,7 @@
             "uid": "Prometheus"
           },
           "exemplar": true,
-          "expr": "sum(vector_index_tombstone_cleaned)",
+          "expr": "sum(vector_index_tombstone_cleaned{})",
           "interval": "",
           "legendFormat": "",
           "refId": "A"
@@ -867,7 +867,7 @@
             "uid": "Prometheus"
           },
           "exemplar": true,
-          "expr": "go_memstats_heap_inuse_bytes",
+          "expr": "go_memstats_heap_inuse_bytes{}",
           "interval": "",
           "legendFormat": "",
           "refId": "A"

--- a/tools/dev/grafana/dashboards/lsm.json
+++ b/tools/dev/grafana/dashboards/lsm.json
@@ -297,7 +297,7 @@
             "uid": "Prometheus"
           },
           "editorMode": "code",
-          "expr": "lsm_memtable_size",
+          "expr": "lsm_memtable_size{}",
           "legendFormat": "{{path}}",
           "range": true,
           "refId": "A"
@@ -386,7 +386,7 @@
             "uid": "Prometheus"
           },
           "editorMode": "code",
-          "expr": "rate(lsm_memtable_durations_ms_sum[$__interval])/rate(lsm_memtable_durations_ms_count[$__interval])",
+          "expr": "rate(lsm_memtable_durations_ms_sum{}[$__interval])/rate(lsm_memtable_durations_ms_count{}[$__interval])",
           "legendFormat": "{{operation}} ({{path}})",
           "range": true,
           "refId": "A"

--- a/tools/dev/grafana/dashboards/objects.json
+++ b/tools/dev/grafana/dashboards/objects.json
@@ -320,7 +320,7 @@
             "uid": "Prometheus"
           },
           "exemplar": true,
-          "expr": "rate(batch_delete_durations_ms_sum[$__interval])/rate(batch_delete_durations_ms_count[$__interval])",
+          "expr": "rate(batch_delete_durations_ms_sum{}[$__interval])/rate(batch_delete_durations_ms_count{}[$__interval])",
           "interval": "",
           "legendFormat": "{{ operation }} ({{class_name}}/{{shard_name}})",
           "refId": "A"

--- a/tools/dev/grafana/dashboards/startup.json
+++ b/tools/dev/grafana/dashboards/startup.json
@@ -104,7 +104,7 @@
             "uid": "Prometheus"
           },
           "exemplar": true,
-          "expr": "rate(startup_durations_ms_sum[$__interval])/rate(startup_durations_ms_count[$__interval])",
+          "expr": "rate(startup_durations_ms_sum{}[$__interval])/rate(startup_durations_ms_count{}[$__interval])",
           "interval": "",
           "legendFormat": "{{operation}} ({{class_name}} / {{shard_name}})",
           "refId": "A"
@@ -394,7 +394,7 @@
             "uid": "Prometheus"
           },
           "exemplar": true,
-          "expr": "rate(startup_diskio_throughput_sum[$__interval])/rate(startup_diskio_throughput_count[$__interval])",
+          "expr": "rate(startup_diskio_throughput_sum{}[$__interval])/rate(startup_diskio_throughput_count{}[$__interval])",
           "interval": "",
           "legendFormat": "{{operation}} ({{class_name}}/{{shard_name}})",
           "refId": "A"

--- a/tools/dev/grafana/dashboards/usage.json
+++ b/tools/dev/grafana/dashboards/usage.json
@@ -79,7 +79,7 @@
             "uid": "Prometheus"
           },
           "exemplar": true,
-          "expr": "sum(object_count)",
+          "expr": "sum(object_count{})",
           "interval": "",
           "legendFormat": "",
           "refId": "A"
@@ -378,7 +378,7 @@
             "uid": "Prometheus"
           },
           "exemplar": true,
-          "expr": "object_count",
+          "expr": "object_count{}",
           "interval": "",
           "legendFormat": "{{ class_name }} / {{ shard_name }}",
           "refId": "A"

--- a/tools/dev/grafana/dashboards/vectorindex.json
+++ b/tools/dev/grafana/dashboards/vectorindex.json
@@ -106,7 +106,7 @@
             "uid": "Prometheus"
           },
           "exemplar": true,
-          "expr": "vector_index_size",
+          "expr": "vector_index_size{}",
           "interval": "",
           "legendFormat": "{{class_name}} / {{shard_name}}",
           "refId": "A"
@@ -151,7 +151,7 @@
             "uid": "Prometheus"
           },
           "exemplar": true,
-          "expr": "sum(increase(vector_index_maintenance_durations_ms_bucket[$__interval])) by (le)",
+          "expr": "sum(increase(vector_index_maintenance_durations_ms_bucket{}[$__interval])) by (le)",
           "format": "heatmap",
           "interval": "",
           "legendFormat": "{{le}}",


### PR DESCRIPTION
### What's being changed:

PromQL expressions are changed from: `metric_name` to `metric_name{}` to allow for easier patching of variables. This does not have an impact on existing dashboards.

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.
