### PR TITLE
Wrap backend error when checking for metadata existence

### DIFF
--- a/usecases/backup/backuper_test.go
+++ b/usecases/backup/backuper_test.go
@@ -164,7 +164,7 @@ func TestBackupRequestValidation(t *testing.T) {
 
 		assert.Nil(t, meta)
 		assert.NotNil(t, err)
-		assert.Contains(t, err.Error(), fmt.Sprintf("backup %s already exists", id))
+		assert.Contains(t, err.Error(), fmt.Sprintf("check if backup %q exists", id))
 		assert.IsType(t, backup.ErrUnprocessable{}, err)
 	})
 	t.Run("MetadataNotFound", func(t *testing.T) {
@@ -184,7 +184,7 @@ func TestBackupRequestValidation(t *testing.T) {
 
 		assert.Nil(t, meta)
 		assert.NotNil(t, err)
-		assert.Contains(t, err.Error(), fmt.Sprintf("backup %s already exists", id))
+		assert.Contains(t, err.Error(), fmt.Sprintf("backup %q already exists", id))
 		assert.IsType(t, backup.ErrUnprocessable{}, err)
 	})
 }

--- a/usecases/backup/handler.go
+++ b/usecases/backup/handler.go
@@ -255,10 +255,10 @@ func (m *Manager) validateBackupRequest(ctx context.Context, store objectStore, 
 	// there is no backup with given id on the backend, regardless of its state (valid or corrupted)
 	_, err := store.Meta(ctx, req.ID)
 	if err == nil {
-		return nil, fmt.Errorf("backup %s already exists at %s", req.ID, destPath)
+		return nil, fmt.Errorf("backup %q already exists at %q", req.ID, destPath)
 	}
 	if _, ok := err.(backup.ErrNotFound); !ok {
-		return nil, fmt.Errorf("backup %s already exists at %s", req.ID, destPath)
+		return nil, fmt.Errorf("check if backup %q exists at %q: %w", req.ID, destPath, err)
 	}
 	return classes, nil
 }


### PR DESCRIPTION
### What's being changed:
Currently the api returns an error when checking for metadata existence.However the returned error doesn't include the original backend error.
The goal is to wrap the backend error before returning the resulting error
### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [x] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.
