### PR TITLE
Mark PointingTo as deprecated/experimental

### DIFF
--- a/adapters/handlers/graphql/local/aggregate/properties.go
+++ b/adapters/handlers/graphql/local/aggregate/properties.go
@@ -159,6 +159,7 @@ func referencePropertyFields(class *models.Class,
 
 				return ref.PointingTo, nil
 			},
+			DeprecationReason: "Experimental, the format will change",
 		},
 	}
 


### PR DESCRIPTION
### What's being changed:

Marks PointingTo as deprecated/experimental because the format will change in the future, but allows users to test it out. [This ticket contains](https://semi-technology.atlassian.net/browse/WEAVIATE-350) the steps to make this feature usable

![image](https://user-images.githubusercontent.com/5353192/191202973-bfad9e26-48be-4238-b654-00c464549d8b.png)



