### PR TITLE
Fix potential SEGFAULT on concurrent nested filter and hash bucket compaction

### DIFF
--- a/adapters/handlers/rest/configure_api.go
+++ b/adapters/handlers/rest/configure_api.go
@@ -155,6 +155,7 @@ func configureAPI(api *operations.WeaviateAPI) http.Handler {
 	// TODO: configure http transport for efficient intra-cluster comm
 	remoteIndexClient := clients.NewRemoteIndex(clusterHttpClient)
 	repo := db.New(appState.Logger, db.Config{
+		FlushIdleAfter:            appState.ServerConfig.Config.Persistence.FlushIdleMemtablesAfter,
 		RootPath:                  appState.ServerConfig.Config.Persistence.DataPath,
 		QueryLimit:                appState.ServerConfig.Config.QueryDefaults.Limit,
 		QueryMaximumResults:       appState.ServerConfig.Config.QueryMaximumResults,

--- a/adapters/repos/db/aggregations_integration_test.go
+++ b/adapters/repos/db/aggregations_integration_test.go
@@ -47,7 +47,6 @@ func Test_Aggregations(t *testing.T) {
 		DiskUseWarningPercentage:  config.DefaultDiskUseWarningPercentage,
 		DiskUseReadOnlyPercentage: config.DefaultDiskUseReadonlyPercentage,
 		MaxImportGoroutinesFactor: 1,
-		FlushIdleAfter:            60,
 	}, &fakeRemoteClient{},
 		&fakeNodeResolver{}, nil)
 	repo.SetSchemaGetter(schemaGetter)

--- a/adapters/repos/db/aggregations_integration_test.go
+++ b/adapters/repos/db/aggregations_integration_test.go
@@ -41,11 +41,13 @@ func Test_Aggregations(t *testing.T) {
 	logger := logrus.New()
 	schemaGetter := &fakeSchemaGetter{shardState: shardState}
 	repo := New(logger, Config{
+		FlushIdleAfter:            60,
 		RootPath:                  dirName,
 		QueryMaximumResults:       10000,
 		DiskUseWarningPercentage:  config.DefaultDiskUseWarningPercentage,
 		DiskUseReadOnlyPercentage: config.DefaultDiskUseReadonlyPercentage,
 		MaxImportGoroutinesFactor: 1,
+		FlushIdleAfter:            60,
 	}, &fakeRemoteClient{},
 		&fakeNodeResolver{}, nil)
 	repo.SetSchemaGetter(schemaGetter)
@@ -86,6 +88,7 @@ func Test_Aggregations_MultiShard(t *testing.T) {
 	logger := logrus.New()
 	schemaGetter := &fakeSchemaGetter{shardState: shardState}
 	repo := New(logger, Config{
+		FlushIdleAfter:            60,
 		RootPath:                  dirName,
 		QueryMaximumResults:       10000,
 		DiskUseWarningPercentage:  config.DefaultDiskUseWarningPercentage,

--- a/adapters/repos/db/backup_integration_test.go
+++ b/adapters/repos/db/backup_integration_test.go
@@ -209,6 +209,7 @@ func setupTestDB(t *testing.T, rootDir string, classes ...*models.Class) *DB {
 
 	schemaGetter := &fakeSchemaGetter{shardState: singleShardState()}
 	db := New(logger, Config{
+		FlushIdleAfter:            60,
 		RootPath:                  rootDir,
 		QueryMaximumResults:       10,
 		DiskUseWarningPercentage:  config.DefaultDiskUseWarningPercentage,

--- a/adapters/repos/db/batch_integration_test.go
+++ b/adapters/repos/db/batch_integration_test.go
@@ -45,6 +45,7 @@ func TestBatchPutObjects(t *testing.T) {
 	logger := logrus.New()
 	schemaGetter := &fakeSchemaGetter{shardState: singleShardState()}
 	repo := New(logger, Config{
+		FlushIdleAfter:            60,
 		RootPath:                  dirName,
 		QueryMaximumResults:       10000,
 		DiskUseWarningPercentage:  config.DefaultDiskUseWarningPercentage,
@@ -72,6 +73,7 @@ func TestBatchDeleteObjects(t *testing.T) {
 	logger := logrus.New()
 	schemaGetter := &fakeSchemaGetter{shardState: singleShardState()}
 	repo := New(logger, Config{
+		FlushIdleAfter:            60,
 		RootPath:                  dirName,
 		QueryMaximumResults:       10000,
 		DiskUseWarningPercentage:  config.DefaultDiskUseWarningPercentage,
@@ -98,6 +100,7 @@ func TestBatchDeleteObjects_Journey(t *testing.T) {
 	logger := logrus.New()
 	schemaGetter := &fakeSchemaGetter{shardState: singleShardState()}
 	repo := New(logger, Config{
+		FlushIdleAfter:            60,
 		RootPath:                  dirName,
 		QueryMaximumResults:       queryMaximumResults,
 		DiskUseWarningPercentage:  config.DefaultDiskUseWarningPercentage,

--- a/adapters/repos/db/batch_reference_integration_test.go
+++ b/adapters/repos/db/batch_reference_integration_test.go
@@ -43,6 +43,7 @@ func Test_AddingReferencesInBatches(t *testing.T) {
 	logger := logrus.New()
 	schemaGetter := &fakeSchemaGetter{shardState: singleShardState()}
 	repo := New(logger, Config{
+		FlushIdleAfter:            60,
 		RootPath:                  dirName,
 		QueryMaximumResults:       10000,
 		DiskUseWarningPercentage:  config.DefaultDiskUseWarningPercentage,

--- a/adapters/repos/db/classification_integration_test.go
+++ b/adapters/repos/db/classification_integration_test.go
@@ -41,6 +41,7 @@ func TestClassifications(t *testing.T) {
 	logger := logrus.New()
 	schemaGetter := &fakeSchemaGetter{shardState: singleShardState()}
 	repo := New(logger, Config{
+		FlushIdleAfter:            60,
 		RootPath:                  dirName,
 		QueryMaximumResults:       10000,
 		DiskUseWarningPercentage:  config.DefaultDiskUseWarningPercentage,

--- a/adapters/repos/db/clusterintegrationtest/cluster_integration_test.go
+++ b/adapters/repos/db/clusterintegrationtest/cluster_integration_test.go
@@ -707,6 +707,7 @@ func (n *node) init(numberOfNodes int, dirName string, shardStateRaw []byte,
 
 	client := clients.NewRemoteIndex(&http.Client{})
 	n.repo = db.New(logger, db.Config{
+		FlushIdleAfter:            60,
 		RootPath:                  localDir,
 		QueryMaximumResults:       10000,
 		DiskUseWarningPercentage:  config.DefaultDiskUseWarningPercentage,

--- a/adapters/repos/db/crud_deletion_integration_test.go
+++ b/adapters/repos/db/crud_deletion_integration_test.go
@@ -38,6 +38,7 @@ func TestDeleteJourney(t *testing.T) {
 	logger := logrus.New()
 	schemaGetter := &fakeSchemaGetter{shardState: singleShardState()}
 	repo := New(logger, Config{
+		FlushIdleAfter:            60,
 		RootPath:                  dirName,
 		QueryMaximumResults:       10000,
 		DiskUseWarningPercentage:  config.DefaultDiskUseWarningPercentage,

--- a/adapters/repos/db/crud_integration_test.go
+++ b/adapters/repos/db/crud_integration_test.go
@@ -87,6 +87,7 @@ func TestCRUD(t *testing.T) {
 	}
 	schemaGetter := &fakeSchemaGetter{shardState: singleShardState()}
 	repo := New(logger, Config{
+		FlushIdleAfter:            60,
 		RootPath:                  dirName,
 		QueryMaximumResults:       10,
 		DiskUseWarningPercentage:  config.DefaultDiskUseWarningPercentage,
@@ -1293,6 +1294,7 @@ func Test_ImportWithoutVector_UpdateWithVectorLater(t *testing.T) {
 
 	schemaGetter := &fakeSchemaGetter{shardState: singleShardState()}
 	repo := New(logger, Config{
+		FlushIdleAfter:            60,
 		RootPath:                  dirName,
 		QueryMaximumResults:       10000,
 		DiskUseWarningPercentage:  config.DefaultDiskUseWarningPercentage,
@@ -1450,7 +1452,8 @@ func TestVectorSearch_ByDistance(t *testing.T) {
 
 	schemaGetter := &fakeSchemaGetter{shardState: singleShardState()}
 	repo := New(logger, Config{
-		RootPath: dirName,
+		FlushIdleAfter: 60,
+		RootPath:       dirName,
 		// this is set really low to ensure that search
 		// by distance is conducted, which executes
 		// without regard to this value
@@ -1587,7 +1590,8 @@ func TestVectorSearch_ByCertainty(t *testing.T) {
 
 	schemaGetter := &fakeSchemaGetter{shardState: singleShardState()}
 	repo := New(logger, Config{
-		RootPath: dirName,
+		FlushIdleAfter: 60,
+		RootPath:       dirName,
 		// this is set really low to ensure that search
 		// by distance is conducted, which executes
 		// without regard to this value
@@ -1736,6 +1740,7 @@ func Test_PutPatchRestart(t *testing.T) {
 
 	schemaGetter := &fakeSchemaGetter{shardState: singleShardState()}
 	repo := New(logger, Config{
+		FlushIdleAfter:            60,
 		RootPath:                  dirName,
 		QueryMaximumResults:       100,
 		DiskUseWarningPercentage:  config.DefaultDiskUseWarningPercentage,

--- a/adapters/repos/db/crud_noindex_property_integration_test.go
+++ b/adapters/repos/db/crud_noindex_property_integration_test.go
@@ -61,6 +61,7 @@ func TestCRUD_NoIndexProp(t *testing.T) {
 		DiskUseWarningPercentage:  config.DefaultDiskUseWarningPercentage,
 		DiskUseReadOnlyPercentage: config.DefaultDiskUseReadonlyPercentage,
 		MaxImportGoroutinesFactor: 1,
+		FlushIdleAfter:            60,
 	}, &fakeRemoteClient{}, &fakeNodeResolver{}, nil)
 	repo.SetSchemaGetter(schemaGetter)
 	err := repo.WaitForStartup(testCtx())
@@ -111,7 +112,7 @@ func TestCRUD_NoIndexProp(t *testing.T) {
 		assert.Equal(t, expectedSchema, res.Schema)
 	})
 
-	//Same as above, but with Object()
+	// Same as above, but with Object()
 	t.Run("all props are present when getting by id and class", func(t *testing.T) {
 		res, err := repo.Object(context.Background(), "ThingClassWithNoIndexProps", thingID,
 			search.SelectProperties{}, additional.Properties{})

--- a/adapters/repos/db/crud_null_objects_integration_test.go
+++ b/adapters/repos/db/crud_null_objects_integration_test.go
@@ -108,6 +108,7 @@ func createRepo(t *testing.T) (*Migrator, *DB, *fakeSchemaGetter) {
 	logger, _ := test.NewNullLogger()
 	dirName := t.TempDir()
 	repo := New(logger, Config{
+		FlushIdleAfter:            60,
 		RootPath:                  dirName,
 		QueryMaximumResults:       10,
 		DiskUseWarningPercentage:  config.DefaultDiskUseWarningPercentage,

--- a/adapters/repos/db/crud_references_integration_test.go
+++ b/adapters/repos/db/crud_references_integration_test.go
@@ -118,6 +118,7 @@ func TestNestedReferences(t *testing.T) {
 	logger := logrus.New()
 	schemaGetter := &fakeSchemaGetter{shardState: singleShardState()}
 	repo := New(logger, Config{
+		FlushIdleAfter:            60,
 		RootPath:                  dirName,
 		DiskUseWarningPercentage:  config.DefaultDiskUseWarningPercentage,
 		DiskUseReadOnlyPercentage: config.DefaultDiskUseReadonlyPercentage,
@@ -456,6 +457,7 @@ func Test_AddingReferenceOneByOne(t *testing.T) {
 	logger := logrus.New()
 	schemaGetter := &fakeSchemaGetter{shardState: singleShardState()}
 	repo := New(logger, Config{
+		FlushIdleAfter:            60,
 		RootPath:                  dirName,
 		DiskUseWarningPercentage:  config.DefaultDiskUseWarningPercentage,
 		DiskUseReadOnlyPercentage: config.DefaultDiskUseReadonlyPercentage,

--- a/adapters/repos/db/crud_references_multiple_types_integration_test.go
+++ b/adapters/repos/db/crud_references_multiple_types_integration_test.go
@@ -38,6 +38,7 @@ func TestMultipleCrossRefTypes(t *testing.T) {
 	logger := logrus.New()
 	schemaGetter := &fakeSchemaGetter{shardState: singleShardState()}
 	repo := New(logger, Config{
+		FlushIdleAfter:            60,
 		RootPath:                  dirName,
 		DiskUseWarningPercentage:  config.DefaultDiskUseWarningPercentage,
 		DiskUseReadOnlyPercentage: config.DefaultDiskUseReadonlyPercentage,

--- a/adapters/repos/db/crud_update_integration_test.go
+++ b/adapters/repos/db/crud_update_integration_test.go
@@ -47,6 +47,7 @@ func TestUpdateJourney(t *testing.T) {
 	logger := logrus.New()
 	schemaGetter := &fakeSchemaGetter{shardState: singleShardState()}
 	repo := New(logger, Config{
+		FlushIdleAfter:            60,
 		RootPath:                  dirName,
 		QueryMaximumResults:       10000,
 		DiskUseWarningPercentage:  config.DefaultDiskUseWarningPercentage,

--- a/adapters/repos/db/delete_filter_integration_test.go
+++ b/adapters/repos/db/delete_filter_integration_test.go
@@ -60,6 +60,7 @@ func Test_FilterSearchesOnDeletedDocIDsWithLimits(t *testing.T) {
 	}
 	schemaGetter := &fakeSchemaGetter{shardState: singleShardState()}
 	repo := New(logger, Config{
+		FlushIdleAfter:            60,
 		RootPath:                  dirName,
 		QueryMaximumResults:       10000,
 		DiskUseWarningPercentage:  config.DefaultDiskUseWarningPercentage,
@@ -176,6 +177,7 @@ func TestLimitOneAfterDeletion(t *testing.T) {
 	}
 	schemaGetter := &fakeSchemaGetter{shardState: singleShardState()}
 	repo := New(logger, Config{
+		FlushIdleAfter:            60,
 		RootPath:                  dirName,
 		QueryMaximumResults:       10000,
 		DiskUseWarningPercentage:  config.DefaultDiskUseWarningPercentage,

--- a/adapters/repos/db/filters_integration_test.go
+++ b/adapters/repos/db/filters_integration_test.go
@@ -41,6 +41,7 @@ func TestFilters(t *testing.T) {
 	logger, _ := test.NewNullLogger()
 	schemaGetter := &fakeSchemaGetter{shardState: singleShardState()}
 	repo := New(logger, Config{
+		FlushIdleAfter:            60,
 		RootPath:                  dirName,
 		QueryMaximumResults:       10000,
 		DiskUseWarningPercentage:  config.DefaultDiskUseWarningPercentage,
@@ -730,6 +731,7 @@ func TestGeoPropUpdateJourney(t *testing.T) {
 	logger, _ := test.NewNullLogger()
 	schemaGetter := &fakeSchemaGetter{shardState: singleShardState()}
 	repo := New(logger, Config{
+		FlushIdleAfter:            60,
 		RootPath:                  dirName,
 		QueryMaximumResults:       10000,
 		DiskUseWarningPercentage:  config.DefaultDiskUseWarningPercentage,
@@ -840,6 +842,7 @@ func TestCasingOfOperatorCombinations(t *testing.T) {
 	logger, _ := test.NewNullLogger()
 	schemaGetter := &fakeSchemaGetter{shardState: singleShardState()}
 	repo := New(logger, Config{
+		FlushIdleAfter:            60,
 		RootPath:                  dirName,
 		QueryMaximumResults:       10000,
 		DiskUseWarningPercentage:  config.DefaultDiskUseWarningPercentage,

--- a/adapters/repos/db/filters_limits_integration_test.go
+++ b/adapters/repos/db/filters_limits_integration_test.go
@@ -50,7 +50,6 @@ func Test_LimitsOnChainedFilters(t *testing.T) {
 		DiskUseWarningPercentage:  config.DefaultDiskUseWarningPercentage,
 		DiskUseReadOnlyPercentage: config.DefaultDiskUseReadonlyPercentage,
 		MaxImportGoroutinesFactor: 1,
-		FlushIdleAfter:            60,
 	}, &fakeRemoteClient{}, &fakeNodeResolver{}, nil)
 	repo.SetSchemaGetter(schemaGetter)
 	err := repo.WaitForStartup(testCtx())

--- a/adapters/repos/db/filters_limits_integration_test.go
+++ b/adapters/repos/db/filters_limits_integration_test.go
@@ -44,11 +44,13 @@ func Test_LimitsOnChainedFilters(t *testing.T) {
 	logger := logrus.New()
 	schemaGetter := &fakeSchemaGetter{shardState: singleShardState()}
 	repo := New(logger, Config{
+		FlushIdleAfter:            60,
 		RootPath:                  dirName,
 		QueryMaximumResults:       10000,
 		DiskUseWarningPercentage:  config.DefaultDiskUseWarningPercentage,
 		DiskUseReadOnlyPercentage: config.DefaultDiskUseReadonlyPercentage,
 		MaxImportGoroutinesFactor: 1,
+		FlushIdleAfter:            60,
 	}, &fakeRemoteClient{}, &fakeNodeResolver{}, nil)
 	repo.SetSchemaGetter(schemaGetter)
 	err := repo.WaitForStartup(testCtx())
@@ -142,6 +144,7 @@ func Test_FilterLimitsAfterUpdates(t *testing.T) {
 	logger := logrus.New()
 	schemaGetter := &fakeSchemaGetter{shardState: singleShardState()}
 	repo := New(logger, Config{
+		FlushIdleAfter:            60,
 		RootPath:                  dirName,
 		QueryMaximumResults:       10000,
 		DiskUseWarningPercentage:  config.DefaultDiskUseWarningPercentage,
@@ -269,6 +272,7 @@ func Test_AggregationsAfterUpdates(t *testing.T) {
 	logger := logrus.New()
 	schemaGetter := &fakeSchemaGetter{shardState: singleShardState()}
 	repo := New(logger, Config{
+		FlushIdleAfter:            60,
 		RootPath:                  dirName,
 		QueryMaximumResults:       10000,
 		DiskUseWarningPercentage:  config.DefaultDiskUseWarningPercentage,

--- a/adapters/repos/db/filters_on_refs_integration_test.go
+++ b/adapters/repos/db/filters_on_refs_integration_test.go
@@ -41,6 +41,7 @@ func TestRefFilters(t *testing.T) {
 	logger, _ := test.NewNullLogger()
 	schemaGetter := &fakeSchemaGetter{shardState: singleShardState()}
 	repo := New(logger, Config{
+		FlushIdleAfter:            60,
 		RootPath:                  dirName,
 		QueryLimit:                20,
 		QueryMaximumResults:       10000,
@@ -464,6 +465,7 @@ func TestRefFilters_MergingWithAndOperator(t *testing.T) {
 	logger, _ := test.NewNullLogger()
 	schemaGetter := &fakeSchemaGetter{shardState: singleShardState()}
 	repo := New(logger, Config{
+		FlushIdleAfter:            60,
 		RootPath:                  dirName,
 		QueryMaximumResults:       10000,
 		DiskUseWarningPercentage:  config.DefaultDiskUseWarningPercentage,

--- a/adapters/repos/db/index.go
+++ b/adapters/repos/db/index.go
@@ -195,6 +195,7 @@ type IndexConfig struct {
 	DiskUseReadOnlyPercentage uint64
 	MaxImportGoroutinesFactor float64
 	NodeName                  string
+	FlushIdleAfter            int
 }
 
 func indexID(class schema.ClassName) string {

--- a/adapters/repos/db/init.go
+++ b/adapters/repos/db/init.go
@@ -57,6 +57,7 @@ func (d *DB) init(ctx context.Context) error {
 				QueryMaximumResults:       d.config.QueryMaximumResults,
 				MaxImportGoroutinesFactor: d.config.MaxImportGoroutinesFactor,
 				NodeName:                  d.config.NodeName,
+				FlushIdleAfter:            d.config.FlushIdleAfter,
 			}, d.schemaGetter.ShardingState(class.Class),
 				inverted.ConfigFromModel(invertedConfig),
 				class.VectorIndexConfig.(schema.VectorIndexConfig),

--- a/adapters/repos/db/inverted/searcher_doc_pointers.go
+++ b/adapters/repos/db/inverted/searcher_doc_pointers.go
@@ -81,10 +81,7 @@ func (fs *Searcher) docPointersInvertedNoFrequency(prop string, b *lsmkv.Bucket,
 		// filters - which happens after the RowReader has completed - this can lead
 		// to segfault crashes. Now is the time to safely copy it, creating a new
 		// and immutable slice.
-		hashCopy := make([]byte, len(currHash))
-		copy(hashCopy, currHash)
-
-		hashes = append(hashes, hashCopy)
+		hashes = append(hashes, copyBytes(currHash))
 		if limit > 0 && pointers.count >= uint64(limit) {
 			return false, nil
 		}
@@ -149,10 +146,7 @@ func (fs *Searcher) docPointersInvertedFrequency(prop string, b *lsmkv.Bucket, l
 		// filters - which happens after the RowReader has completed - this can lead
 		// to segfault crashes. Now is the time to safely copy it, creating a new
 		// and immutable slice.
-		hashCopy := make([]byte, len(currHash))
-		copy(hashCopy, currHash)
-
-		hashes = append(hashes, hashCopy)
+		hashes = append(hashes, copyBytes(currHash))
 		if limit > 0 && pointers.count >= uint64(limit) {
 			return false, nil
 		}
@@ -274,4 +268,10 @@ func docPointerChecksum(pointers []uint64) ([]byte, error) {
 	}
 
 	return buf.Bytes(), nil
+}
+
+func copyBytes(in []byte) []byte {
+	out := make([]byte, len(in))
+	copy(out, in)
+	return out
 }

--- a/adapters/repos/db/inverted/searcher_doc_pointers.go
+++ b/adapters/repos/db/inverted/searcher_doc_pointers.go
@@ -75,7 +75,16 @@ func (fs *Searcher) docPointersInvertedNoFrequency(prop string, b *lsmkv.Bucket,
 			return false, errors.Wrap(err, "get hash")
 		}
 
-		hashes = append(hashes, currHash)
+		// currHash is only safe to access for the lifetime of the RowReader, once
+		// that has finished, a compaction could happen and remove the underlying
+		// memory that the slice points to. Since the hashes will be used to merge
+		// filters - which happens after the RowReader has completed - this can lead
+		// to segfault crashes. Now is the time to safely copy it, creating a new
+		// and immutable slice.
+		hashCopy := make([]byte, len(currHash))
+		copy(hashCopy, currHash)
+
+		hashes = append(hashes, hashCopy)
 		if limit > 0 && pointers.count >= uint64(limit) {
 			return false, nil
 		}

--- a/adapters/repos/db/inverted_index_integration_test.go
+++ b/adapters/repos/db/inverted_index_integration_test.go
@@ -42,6 +42,7 @@ func TestIndexByTimestamps_AddClass(t *testing.T) {
 	logger := logrus.New()
 	schemaGetter := &fakeSchemaGetter{shardState: shardState}
 	repo := New(logger, Config{
+		FlushIdleAfter:            60,
 		RootPath:                  dirName,
 		QueryMaximumResults:       10000,
 		DiskUseWarningPercentage:  config.DefaultDiskUseWarningPercentage,
@@ -128,6 +129,7 @@ func TestIndexByTimestamps_GetClass(t *testing.T) {
 		},
 	}}
 	repo := New(logger, Config{
+		FlushIdleAfter:            60,
 		RootPath:                  dirName,
 		QueryMaximumResults:       10000,
 		DiskUseWarningPercentage:  config.DefaultDiskUseWarningPercentage,

--- a/adapters/repos/db/merge_integration_test.go
+++ b/adapters/repos/db/merge_integration_test.go
@@ -44,6 +44,7 @@ func Test_MergingObjects(t *testing.T) {
 	logger := logrus.New()
 	schemaGetter := &fakeSchemaGetter{shardState: singleShardState()}
 	repo := New(logger, Config{
+		FlushIdleAfter:            60,
 		RootPath:                  dirName,
 		DiskUseWarningPercentage:  config.DefaultDiskUseWarningPercentage,
 		DiskUseReadOnlyPercentage: config.DefaultDiskUseReadonlyPercentage,
@@ -398,6 +399,7 @@ func Test_Merge_UntouchedPropsCorrectlyIndexed(t *testing.T) {
 	logger := logrus.New()
 	schemaGetter := &fakeSchemaGetter{shardState: singleShardState()}
 	repo := New(logger, Config{
+		FlushIdleAfter:            60,
 		RootPath:                  dirName,
 		DiskUseWarningPercentage:  config.DefaultDiskUseWarningPercentage,
 		DiskUseReadOnlyPercentage: config.DefaultDiskUseReadonlyPercentage,

--- a/adapters/repos/db/migrator.go
+++ b/adapters/repos/db/migrator.go
@@ -40,6 +40,7 @@ func (m *Migrator) AddClass(ctx context.Context, class *models.Class,
 			QueryMaximumResults:       m.db.config.QueryMaximumResults,
 			MaxImportGoroutinesFactor: m.db.config.MaxImportGoroutinesFactor,
 			NodeName:                  m.db.config.NodeName,
+			FlushIdleAfter:            m.db.config.FlushIdleAfter,
 		},
 		shardState,
 		// no backward-compatibility check required, since newly added classes will

--- a/adapters/repos/db/multi_shard_integration_test.go
+++ b/adapters/repos/db/multi_shard_integration_test.go
@@ -274,6 +274,7 @@ func setupMultiShardTest(t *testing.T) (*DB, *logrus.Logger) {
 
 	logger, _ := test.NewNullLogger()
 	repo := New(logger, Config{
+		FlushIdleAfter:            60,
 		RootPath:                  dirName,
 		QueryMaximumResults:       10000,
 		DiskUseWarningPercentage:  config.DefaultDiskUseWarningPercentage,

--- a/adapters/repos/db/repo.go
+++ b/adapters/repos/db/repo.go
@@ -74,6 +74,7 @@ type Config struct {
 	DiskUseReadOnlyPercentage uint64
 	MaxImportGoroutinesFactor float64
 	NodeName                  string
+	FlushIdleAfter            int
 }
 
 // GetIndex returns the index if it exists or nil if it doesn't

--- a/adapters/repos/db/restart_journey_integration_test.go
+++ b/adapters/repos/db/restart_journey_integration_test.go
@@ -52,6 +52,7 @@ func TestRestartJourney(t *testing.T) {
 	shardState := singleShardState()
 	schemaGetter := &fakeSchemaGetter{shardState: shardState}
 	repo := New(logger, Config{
+		FlushIdleAfter:            60,
 		RootPath:                  dirName,
 		QueryMaximumResults:       10000,
 		DiskUseWarningPercentage:  config.DefaultDiskUseWarningPercentage,
@@ -172,6 +173,7 @@ func TestRestartJourney(t *testing.T) {
 		repo = nil
 
 		newRepo = New(logger, Config{
+			FlushIdleAfter:            60,
 			RootPath:                  dirName,
 			QueryMaximumResults:       10000,
 			DiskUseWarningPercentage:  config.DefaultDiskUseWarningPercentage,

--- a/adapters/repos/db/shard.go
+++ b/adapters/repos/db/shard.go
@@ -236,6 +236,7 @@ func (s *Shard) initDBFile(ctx context.Context) error {
 		lsmkv.WithStrategy(lsmkv.StrategyReplace),
 		lsmkv.WithSecondaryIndices(1),
 		lsmkv.WithMonitorCount(),
+		lsmkv.WithIdleThreshold(time.Duration(s.index.Config.FlushIdleAfter)*time.Second),
 	)
 	if err != nil {
 		return errors.Wrap(err, "create objects bucket")

--- a/adapters/repos/db/shard.go
+++ b/adapters/repos/db/shard.go
@@ -308,6 +308,7 @@ func (s *Shard) addIDProperty(ctx context.Context) error {
 
 	err := s.store.CreateOrLoadBucket(ctx,
 		helpers.BucketFromPropNameLSM(filters.InternalPropID),
+		lsmkv.WithIdleThreshold(time.Duration(s.index.Config.FlushIdleAfter)*time.Second),
 		lsmkv.WithStrategy(lsmkv.StrategySetCollection))
 	if err != nil {
 		return err
@@ -315,6 +316,7 @@ func (s *Shard) addIDProperty(ctx context.Context) error {
 
 	err = s.store.CreateOrLoadBucket(ctx,
 		helpers.HashBucketFromPropNameLSM(filters.InternalPropID),
+		lsmkv.WithIdleThreshold(time.Duration(s.index.Config.FlushIdleAfter)*time.Second),
 		lsmkv.WithStrategy(lsmkv.StrategyReplace))
 	if err != nil {
 		return err
@@ -341,12 +343,14 @@ func (s *Shard) addTimestampProperties(ctx context.Context) error {
 func (s *Shard) addCreationTimeUnixProperty(ctx context.Context) error {
 	err := s.store.CreateOrLoadBucket(ctx,
 		helpers.BucketFromPropNameLSM(filters.InternalPropCreationTimeUnix),
+		lsmkv.WithIdleThreshold(time.Duration(s.index.Config.FlushIdleAfter)*time.Second),
 		lsmkv.WithStrategy(lsmkv.StrategySetCollection))
 	if err != nil {
 		return err
 	}
 	err = s.store.CreateOrLoadBucket(ctx,
 		helpers.HashBucketFromPropNameLSM(filters.InternalPropCreationTimeUnix),
+		lsmkv.WithIdleThreshold(time.Duration(s.index.Config.FlushIdleAfter)*time.Second),
 		lsmkv.WithStrategy(lsmkv.StrategyReplace))
 	if err != nil {
 		return err
@@ -358,12 +362,14 @@ func (s *Shard) addCreationTimeUnixProperty(ctx context.Context) error {
 func (s *Shard) addLastUpdateTimeUnixProperty(ctx context.Context) error {
 	err := s.store.CreateOrLoadBucket(ctx,
 		helpers.BucketFromPropNameLSM(filters.InternalPropLastUpdateTimeUnix),
+		lsmkv.WithIdleThreshold(time.Duration(s.index.Config.FlushIdleAfter)*time.Second),
 		lsmkv.WithStrategy(lsmkv.StrategySetCollection))
 	if err != nil {
 		return err
 	}
 	err = s.store.CreateOrLoadBucket(ctx,
 		helpers.HashBucketFromPropNameLSM(filters.InternalPropLastUpdateTimeUnix),
+		lsmkv.WithIdleThreshold(time.Duration(s.index.Config.FlushIdleAfter)*time.Second),
 		lsmkv.WithStrategy(lsmkv.StrategyReplace))
 	if err != nil {
 		return err
@@ -380,14 +386,18 @@ func (s *Shard) addProperty(ctx context.Context, prop *models.Property) error {
 	if schema.IsRefDataType(prop.DataType) {
 		err := s.store.CreateOrLoadBucket(ctx,
 			helpers.BucketFromPropNameLSM(helpers.MetaCountProp(prop.Name)),
-			lsmkv.WithStrategy(lsmkv.StrategySetCollection)) // ref props do not have frequencies -> Set
+			lsmkv.WithStrategy(lsmkv.StrategySetCollection), // ref props do not have frequencies -> Set
+			lsmkv.WithIdleThreshold(time.Duration(s.index.Config.FlushIdleAfter)*time.Second),
+		)
 		if err != nil {
 			return err
 		}
 
 		err = s.store.CreateOrLoadBucket(ctx,
 			helpers.HashBucketFromPropNameLSM(helpers.MetaCountProp(prop.Name)),
-			lsmkv.WithStrategy(lsmkv.StrategyReplace))
+			lsmkv.WithStrategy(lsmkv.StrategyReplace),
+			lsmkv.WithIdleThreshold(time.Duration(s.index.Config.FlushIdleAfter)*time.Second),
+		)
 		if err != nil {
 			return err
 		}
@@ -400,6 +410,7 @@ func (s *Shard) addProperty(ctx context.Context, prop *models.Property) error {
 	var mapOpts []lsmkv.BucketOption
 	if inverted.HasFrequency(schema.DataType(prop.DataType[0])) {
 		mapOpts = append(mapOpts, lsmkv.WithStrategy(lsmkv.StrategyMapCollection))
+		mapOpts = append(mapOpts, lsmkv.WithIdleThreshold(time.Duration(s.index.Config.FlushIdleAfter)*time.Second))
 		if s.versioner.Version() < 2 {
 			mapOpts = append(mapOpts, lsmkv.WithLegacyMapSorting())
 		}
@@ -414,7 +425,9 @@ func (s *Shard) addProperty(ctx context.Context, prop *models.Property) error {
 	}
 
 	err = s.store.CreateOrLoadBucket(ctx, helpers.HashBucketFromPropNameLSM(prop.Name),
-		lsmkv.WithStrategy(lsmkv.StrategyReplace))
+		lsmkv.WithStrategy(lsmkv.StrategyReplace),
+		lsmkv.WithIdleThreshold(time.Duration(s.index.Config.FlushIdleAfter)*time.Second),
+	)
 	if err != nil {
 		return err
 	}

--- a/usecases/classification/integrationtest/classifier_integration_test.go
+++ b/usecases/classification/integrationtest/classifier_integration_test.go
@@ -46,6 +46,7 @@ func Test_Classifier_KNN_SaveConsistency(t *testing.T) {
 	sg := &fakeSchemaGetter{shardState: shardState}
 
 	vrepo := db.New(logger, db.Config{
+		FlushIdleAfter:            60,
 		RootPath:                  dirName,
 		QueryMaximumResults:       10000,
 		DiskUseWarningPercentage:  config.DefaultDiskUseWarningPercentage,

--- a/usecases/config/config_handler.go
+++ b/usecases/config/config_handler.go
@@ -141,7 +141,8 @@ type Profiling struct {
 }
 
 type Persistence struct {
-	DataPath string `json:"dataPath" yaml:"dataPath"`
+	DataPath                string `json:"dataPath" yaml:"dataPath"`
+	FlushIdleMemtablesAfter int    `json:"flushIdleMemtablesAfter" yaml:"flushIdleMemtablesAfter"`
 }
 
 func (p Persistence) Validate() error {

--- a/usecases/config/environment.go
+++ b/usecases/config/environment.go
@@ -102,6 +102,17 @@ func FromEnv(config *Config) error {
 		config.Persistence.DataPath = v
 	}
 
+	if v := os.Getenv("PERSISTENCE_FLUSH_IDLE_MEMTABLES_AFTER"); v != "" {
+		asInt, err := strconv.Atoi(v)
+		if err != nil {
+			return errors.Wrapf(err, "parse PERSISTENCE_FLUSH_IDLE_MEMTABLES_AFTER as int")
+		}
+
+		config.Persistence.FlushIdleMemtablesAfter = asInt
+	} else {
+		config.Persistence.FlushIdleMemtablesAfter = DefaultPersistenceFlushIdleMemtablesAfter
+	}
+
 	if v := os.Getenv("ORIGIN"); v != "" {
 		config.Origin = v
 	}
@@ -216,6 +227,8 @@ func FromEnv(config *Config) error {
 }
 
 const DefaultQueryMaximumResults = int64(10000)
+
+const DefaultPersistenceFlushIdleMemtablesAfter = 60
 
 const VectorizerModuleNone = "none"
 

--- a/usecases/config/environment.go
+++ b/usecases/config/environment.go
@@ -106,6 +106,8 @@ func FromEnv(config *Config) error {
 		asInt, err := strconv.Atoi(v)
 		if err != nil {
 			return errors.Wrapf(err, "parse PERSISTENCE_FLUSH_IDLE_MEMTABLES_AFTER as int")
+		} else if asInt <= 0 {
+			return errors.New("PERSISTENCE_FLUSH_IDLE_MEMTABLES_AFTER must be a positive value larger 0")
 		}
 
 		config.Persistence.FlushIdleMemtablesAfter = asInt

--- a/usecases/config/environment_test.go
+++ b/usecases/config/environment_test.go
@@ -51,3 +51,34 @@ func TestEnvironmentImportGoroutineFactor(t *testing.T) {
 		})
 	}
 }
+
+func TestEnvironmentSetFlushAfter(t *testing.T) {
+	factors := []struct {
+		name        string
+		flushAfter  []string
+		expected    int
+		expectedErr bool
+	}{
+		{"Valid", []string{"1"}, 1, false},
+		{"not given", []string{}, DefaultPersistenceFlushIdleMemtablesAfter, false},
+		{"invalid factor", []string{"-1"}, -1, true},
+		{"zero factor", []string{"0"}, -1, true},
+		{"not parsable", []string{"I'm not a number"}, -1, true},
+	}
+	for _, tt := range factors {
+		t.Run(tt.name, func(t *testing.T) {
+			os.Clearenv()
+			if len(tt.flushAfter) == 1 {
+				os.Setenv("PERSISTENCE_FLUSH_IDLE_MEMTABLES_AFTER", tt.flushAfter[0])
+			}
+			conf := Config{}
+			err := FromEnv(&conf)
+
+			if tt.expectedErr {
+				require.NotNil(t, err)
+			} else {
+				require.Equal(t, tt.expected, conf.Persistence.FlushIdleMemtablesAfter)
+			}
+		})
+	}
+}


### PR DESCRIPTION
### What's being changed:
- There was essentially a data race between the property hash buckets and compactions happening on those buckets. The values are obtained using an `inverted.RowReader` which wraps a Cursor. The values are only threadsafe until the cursor is closed. In our scenario we are using the values also after the work done through the`RowReader` has been completed. This is now threadsafe by copying the hash instead of referencing it. This behavior is covered by a [completely new chaos pipeline](https://github.com/semi-technologies/weaviate-chaos-engineering/pull/11).
- This PR also adds the ability to override the idle memtable flush threshold (default=60s), as the new chaos pipeline forces a flush by waiting. Without this feature, the pipeline would have to wait for 10x60s, now it waits for just 10x5s. A unit test for parsing the config was added.

Fixes #2211 

### Review checklist

- ~~Documentation has been updated, if necessary. Link to changed documentation:~~
- [x] Chaos pipeline run or not necessary. Link to pipeline: see below
- [x] All new code is covered by tests where it is reasonable: new config has unit test, racy behavior [has new chaos pipeline](https://github.com/semi-technologies/weaviate-chaos-engineering/pull/11) scenario (which is now green).
- ~~Performance tests have been run or not necessary.~~ deemed not necessary
