### PR TITLE
Improve weaviate docker image build time

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -6,17 +6,24 @@ data/
 data-node2/
 data_wiki/
 logs/
-test/acceptance/
-/snapshots/
-/snapshots-fs/
-/snapshots-node2/
-/snapshots-s3/
-/snapshots-gcs/
-/backups/
-/backups-fs/
-/backups-node2/
-/backups-s3/
-/backups-gcs/
-*.fvecs  # sift data
-*.png  # profiling
-*.out
+snapshots/
+snapshots-fs/
+snapshots-node2/
+snapshots-s3/
+snapshots-gcs/
+backups/
+backups-fs/
+backups-node2/
+backups-s3/
+backups-gcs/
+test/
+tools/
+**/*.fvecs  # sift data
+**/*.png  # profiling
+**/*.out
+**/*.txt
+**/*.csv
+**/*.md
+**/*_test.go
+**/.DS_Store
+**/testdata/

--- a/.dockerignore
+++ b/.dockerignore
@@ -21,9 +21,11 @@ tools/
 **/*.fvecs  # sift data
 **/*.png  # profiling
 **/*.out
-**/*.txt
 **/*.csv
 **/*.md
 **/*_test.go
 **/.DS_Store
 **/testdata/
+coverage-integration.txt
+coverage-unit.txt
+

--- a/.gitignore
+++ b/.gitignore
@@ -99,16 +99,7 @@ docker-compose/runtime-unstable/data
 c.out
 
 esbackups/
-adapters/repos/backups/testdata/
-adapters/repos/db/testdata/
-adapters/repos/db/vector/hnsw/testdata
-adapters/repos/db/lsmkv/testdata
-adapters/repos/db/inverted/testdata
-adapters/repos/db/clusterintegrationtest/testdata
-adapters/repos/classifications/testdata
-usecases/classification/integrationtest/testdata
-adapters/repos/schema/testdata
-adapters/repos/modules/testdata/
+**/testdata/
 
 # coverage files
 coverage*.txt


### PR DESCRIPTION
### What's being changed:

- Significantly reduce build time of the weaviate docker image by fixing the dockerignore to reference unneeded files correctly.

- Update gitignore to use `**` matching on `testdata/` dirs instead of naming each one individually

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.
