### PR TITLE
Add filtering for null properties

### DIFF
--- a/adapters/handlers/graphql/local/common_filters/filters.go
+++ b/adapters/handlers/graphql/local/common_filters/filters.go
@@ -37,6 +37,7 @@ func BuildNew(path string) graphql.InputObjectConfigFieldMap {
 					"LessThan":         &graphql.EnumValueConfig{},
 					"LessThanEqual":    &graphql.EnumValueConfig{},
 					"WithinGeoRange":   &graphql.EnumValueConfig{},
+					"IsNull":           &graphql.EnumValueConfig{},
 				},
 				Description: descriptions.WhereOperatorEnum,
 			}),

--- a/adapters/handlers/graphql/local/common_filters/parse_test.go
+++ b/adapters/handlers/graphql/local/common_filters/parse_test.go
@@ -108,6 +108,31 @@ func TestExtractFilterLike_ValueText(t *testing.T) {
 	resolver.AssertResolve(t, query)
 }
 
+func TestExtractFilterIsNull(t *testing.T) {
+	resolver := newMockResolver(t, mockParams{reportFilter: true})
+	expectedParams := &filters.LocalFilter{Root: &filters.Clause{
+		Operator: filters.OperatorIsNull,
+		On: &filters.Path{
+			Class:    schema.AssertValidClassName("SomeAction"),
+			Property: schema.AssertValidPropertyName("name"),
+		},
+		Value: &filters.Value{
+			Value: "true",
+			Type:  schema.DataTypeText,
+		},
+	}}
+
+	resolver.On("ReportFilters", expectedParams).
+		Return(test_helper.EmptyList(), nil).Once()
+
+	query := `{ SomeAction(where: {
+			path: ["name"],
+			operator: IsNull,
+			valueText: "true",
+		}) }`
+	resolver.AssertResolve(t, query)
+}
+
 func TestExtractFilterGeoLocation(t *testing.T) {
 	t.Parallel()
 

--- a/adapters/handlers/rest/embedded_spec.go
+++ b/adapters/handlers/rest/embedded_spec.go
@@ -3302,6 +3302,10 @@ func init() {
           "type": "number",
           "format": "int"
         },
+        "indexNullState": {
+          "description": "Index each object with the null state",
+          "type": "boolean"
+        },
         "indexTimestamps": {
           "description": "Index each object by its internal timestamps",
           "type": "boolean"
@@ -7476,6 +7480,10 @@ func init() {
           "description": "Asynchronous index clean up happens every n seconds",
           "type": "number",
           "format": "int"
+        },
+        "indexNullState": {
+          "description": "Index each object with the null state",
+          "type": "boolean"
         },
         "indexTimestamps": {
           "description": "Index each object by its internal timestamps",

--- a/adapters/handlers/rest/embedded_spec.go
+++ b/adapters/handlers/rest/embedded_spec.go
@@ -3849,7 +3849,8 @@ func init() {
             "GreaterThanEqual",
             "LessThan",
             "LessThanEqual",
-            "WithinGeoRange"
+            "WithinGeoRange",
+            "IsNull"
           ],
           "example": "GreaterThanEqual"
         },
@@ -8041,7 +8042,8 @@ func init() {
             "GreaterThanEqual",
             "LessThan",
             "LessThanEqual",
-            "WithinGeoRange"
+            "WithinGeoRange",
+            "IsNull"
           ],
           "example": "GreaterThanEqual"
         },

--- a/adapters/handlers/rest/filterext/parse.go
+++ b/adapters/handlers/rest/filterext/parse.go
@@ -141,7 +141,8 @@ func parseOperator(in string) (filters.Operator, error) {
 		return filters.OperatorOr, nil
 	case models.WhereFilterOperatorNot:
 		return filters.OperatorNot, nil
-
+	case models.WhereFilterOperatorIsNull:
+		return filters.OperatorIsNull, nil
 	default:
 		return -1, fmt.Errorf("unrecognized operator: %s", in)
 	}

--- a/adapters/repos/db/filters_integration_test.go
+++ b/adapters/repos/db/filters_integration_test.go
@@ -82,6 +82,7 @@ var (
 	wgr  = filters.OperatorWithinGeoRange
 	and  = filters.OperatorAnd
 	or   = filters.OperatorOr
+	null = filters.OperatorIsNull
 
 	// datatypes
 	dtInt            = schema.DataTypeInt
@@ -154,7 +155,7 @@ func testPrimitiveProps(repo *DB) func(t *testing.T) {
 			{
 				name:        "modelName != sprinter",
 				filter:      buildFilter("modelName", "sprinter", neq, dtString),
-				expectedIDs: []strfmt.UUID{carE63sID, carPoloID},
+				expectedIDs: []strfmt.UUID{carE63sID, carPoloID, carNilID},
 			},
 			{
 				name:        "modelName = spr*er (optimizable) dtString",
@@ -289,7 +290,7 @@ func testPrimitiveProps(repo *DB) func(t *testing.T) {
 			{
 				name:        "by id not equal",
 				filter:      buildFilter("id", carE63sID.String(), neq, dtString),
-				expectedIDs: []strfmt.UUID{carPoloID, carSprinterID},
+				expectedIDs: []strfmt.UUID{carPoloID, carSprinterID, carNilID},
 			},
 			{
 				name:        "by id less then equal",
@@ -304,12 +305,12 @@ func testPrimitiveProps(repo *DB) func(t *testing.T) {
 			{
 				name:        "by id greater then equal",
 				filter:      buildFilter("id", carPoloID.String(), gte, dtString),
-				expectedIDs: []strfmt.UUID{carPoloID, carSprinterID},
+				expectedIDs: []strfmt.UUID{carPoloID, carSprinterID, carNilID},
 			},
 			{
 				name:        "by id greater then",
 				filter:      buildFilter("id", carPoloID.String(), gt, dtString),
-				expectedIDs: []strfmt.UUID{carSprinterID},
+				expectedIDs: []strfmt.UUID{carSprinterID, carNilID},
 			},
 			{
 				name: "within 600km of San Francisco",
@@ -386,6 +387,16 @@ func testPrimitiveProps(repo *DB) func(t *testing.T) {
 				name:        "by color with array field tokenization multiword (2)",
 				filter:      buildFilter("colorArrayField", "dark grey", eq, dtString),
 				expectedIDs: []strfmt.UUID{},
+			},
+			{
+				name:        "by null value",
+				filter:      buildFilter("colorArrayField", true, null, dtBool),
+				expectedIDs: []strfmt.UUID{carNilID},
+			},
+			{
+				name:        "by value not null",
+				filter:      buildFilter("colorArrayField", false, null, dtBool),
+				expectedIDs: []strfmt.UUID{carE63sID, carPoloID, carSprinterID},
 			},
 		}
 
@@ -647,6 +658,7 @@ var (
 	carSprinterID strfmt.UUID = "d4c48788-7798-4bdd-bca9-5cd5012a5271"
 	carE63sID     strfmt.UUID = "62906c61-f92f-4f2c-874f-842d4fb9d80b"
 	carPoloID     strfmt.UUID = "b444e1d8-d73a-4d53-a417-8d6501c27f2e"
+	carNilID      strfmt.UUID = "b444e1d8-d73a-4d53-a417-8d6501c27f3e"
 )
 
 func mustParseTime(in string) time.Time {
@@ -712,6 +724,13 @@ var cars = []models.Object{
 			"colorField":      "dark grey",
 			"colorArrayWord":  []interface{}{"dark", "grey"},
 			"colorArrayField": []interface{}{"dark", "grey"},
+		},
+	},
+	{
+		Class: carClass.Class,
+		ID:    carNilID,
+		Properties: map[string]interface{}{
+			"modelName": "NilCar",
 		},
 	},
 }
@@ -1126,112 +1145,112 @@ func testSortProperties(repo *DB) func(t *testing.T) {
 				sort: []filters.Sort{
 					buildSortFilter([]string{"modelName"}, "asc"),
 				},
-				expectedIDs: []strfmt.UUID{carE63sID, carPoloID, carSprinterID},
+				expectedIDs: []strfmt.UUID{carE63sID, carNilID, carPoloID, carSprinterID},
 			},
 			{
 				name: "modelName desc",
 				sort: []filters.Sort{
 					buildSortFilter([]string{"modelName"}, "desc"),
 				},
-				expectedIDs: []strfmt.UUID{carSprinterID, carPoloID, carE63sID},
+				expectedIDs: []strfmt.UUID{carSprinterID, carPoloID, carNilID, carE63sID},
 			},
 			{
 				name: "horsepower asc",
 				sort: []filters.Sort{
 					buildSortFilter([]string{"horsepower"}, "asc"),
 				},
-				expectedIDs: []strfmt.UUID{carPoloID, carSprinterID, carE63sID},
+				expectedIDs: []strfmt.UUID{carNilID, carPoloID, carSprinterID, carE63sID},
 			},
 			{
 				name: "horsepower desc",
 				sort: []filters.Sort{
 					buildSortFilter([]string{"horsepower"}, "desc"),
 				},
-				expectedIDs: []strfmt.UUID{carE63sID, carSprinterID, carPoloID},
+				expectedIDs: []strfmt.UUID{carE63sID, carSprinterID, carPoloID, carNilID},
 			},
 			{
 				name: "weight asc",
 				sort: []filters.Sort{
 					buildSortFilter([]string{"weight"}, "asc"),
 				},
-				expectedIDs: []strfmt.UUID{carPoloID, carE63sID, carSprinterID},
+				expectedIDs: []strfmt.UUID{carNilID, carPoloID, carE63sID, carSprinterID},
 			},
 			{
 				name: "weight desc",
 				sort: []filters.Sort{
 					buildSortFilter([]string{"weight"}, "desc"),
 				},
-				expectedIDs: []strfmt.UUID{carSprinterID, carE63sID, carPoloID},
+				expectedIDs: []strfmt.UUID{carSprinterID, carE63sID, carPoloID, carNilID},
 			},
 			{
 				name: "released asc",
 				sort: []filters.Sort{
 					buildSortFilter([]string{"released"}, "asc"),
 				},
-				expectedIDs: []strfmt.UUID{carPoloID, carSprinterID, carE63sID},
+				expectedIDs: []strfmt.UUID{carNilID, carPoloID, carSprinterID, carE63sID},
 			},
 			{
 				name: "released desc",
 				sort: []filters.Sort{
 					buildSortFilter([]string{"released"}, "desc"),
 				},
-				expectedIDs: []strfmt.UUID{carE63sID, carSprinterID, carPoloID},
+				expectedIDs: []strfmt.UUID{carE63sID, carSprinterID, carPoloID, carNilID},
 			},
 			{
 				name: "parkedAt asc",
 				sort: []filters.Sort{
 					buildSortFilter([]string{"parkedAt"}, "asc"),
 				},
-				expectedIDs: []strfmt.UUID{carPoloID, carSprinterID, carE63sID},
+				expectedIDs: []strfmt.UUID{carPoloID, carNilID, carSprinterID, carE63sID},
 			},
 			{
 				name: "parkedAt desc",
 				sort: []filters.Sort{
 					buildSortFilter([]string{"parkedAt"}, "desc"),
 				},
-				expectedIDs: []strfmt.UUID{carE63sID, carSprinterID, carPoloID},
+				expectedIDs: []strfmt.UUID{carE63sID, carSprinterID, carPoloID, carNilID},
 			},
 			{
 				name: "contact asc",
 				sort: []filters.Sort{
 					buildSortFilter([]string{"contact"}, "asc"),
 				},
-				expectedIDs: []strfmt.UUID{carE63sID, carSprinterID, carPoloID},
+				expectedIDs: []strfmt.UUID{carNilID, carE63sID, carSprinterID, carPoloID},
 			},
 			{
 				name: "contact desc",
 				sort: []filters.Sort{
 					buildSortFilter([]string{"contact"}, "desc"),
 				},
-				expectedIDs: []strfmt.UUID{carPoloID, carSprinterID, carE63sID},
+				expectedIDs: []strfmt.UUID{carPoloID, carSprinterID, carE63sID, carNilID},
 			},
 			{
 				name: "description asc",
 				sort: []filters.Sort{
 					buildSortFilter([]string{"description"}, "asc"),
 				},
-				expectedIDs: []strfmt.UUID{carE63sID, carSprinterID, carPoloID},
+				expectedIDs: []strfmt.UUID{carNilID, carE63sID, carSprinterID, carPoloID},
 			},
 			{
 				name: "description desc",
 				sort: []filters.Sort{
 					buildSortFilter([]string{"description"}, "desc"),
 				},
-				expectedIDs: []strfmt.UUID{carPoloID, carSprinterID, carE63sID},
+				expectedIDs: []strfmt.UUID{carPoloID, carSprinterID, carE63sID, carNilID},
 			},
 			{
 				name: "colorArrayWord asc",
 				sort: []filters.Sort{
 					buildSortFilter([]string{"colorArrayWord"}, "asc"),
 				},
-				expectedIDs: []strfmt.UUID{carPoloID, carSprinterID, carE63sID},
+				expectedIDs: []strfmt.UUID{carNilID, carPoloID, carSprinterID, carE63sID},
 			},
 			{
 				name: "colorArrayWord desc",
 				sort: []filters.Sort{
 					buildSortFilter([]string{"colorArrayWord"}, "desc"),
 				},
-				expectedIDs: []strfmt.UUID{carE63sID, carSprinterID, carPoloID},
+				expectedIDs: []strfmt.UUID{carE63sID, carSprinterID, carPoloID, carNilID},
 			},
 			{
 				name: "modelName and horsepower asc",
@@ -1239,7 +1258,7 @@ func testSortProperties(repo *DB) func(t *testing.T) {
 					buildSortFilter([]string{"modelName"}, "asc"),
 					buildSortFilter([]string{"horsepower"}, "asc"),
 				},
-				expectedIDs: []strfmt.UUID{carE63sID, carPoloID, carSprinterID},
+				expectedIDs: []strfmt.UUID{carE63sID, carNilID, carPoloID, carSprinterID},
 			},
 			{
 				name: "horsepower and modelName asc",
@@ -1247,7 +1266,7 @@ func testSortProperties(repo *DB) func(t *testing.T) {
 					buildSortFilter([]string{"horsepower"}, "asc"),
 					buildSortFilter([]string{"modelName"}, "asc"),
 				},
-				expectedIDs: []strfmt.UUID{carPoloID, carSprinterID, carE63sID},
+				expectedIDs: []strfmt.UUID{carNilID, carPoloID, carSprinterID, carE63sID},
 			},
 			{
 				name: "horsepower and modelName asc invalid sort",
@@ -1278,7 +1297,7 @@ func testSortProperties(repo *DB) func(t *testing.T) {
 					for pos, concept := range res {
 						ids[pos] = concept.ID
 					}
-					assert.EqualValues(t, ids, test.expectedIDs, "ids dont match")
+					assert.EqualValues(t, test.expectedIDs, ids, "ids dont match")
 				}
 			})
 		}

--- a/adapters/repos/db/index.go
+++ b/adapters/repos/db/index.go
@@ -152,6 +152,16 @@ func (i *Index) addTimestampProperties(ctx context.Context) error {
 	return nil
 }
 
+func (i *Index) addNullStateProperty(ctx context.Context, prop *models.Property) error {
+	for name, shard := range i.Shards {
+		if err := shard.addNullState(ctx, prop); err != nil {
+			return errors.Wrapf(err, "add null state to shard %q", name)
+		}
+	}
+
+	return nil
+}
+
 func (i *Index) updateVectorIndexConfig(ctx context.Context,
 	updated schema.VectorIndexConfig,
 ) error {

--- a/adapters/repos/db/index_integration_test.go
+++ b/adapters/repos/db/index_integration_test.go
@@ -237,5 +237,6 @@ func invertedConfig() *models.InvertedIndexConfig {
 		Stopwords: &models.StopwordConfig{
 			Preset: "none",
 		},
+		IndexNullState: true,
 	}
 }

--- a/adapters/repos/db/inverted/config.go
+++ b/adapters/repos/db/inverted/config.go
@@ -44,6 +44,7 @@ func ConfigFromModel(iicm *models.InvertedIndexConfig) schema.InvertedIndexConfi
 
 	conf.CleanupIntervalSeconds = iicm.CleanupIntervalSeconds
 	conf.IndexTimestamps = iicm.IndexTimestamps
+	conf.IndexNullState = iicm.IndexNullState
 
 	if iicm.Bm25 == nil {
 		conf.BM25.K1 = float64(config.DefaultBM25k1)

--- a/adapters/repos/db/inverted/prop_value_pairs.go
+++ b/adapters/repos/db/inverted/prop_value_pairs.go
@@ -48,6 +48,11 @@ func (pv *propValuePair) fetchDocIDs(s *Searcher, limit int,
 			pv.prop = filters.InternalPropID
 			pv.hasFrequency = false
 		}
+
+		if pv.operator == filters.OperatorIsNull {
+			id += filters.InternalNullIndex
+		}
+
 		b := s.store.Bucket(id)
 
 		if b == nil && (pv.prop == filters.InternalPropCreationTimeUnix ||

--- a/adapters/repos/db/inverted/prop_value_pairs.go
+++ b/adapters/repos/db/inverted/prop_value_pairs.go
@@ -55,6 +55,11 @@ func (pv *propValuePair) fetchDocIDs(s *Searcher, limit int,
 
 		b := s.store.Bucket(id)
 
+		if b == nil && pv.operator == filters.OperatorIsNull {
+			return errors.Errorf("Nullstate must be indexed to be filterable! " +
+				"add `indexNullState: true` to the invertedIndexConfig")
+		}
+
 		if b == nil && (pv.prop == filters.InternalPropCreationTimeUnix ||
 			pv.prop == filters.InternalPropLastUpdateTimeUnix) {
 			return errors.Errorf("timestamps must be indexed to be filterable! " +

--- a/adapters/repos/db/inverted/row_reader.go
+++ b/adapters/repos/db/inverted/row_reader.go
@@ -80,6 +80,8 @@ func (rr *RowReader) Read(ctx context.Context, readFn ReadFn) error {
 		return rr.lessThan(ctx, readFn, true)
 	case filters.OperatorLike:
 		return rr.like(ctx, readFn)
+	case filters.OperatorIsNull: // we need to fetch a row with a given value (there is only nil and !nil) and can reuse equal to get the correct row
+		return rr.equal(ctx, readFn)
 	default:
 		return fmt.Errorf("operator not supported in standalone "+
 			"mode, see %s for details", notimplemented.Link)

--- a/adapters/repos/db/inverted_index_integration_test.go
+++ b/adapters/repos/db/inverted_index_integration_test.go
@@ -195,7 +195,7 @@ func TestIndexNullState_GetClass(t *testing.T) {
 
 	tests := map[string]strfmt.UUID{"filterNull": testID1, "filterNonNull": testID2}
 	for name, searchVal := range tests {
-		t.Run("test "+name+"directly on nullState property", func(t *testing.T) {
+		t.Run("test "+name+" directly on nullState property", func(t *testing.T) {
 			createTimeStringFilter := &filters.LocalFilter{
 				Root: &filters.Clause{
 					Operator: filters.OperatorEqual,
@@ -204,7 +204,7 @@ func TestIndexNullState_GetClass(t *testing.T) {
 						Property: "name_nullState",
 					},
 					Value: &filters.Value{
-						Value: searchVal == testID1,
+						Value: searchVal != testID1,
 						Type:  "boolean",
 					},
 				},

--- a/adapters/repos/db/inverted_index_integration_test.go
+++ b/adapters/repos/db/inverted_index_integration_test.go
@@ -34,7 +34,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestIndexByTimestamps_AddClass(t *testing.T) {
+func TestIndexByTimestampsNullState_AddClass(t *testing.T) {
 	rand.Seed(time.Now().UnixNano())
 	dirName := t.TempDir()
 
@@ -65,6 +65,7 @@ func TestIndexByTimestamps_AddClass(t *testing.T) {
 					Preset: "none",
 				},
 				IndexTimestamps: true,
+				IndexNullState:  true,
 			},
 			Properties: []*models.Property{
 				{
@@ -93,6 +94,10 @@ func TestIndexByTimestamps_AddClass(t *testing.T) {
 
 				updateHashBucket := shd.store.Bucket("hash_property__lastUpdateTimeUnix")
 				assert.NotNil(t, updateHashBucket, "hash_property__creationTimeUnix bucket not found")
+
+				assert.NotNil(t, shd.store.Bucket("property_name"+filters.InternalNullIndex), "property_name"+filters.InternalNullIndex+"bucket not found")
+				assert.NotNil(t, shd.store.Bucket("hash_property_name"+filters.InternalNullIndex), "hash_property_name"+filters.InternalNullIndex+"bucket not found")
+
 			}
 		}
 	})

--- a/adapters/repos/db/inverted_index_integration_test.go
+++ b/adapters/repos/db/inverted_index_integration_test.go
@@ -38,9 +38,32 @@ func TestIndexByTimestampsNullState_AddClass(t *testing.T) {
 	rand.Seed(time.Now().UnixNano())
 	dirName := t.TempDir()
 
+	class := &models.Class{
+		Class:             "TestClass",
+		VectorIndexConfig: hnsw.NewDefaultUserConfig(),
+		InvertedIndexConfig: &models.InvertedIndexConfig{
+			CleanupIntervalSeconds: 60,
+			Stopwords: &models.StopwordConfig{
+				Preset: "none",
+			},
+			IndexTimestamps: true,
+			IndexNullState:  true,
+		},
+		Properties: []*models.Property{
+			{
+				Name:         "name",
+				DataType:     []string{"string"},
+				Tokenization: "word",
+			},
+		},
+	}
 	shardState := singleShardState()
 	logger := logrus.New()
-	schemaGetter := &fakeSchemaGetter{shardState: shardState}
+	schemaGetter := &fakeSchemaGetter{shardState: shardState, schema: schema.Schema{
+		Objects: &models.Schema{
+			Classes: []*models.Class{class},
+		},
+	}}
 	repo := New(logger, Config{
 		FlushIdleAfter:            60,
 		RootPath:                  dirName,
@@ -56,26 +79,6 @@ func TestIndexByTimestampsNullState_AddClass(t *testing.T) {
 	migrator := NewMigrator(repo, logger)
 
 	t.Run("add class", func(t *testing.T) {
-		class := &models.Class{
-			Class:             "TestClass",
-			VectorIndexConfig: hnsw.NewDefaultUserConfig(),
-			InvertedIndexConfig: &models.InvertedIndexConfig{
-				CleanupIntervalSeconds: 60,
-				Stopwords: &models.StopwordConfig{
-					Preset: "none",
-				},
-				IndexTimestamps: true,
-				IndexNullState:  true,
-			},
-			Properties: []*models.Property{
-				{
-					Name:         "name",
-					DataType:     []string{"string"},
-					Tokenization: "word",
-				},
-			},
-		}
-
 		err := migrator.AddClass(context.Background(), class, schemaGetter.shardState)
 		require.Nil(t, err)
 	})
@@ -101,6 +104,122 @@ func TestIndexByTimestampsNullState_AddClass(t *testing.T) {
 			}
 		}
 	})
+
+	t.Run("Add Objects", func(t *testing.T) {
+		testID1 := strfmt.UUID("a0b55b05-bc5b-4cc9-b646-1452d1390a62")
+		objWithProperty := &models.Object{
+			ID:         testID1,
+			Class:      "TestClass",
+			Properties: map[string]interface{}{"name": "objectarooni"},
+		}
+		vec := []float32{1, 2, 3}
+		require.Nil(t, repo.PutObject(context.Background(), objWithProperty, vec))
+
+		testID2 := strfmt.UUID("a0b55b05-bc5b-4cc9-b646-1452d1390a63")
+		objWithoutProperty := &models.Object{
+			ID:         testID2,
+			Class:      "TestClass",
+			Properties: map[string]interface{}{"name": nil},
+		}
+		require.Nil(t, repo.PutObject(context.Background(), objWithoutProperty, vec))
+	})
+}
+
+func TestIndexNullState_GetClass(t *testing.T) {
+	rand.Seed(time.Now().UnixNano())
+	dirName := t.TempDir()
+
+	class := &models.Class{
+		Class:             "TestClass",
+		VectorIndexConfig: hnsw.NewDefaultUserConfig(),
+		InvertedIndexConfig: &models.InvertedIndexConfig{
+			CleanupIntervalSeconds: 60,
+			IndexTimestamps:        true,
+			IndexNullState:         true,
+		},
+		Properties: []*models.Property{
+			{
+				Name:     "name",
+				DataType: []string{"string"},
+			},
+			{
+				Name:     "number array",
+				DataType: []string{"number[]"},
+			},
+		},
+	}
+
+	shardState := singleShardState()
+	logger := logrus.New()
+	schemaGetter := &fakeSchemaGetter{shardState: shardState, schema: schema.Schema{
+		Objects: &models.Schema{
+			Classes: []*models.Class{class},
+		},
+	}}
+	repo := New(logger, Config{
+		RootPath:                  dirName,
+		QueryMaximumResults:       10000,
+		DiskUseWarningPercentage:  config.DefaultDiskUseWarningPercentage,
+		DiskUseReadOnlyPercentage: config.DefaultDiskUseReadonlyPercentage,
+		MaxImportGoroutinesFactor: 1,
+	}, &fakeRemoteClient{}, &fakeNodeResolver{}, nil)
+	repo.SetSchemaGetter(schemaGetter)
+	err := repo.WaitForStartup(testCtx())
+	require.Nil(t, err)
+	defer repo.Shutdown(testCtx())
+	migrator := NewMigrator(repo, logger)
+
+	require.Nil(t, migrator.AddClass(context.Background(), class, schemaGetter.shardState))
+
+	testID1 := strfmt.UUID("a0b55b05-bc5b-4cc9-b646-1452d1390a62")
+	objWithProperty := &models.Object{
+		ID:         testID1,
+		Class:      "TestClass",
+		Properties: map[string]interface{}{"name": "objectarooni", "name array": []float64{0.5, 1.4}},
+	}
+	require.Nil(t, repo.PutObject(context.Background(), objWithProperty, []float32{1, 2, 3}))
+
+	testID2 := strfmt.UUID("a0b55b05-bc5b-4cc9-b646-1452d1390a63")
+	objWithoutProperty := &models.Object{
+		ID:         testID2,
+		Class:      "TestClass",
+		Properties: map[string]interface{}{"name": nil, "name array": nil},
+	}
+	require.Nil(t, repo.PutObject(context.Background(), objWithoutProperty, []float32{1, 2, 4}))
+
+	require.Equal(t, 1, len(migrator.db.indices["testclass"].Shards))
+	for _, shd := range migrator.db.indices["testclass"].Shards {
+		bucket := shd.store.Bucket("property_name" + filters.InternalNullIndex)
+		require.NotNil(t, bucket)
+	}
+
+	tests := map[string]strfmt.UUID{"filterNull": testID1, "filterNonNull": testID2}
+	for name, searchVal := range tests {
+		t.Run("test "+name+"directly on nullState property", func(t *testing.T) {
+			createTimeStringFilter := &filters.LocalFilter{
+				Root: &filters.Clause{
+					Operator: filters.OperatorEqual,
+					On: &filters.Path{
+						Class:    "TestClass",
+						Property: "name_nullState",
+					},
+					Value: &filters.Value{
+						Value: searchVal == testID1,
+						Type:  "boolean",
+					},
+				},
+			}
+
+			res1, err := repo.ClassSearch(context.Background(), traverser.GetParams{
+				ClassName:  "TestClass",
+				Pagination: &filters.Pagination{Limit: 10},
+				Filters:    createTimeStringFilter,
+			})
+			require.Nil(t, err)
+			assert.Len(t, res1, 1)
+			assert.Equal(t, searchVal, res1[0].ID)
+		})
+	}
 }
 
 func TestIndexByTimestamps_GetClass(t *testing.T) {

--- a/adapters/repos/db/migrator.go
+++ b/adapters/repos/db/migrator.go
@@ -74,6 +74,14 @@ func (m *Migrator) AddClass(ctx context.Context, class *models.Class,
 		if err != nil {
 			return errors.Wrapf(err, "extend idx '%s' with property", idx.ID())
 		}
+
+		if class.InvertedIndexConfig.IndexNullState {
+			err = idx.addNullStateProperty(ctx, prop)
+			if err != nil {
+				return errors.Wrapf(err, "extend idx '%s' with nullstate properties", idx.ID())
+			}
+		}
+
 	}
 
 	m.db.indices[idx.ID()] = idx

--- a/adapters/repos/db/shard.go
+++ b/adapters/repos/db/shard.go
@@ -341,6 +341,28 @@ func (s *Shard) addTimestampProperties(ctx context.Context) error {
 	return nil
 }
 
+func (s *Shard) addNullState(ctx context.Context, prop *models.Property) error {
+	if s.isReadOnly() {
+		return storagestate.ErrStatusReadOnly
+	}
+
+	err := s.store.CreateOrLoadBucket(ctx,
+		helpers.BucketFromPropNameLSM(prop.Name+filters.InternalNullIndex),
+		lsmkv.WithStrategy(lsmkv.StrategySetCollection))
+	if err != nil {
+		return err
+	}
+
+	err = s.store.CreateOrLoadBucket(ctx,
+		helpers.HashBucketFromPropNameLSM(prop.Name+filters.InternalNullIndex),
+		lsmkv.WithStrategy(lsmkv.StrategyReplace))
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
 func (s *Shard) addCreationTimeUnixProperty(ctx context.Context) error {
 	err := s.store.CreateOrLoadBucket(ctx,
 		helpers.BucketFromPropNameLSM(filters.InternalPropCreationTimeUnix),

--- a/adapters/repos/db/shard_init_properties.go
+++ b/adapters/repos/db/shard_init_properties.go
@@ -52,6 +52,15 @@ func (s *Shard) initProperties() error {
 						return errors.Wrapf(err, "init property %s", prop.Name)
 					}
 				}
+				if s.index.invertedIndexConfig.IndexNullState {
+					eg.Go(func() error {
+						if err := s.addNullState(context.TODO(), prop); err != nil {
+							return errors.Wrapf(err, "init property %s null state", prop.Name)
+						}
+
+						return nil
+					})
+				}
 
 				return nil
 			})

--- a/adapters/repos/db/shard_write_delete.go
+++ b/adapters/repos/db/shard_write_delete.go
@@ -86,7 +86,7 @@ func (s *Shard) cleanupInvertedIndexOnDelete(previous []byte, docID uint64) erro
 		return errors.Wrap(err, "unmarshal previous object")
 	}
 
-	previousInvertProps, err := s.analyzeObject(previousObject)
+	previousInvertProps, _, err := s.analyzeObject(previousObject)
 	if err != nil {
 		return errors.Wrap(err, "analyze previous object")
 	}

--- a/adapters/repos/db/shard_write_inverted_lsm.go
+++ b/adapters/repos/db/shard_write_inverted_lsm.go
@@ -54,11 +54,15 @@ func (s *Shard) extendInvertedIndicesLSM(props []inverted.Property, nilProps []s
 			}
 		}
 
-		// add non-nil properties to the nullstate inverted index
-		if s.index.invertedIndexConfig.IndexNullState && prop.Name[0] != '_' { // do not add "internal" properties (_id etc.)
-			if err := s.addIndexedNullStateToProps(docID, prop.Name, false); err != nil {
-				return errors.Wrap(err, "add indexed null state")
-			}
+		// add non-nil properties to the null-state inverted index, but skip internal properties (__meta_count, _id etc)
+		if (len(prop.Name) > 12 && prop.Name[len(prop.Name)-12:] == "__meta_count") ||
+			prop.Name[0] == '_' ||
+			!s.index.invertedIndexConfig.IndexNullState {
+			continue
+		}
+
+		if err := s.addIndexedNullStateToProps(docID, prop.Name, false); err != nil {
+			return errors.Wrap(err, "add indexed null state")
 		}
 	}
 

--- a/adapters/repos/db/shard_write_inverted_lsm.go
+++ b/adapters/repos/db/shard_write_inverted_lsm.go
@@ -15,6 +15,8 @@ import (
 	"encoding/binary"
 	"math"
 
+	"github.com/semi-technologies/weaviate/entities/filters"
+
 	"github.com/pkg/errors"
 	"github.com/semi-technologies/weaviate/adapters/repos/db/helpers"
 	"github.com/semi-technologies/weaviate/adapters/repos/db/inverted"
@@ -31,7 +33,7 @@ func (s *Shard) extendInvertedIndicesLSM(props []inverted.Property,
 		}
 
 		hashBucket := s.store.Bucket(helpers.HashBucketFromPropNameLSM(prop.Name))
-		if b == nil {
+		if hashBucket == nil {
 			return errors.Errorf("no hash bucket for prop '%s' found", prop.Name)
 		}
 
@@ -51,9 +53,53 @@ func (s *Shard) extendInvertedIndicesLSM(props []inverted.Property,
 				}
 			}
 		}
+
+		if propIsNil := prop.Items == nil; propIsNil && s.index.invertedIndexConfig.IndexNullState {
+			bNullState := s.store.Bucket(helpers.BucketFromPropNameLSM(prop.Name + filters.InternalNullIndex))
+			if bNullState == nil {
+				return errors.Errorf("no bucket for nil prop '%s' found", prop.Name+filters.InternalNullIndex)
+			}
+
+			hashBucketNullState := s.store.Bucket(helpers.HashBucketFromPropNameLSM(prop.Name + filters.InternalNullIndex))
+			if b == nil {
+				return errors.Errorf("no nil-hash bucket for prop '%s' found", prop.Name+filters.InternalNullIndex)
+			}
+
+			err := s.addIndexedNullStateToProps(bNullState, hashBucketNullState, propIsNil, docID)
+			if err != nil {
+				return errors.Wrap(err, "add indexed null state")
+			}
+		}
 	}
 
 	return nil
+}
+
+func (s *Shard) addIndexedNullStateToProps(b, hashBucket *lsmkv.Bucket,
+	isNil bool, docID uint64,
+) error {
+	if b.Strategy() != lsmkv.StrategySetCollection {
+		panic("prop has no frequency, but bucket does not have 'Set' strategy")
+	}
+
+	hash, err := s.generateRowHash()
+	if err != nil {
+		return err
+	}
+
+	var key uint8
+	if isNil {
+		key = uint8(filters.InternalNullState)
+	} else {
+		key = uint8(filters.InternalNotNullState)
+	}
+	if err := hashBucket.Put([]byte{key}, hash); err != nil {
+		return err
+	}
+	docIDBytes := make([]byte, 8)
+	binary.LittleEndian.PutUint64(docIDBytes, docID)
+
+	return b.SetAdd([]byte{key}, [][]byte{docIDBytes})
 }
 
 func (s *Shard) extendInvertedIndexItemWithFrequencyLSM(b, hashBucket *lsmkv.Bucket,

--- a/adapters/repos/db/shard_write_put.go
+++ b/adapters/repos/db/shard_write_put.go
@@ -219,7 +219,7 @@ func (s *Shard) upsertObjectDataLSM(bucket *lsmkv.Bucket, id []byte, data []byte
 func (s *Shard) updateInvertedIndexLSM(object *storobj.Object,
 	status objectInsertStatus, previous []byte,
 ) error {
-	props, err := s.analyzeObject(object)
+	props, nilprops, err := s.analyzeObject(object)
 	if err != nil {
 		return errors.Wrap(err, "analyze next object")
 	}
@@ -239,7 +239,7 @@ func (s *Shard) updateInvertedIndexLSM(object *storobj.Object,
 
 	before := time.Now()
 
-	err = s.extendInvertedIndicesLSM(props, status.docID)
+	err = s.extendInvertedIndicesLSM(props, nilprops, status.docID)
 	if err != nil {
 		return errors.Wrap(err, "put inverted indices props")
 	}
@@ -299,7 +299,7 @@ func (s *Shard) updateInvertedIndexCleanupOldLSM(status objectInsertStatus,
 		return errors.Wrap(err, "unmarshal previous object")
 	}
 
-	previousInvertProps, err := s.analyzeObject(previousObject)
+	previousInvertProps, _, err := s.analyzeObject(previousObject)
 	if err != nil {
 		return errors.Wrap(err, "analyze previous object")
 	}

--- a/entities/filters/consts.go
+++ b/entities/filters/consts.go
@@ -14,6 +14,12 @@ package filters
 const (
 	InternalPropBackwardsCompatID  = "id"
 	InternalPropID                 = "_id"
+	InternalNullIndex              = "_nullState"
 	InternalPropCreationTimeUnix   = "_creationTimeUnix"
 	InternalPropLastUpdateTimeUnix = "_lastUpdateTimeUnix"
+)
+
+const (
+	InternalNullState = iota
+	InternalNotNullState
 )

--- a/entities/filters/consts.go
+++ b/entities/filters/consts.go
@@ -19,7 +19,8 @@ const (
 	InternalPropLastUpdateTimeUnix = "_lastUpdateTimeUnix"
 )
 
+// NotNullState is encoded as 0, so it can be read with the IsNull operator and value false.
 const (
-	InternalNullState = iota
-	InternalNotNullState
+	InternalNotNullState = iota
+	InternalNullState
 )

--- a/entities/filters/filter_validator_test.go
+++ b/entities/filters/filter_validator_test.go
@@ -1,0 +1,61 @@
+package filters
+
+import (
+	"testing"
+
+	"github.com/semi-technologies/weaviate/entities/models"
+	"github.com/semi-technologies/weaviate/entities/schema"
+	"github.com/stretchr/testify/require"
+)
+
+func TestValidateIsNullOperator(t *testing.T) {
+	tests := []struct {
+		name       string
+		schemaType schema.DataType
+		valid      bool
+	}{
+		{
+			name:       "Valid datatype",
+			schemaType: schema.DataTypeBoolean,
+			valid:      true,
+		},
+		{
+			name:       "Invalid datatype (array)",
+			schemaType: schema.DataTypeBooleanArray,
+			valid:      false,
+		},
+		{
+			name:       "Invalid datatype (text)",
+			schemaType: schema.DataTypeText,
+			valid:      false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			sch := schema.Schema{Objects: &models.Schema{
+				Classes: []*models.Class{
+					{
+						Class: "Car",
+						Properties: []*models.Property{
+							{Name: "modelName", DataType: []string{"string"}},
+							{Name: "manufacturerName", DataType: []string{"string"}},
+							{Name: "horsepower", DataType: []string{"int"}},
+						},
+					},
+				},
+			}}
+			cl := Clause{
+				Operator: OperatorIsNull,
+				Value:    &Value{Value: true, Type: tt.schemaType},
+				On:       &Path{Class: "Car", Property: "horsepower"},
+			}
+			err := validateClause(sch, &cl)
+			if tt.valid {
+				require.Nil(t, err)
+			} else {
+				require.NotNil(t, err)
+			}
+		})
+	}
+}

--- a/entities/filters/filters.go
+++ b/entities/filters/filters.go
@@ -21,17 +21,18 @@ import (
 type Operator int
 
 const (
-	OperatorEqual            Operator = 1
-	OperatorNotEqual         Operator = 2
-	OperatorGreaterThan      Operator = 3
-	OperatorGreaterThanEqual Operator = 4
-	OperatorLessThan         Operator = 5
-	OperatorLessThanEqual    Operator = 6
-	OperatorAnd              Operator = 7
-	OperatorOr               Operator = 8
-	OperatorNot              Operator = 9
-	OperatorWithinGeoRange   Operator = 10
-	OperatorLike             Operator = 11
+	OperatorEqual Operator = iota + 1
+	OperatorNotEqual
+	OperatorGreaterThan
+	OperatorGreaterThanEqual
+	OperatorLessThan
+	OperatorLessThanEqual
+	OperatorAnd
+	OperatorOr
+	OperatorNot
+	OperatorWithinGeoRange
+	OperatorLike
+	OperatorIsNull
 )
 
 func (o Operator) OnValue() bool {
@@ -43,7 +44,8 @@ func (o Operator) OnValue() bool {
 		OperatorLessThan,
 		OperatorLessThanEqual,
 		OperatorWithinGeoRange,
-		OperatorLike:
+		OperatorLike,
+		OperatorIsNull:
 		return true
 	default:
 		return false
@@ -74,6 +76,8 @@ func (o Operator) Name() string {
 		return "WithinGeoRange"
 	case OperatorLike:
 		return "Like"
+	case OperatorIsNull:
+		return "IsNull"
 	default:
 		panic("Unknown operator")
 	}

--- a/entities/filters/filters_validator.go
+++ b/entities/filters/filters_validator.go
@@ -63,6 +63,15 @@ func validateClause(sch schema.Schema, clause *Clause) error {
 		return err
 	}
 
+	if clause.Operator == OperatorIsNull {
+		if clause.Value.Type == schema.DataTypeBoolean {
+			return nil
+		} else {
+			errors.Errorf("operator IsNull requires a booleanValue, got %q instead",
+				valueNameFromDataType(clause.Value.Type))
+		}
+	}
+
 	if schema.IsRefDataType(prop.DataType) {
 		// bit of an edge case, directly on refs (i.e. not on a primitive prop of a
 		// ref) we only allow valueInt which is what's used to count references

--- a/entities/models/inverted_index_config.go
+++ b/entities/models/inverted_index_config.go
@@ -37,7 +37,7 @@ type InvertedIndexConfig struct {
 
 	// stopwords
 	Stopwords      *StopwordConfig `json:"stopwords,omitempty"`
-	IndexNullState bool            `json:"indexnullstate"`
+	IndexNullState bool            `json:"indexNullState"`
 }
 
 // Validate validates this inverted index config

--- a/entities/models/inverted_index_config.go
+++ b/entities/models/inverted_index_config.go
@@ -26,7 +26,6 @@ import (
 //
 // swagger:model InvertedIndexConfig
 type InvertedIndexConfig struct {
-
 	// bm25
 	Bm25 *BM25Config `json:"bm25,omitempty"`
 
@@ -37,7 +36,8 @@ type InvertedIndexConfig struct {
 	IndexTimestamps bool `json:"indexTimestamps,omitempty"`
 
 	// stopwords
-	Stopwords *StopwordConfig `json:"stopwords,omitempty"`
+	Stopwords      *StopwordConfig `json:"stopwords,omitempty"`
+	IndexNullState bool            `json:"indexnullstate"`
 }
 
 // Validate validates this inverted index config
@@ -59,7 +59,6 @@ func (m *InvertedIndexConfig) Validate(formats strfmt.Registry) error {
 }
 
 func (m *InvertedIndexConfig) validateBm25(formats strfmt.Registry) error {
-
 	if swag.IsZero(m.Bm25) { // not required
 		return nil
 	}
@@ -77,7 +76,6 @@ func (m *InvertedIndexConfig) validateBm25(formats strfmt.Registry) error {
 }
 
 func (m *InvertedIndexConfig) validateStopwords(formats strfmt.Registry) error {
-
 	if swag.IsZero(m.Stopwords) { // not required
 		return nil
 	}

--- a/entities/models/inverted_index_config.go
+++ b/entities/models/inverted_index_config.go
@@ -36,8 +36,7 @@ type InvertedIndexConfig struct {
 	IndexTimestamps bool `json:"indexTimestamps,omitempty"`
 
 	// stopwords
-	Stopwords      *StopwordConfig `json:"stopwords,omitempty"`
-	IndexNullState bool            `json:"indexNullState"`
+	Stopwords *StopwordConfig `json:"stopwords,omitempty"`
 }
 
 // Validate validates this inverted index config

--- a/entities/models/inverted_index_config.go
+++ b/entities/models/inverted_index_config.go
@@ -32,6 +32,9 @@ type InvertedIndexConfig struct {
 	// Asynchronous index clean up happens every n seconds
 	CleanupIntervalSeconds int64 `json:"cleanupIntervalSeconds,omitempty"`
 
+	// Index each object with the null state
+	IndexNullState bool `json:"indexNullState,omitempty"`
+
 	// Index each object by its internal timestamps
 	IndexTimestamps bool `json:"indexTimestamps,omitempty"`
 

--- a/entities/models/where_filter.go
+++ b/entities/models/where_filter.go
@@ -30,12 +30,11 @@ import (
 //
 // swagger:model WhereFilter
 type WhereFilter struct {
-
 	// combine multiple where filters, requires 'And' or 'Or' operator
 	Operands []*WhereFilter `json:"operands"`
 
 	// operator to use
-	// Enum: [And Or Equal Like Not NotEqual GreaterThan GreaterThanEqual LessThan LessThanEqual WithinGeoRange]
+	// Enum: [And Or Equal Like Not NotEqual GreaterThan GreaterThanEqual LessThan LessThanEqual WithinGeoRange IsNull]
 	Operator string `json:"operator,omitempty"`
 
 	// path to the property currently being filtered
@@ -86,7 +85,6 @@ func (m *WhereFilter) Validate(formats strfmt.Registry) error {
 }
 
 func (m *WhereFilter) validateOperands(formats strfmt.Registry) error {
-
 	if swag.IsZero(m.Operands) { // not required
 		return nil
 	}
@@ -114,7 +112,7 @@ var whereFilterTypeOperatorPropEnum []interface{}
 
 func init() {
 	var res []string
-	if err := json.Unmarshal([]byte(`["And","Or","Equal","Like","Not","NotEqual","GreaterThan","GreaterThanEqual","LessThan","LessThanEqual","WithinGeoRange"]`), &res); err != nil {
+	if err := json.Unmarshal([]byte(`["And","Or","Equal","Like","Not","NotEqual","GreaterThan","GreaterThanEqual","LessThan","LessThanEqual","WithinGeoRange","IsNull"]`), &res); err != nil {
 		panic(err)
 	}
 	for _, v := range res {
@@ -156,6 +154,9 @@ const (
 
 	// WhereFilterOperatorWithinGeoRange captures enum value "WithinGeoRange"
 	WhereFilterOperatorWithinGeoRange string = "WithinGeoRange"
+
+	// WhereFilterOperatorIsNull captures enum value "IsNull"
+	WhereFilterOperatorIsNull string = "IsNull"
 )
 
 // prop value enum
@@ -167,7 +168,6 @@ func (m *WhereFilter) validateOperatorEnum(path, location string, value string) 
 }
 
 func (m *WhereFilter) validateOperator(formats strfmt.Registry) error {
-
 	if swag.IsZero(m.Operator) { // not required
 		return nil
 	}
@@ -181,7 +181,6 @@ func (m *WhereFilter) validateOperator(formats strfmt.Registry) error {
 }
 
 func (m *WhereFilter) validateValueGeoRange(formats strfmt.Registry) error {
-
 	if swag.IsZero(m.ValueGeoRange) { // not required
 		return nil
 	}

--- a/entities/schema/inverted_index_config.go
+++ b/entities/schema/inverted_index_config.go
@@ -16,6 +16,7 @@ type InvertedIndexConfig struct {
 	BM25                   BM25Config
 	Stopwords              StopwordConfig
 	IndexTimestamps        bool
+	IndexNullState         bool
 }
 
 type BM25Config struct {

--- a/openapi-specs/schema.json
+++ b/openapi-specs/schema.json
@@ -346,6 +346,10 @@
         "indexTimestamps":{
           "description": "Index each object by its internal timestamps",
           "type": "boolean"
+        },
+        "indexNullState":{
+          "description": "Index each object with the null state",
+          "type": "boolean"
         }
       },
       "type": "object"

--- a/openapi-specs/schema.json
+++ b/openapi-specs/schema.json
@@ -1347,7 +1347,8 @@
             "GreaterThanEqual",
             "LessThan",
             "LessThanEqual",
-            "WithinGeoRange"
+            "WithinGeoRange",
+            "IsNull"
           ],
           "example": "GreaterThanEqual"
         },

--- a/test/acceptance/graphql_resolvers/setup_test.go
+++ b/test/acceptance/graphql_resolvers/setup_test.go
@@ -129,6 +129,7 @@ func addTestSchema(t *testing.T) {
 				"vectorizeClassName": true,
 			},
 		},
+		InvertedIndexConfig: &models.InvertedIndexConfig{IndexNullState: true, IndexTimestamps: true},
 		Properties: []*models.Property{
 			{
 				Name:     "name",

--- a/test/acceptance/schema/get_schema_without_client_test.go
+++ b/test/acceptance/schema/get_schema_without_client_test.go
@@ -73,7 +73,6 @@ func testGetSchemaWithoutClient(t *testing.T) {
 						"additions": nil,
 						"removals":  nil,
 					},
-					"indexNullState": false,
 				},
 				"moduleConfig": map[string]interface{}{
 					"text2vec-contextionary": map[string]interface{}{

--- a/test/acceptance/schema/get_schema_without_client_test.go
+++ b/test/acceptance/schema/get_schema_without_client_test.go
@@ -73,6 +73,7 @@ func testGetSchemaWithoutClient(t *testing.T) {
 						"additions": nil,
 						"removals":  nil,
 					},
+					"indexNullState": false,
 				},
 				"moduleConfig": map[string]interface{}{
 					"text2vec-contextionary": map[string]interface{}{


### PR DESCRIPTION
### What's being changed:

Adds new operator "IsNull" and everything that is needed to filter for objects where a given property is nil.

[Tests have passed](https://app.travis-ci.com/github/semi-technologies/weaviate/builds/255902735), travis seems to be slow again.

### Review checklist

- [x] Documentation has been updated, if necessary. Link to changed documentation: https://github.com/semi-technologies/weaviate-io/pull/204
- [x] Chaos pipeline run or not necessary. Link to pipeline: https://app.travis-ci.com/github/semi-technologies/weaviate-chaos-engineering/builds/255867233
- [x] All new code is covered by tests where it is reasonable.
- [x] Performance tests have been run or not necessary.
