### PR TITLE
Add a simple way to determine memory usage percentage

### DIFF
--- a/usecases/memwatch/monitor.go
+++ b/usecases/memwatch/monitor.go
@@ -1,0 +1,88 @@
+package memwatch
+
+import (
+	"math"
+	"runtime"
+)
+
+// Monitor allows making statements about the memory ratio used by the application
+type Monitor struct {
+	memProfiler memProfiler
+	limitSetter limitSetter
+	rate        int64
+}
+
+type memProfiler func(p []runtime.MemProfileRecord, inUseZero bool) (int, bool)
+
+// we have no intentions of ever modifying the limit, but SetMemoryLimit with a
+// negative value is the only way to read the limit from the runtime
+type limitSetter func(size int64) int64
+
+// NewMonitor creates a [Monitor] with the given profiler, limitsetter and rate.
+//
+// Typically this would be called with runtime.MemProfile,
+// debug.SetMemoryLimit, and runtime.MemProfileRate
+func NewMonitor(profiler memProfiler, limitSetter limitSetter, rate int) *Monitor {
+	return &Monitor{
+		memProfiler: profiler,
+		limitSetter: limitSetter,
+		rate:        int64(rate),
+	}
+}
+
+// inspired by runtime/pprof/pprof.go
+func (m *Monitor) Ratio() float64 {
+	var p []runtime.MemProfileRecord
+	n, _ := m.memProfiler(nil, true)
+	for {
+		// Allocate room for a slightly bigger profile,
+		// in case a few more entries have been added
+		// since the call to MemProfile.
+		p = make([]runtime.MemProfileRecord, n+50)
+		n, ok := m.memProfiler(p, true)
+		if ok {
+			p = p[0:n]
+			break
+		}
+		// Profile grew; try again.
+	}
+
+	var sum int64
+
+	for _, r := range p {
+		_, size := scaleHeapSample(r.InUseObjects(), r.InUseBytes(), m.rate)
+		sum += size
+	}
+
+	// setting a negative limit is the only way to obtain the current limit
+	limit := m.limitSetter(-1)
+	return float64(sum) / float64(limit)
+}
+
+// copied from runtime/pprof/protomem.go
+//
+// scaleHeapSample adjusts the data from a heap Sample to
+// account for its probability of appearing in the collected
+// data. heap profiles are a sampling of the memory allocations
+// requests in a program. We estimate the unsampled value by dividing
+// each collected sample by its probability of appearing in the
+// profile. heap profiles rely on a poisson process to determine
+// which samples to collect, based on the desired average collection
+// rate R. The probability of a sample of size S to appear in that
+// profile is 1-exp(-S/R).
+func scaleHeapSample(count, size, rate int64) (int64, int64) {
+	if count == 0 || size == 0 {
+		return 0, 0
+	}
+
+	if rate <= 1 {
+		// if rate==1 all samples were collected so no adjustment is needed.
+		// if rate<1 treat as unknown and skip scaling.
+		return count, size
+	}
+
+	avgSize := float64(size) / float64(count)
+	scale := 1 / (1 - math.Exp(-avgSize/float64(rate)))
+
+	return int64(float64(count) * scale), int64(float64(size) * scale)
+}

--- a/usecases/memwatch/monitor_test.go
+++ b/usecases/memwatch/monitor_test.go
@@ -1,0 +1,101 @@
+package memwatch
+
+import (
+	"runtime"
+	"runtime/debug"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestMonitor(t *testing.T) {
+	t.Run("with constant profiles (no changes)", func(t *testing.T) {
+		profiler := &fakeMemProfiler{
+			copyProfiles: [][]runtime.MemProfileRecord{
+				{sampleProfile(10000), sampleProfile(20000)},
+				{sampleProfile(10000), sampleProfile(20000)},
+			},
+		}
+
+		limiter := &fakeLimitSetter{limit: 100000}
+
+		m := NewMonitor(profiler.MemProfile, limiter.SetMemoryLimit, 1)
+
+		assert.Equal(t, 0.3, m.Ratio())
+	})
+
+	t.Run("with one more profile on second call", func(t *testing.T) {
+		profiler := &fakeMemProfiler{
+			copyProfiles: [][]runtime.MemProfileRecord{
+				{sampleProfile(10000)},
+				{sampleProfile(10000), sampleProfile(20000)},
+			},
+		}
+
+		limiter := &fakeLimitSetter{limit: 100000}
+
+		m := NewMonitor(profiler.MemProfile, limiter.SetMemoryLimit, 1)
+
+		assert.Equal(t, 0.3, m.Ratio())
+	})
+
+	t.Run("with sampling rate", func(t *testing.T) {
+		profiler := &fakeMemProfiler{
+			copyProfiles: [][]runtime.MemProfileRecord{
+				{sampleProfile(10000)},
+				{sampleProfile(10000), sampleProfile(20000)},
+			},
+		}
+
+		limiter := &fakeLimitSetter{limit: 100000}
+
+		// sample rate is small enough to not alter the result, yet big enough to
+		// cover the calculation
+		m := NewMonitor(profiler.MemProfile, limiter.SetMemoryLimit, 5)
+
+		assert.Equal(t, 0.3, m.Ratio())
+	})
+
+	t.Run("with real dependencies", func(t *testing.T) {
+		m := NewMonitor(runtime.MemProfile, debug.SetMemoryLimit, runtime.MemProfileRate)
+		_ = m.Ratio()
+	})
+}
+
+type fakeMemProfiler struct {
+	copyProfiles [][]runtime.MemProfileRecord
+	call         int
+}
+
+func (f *fakeMemProfiler) MemProfile(p []runtime.MemProfileRecord, inUseZero bool) (int, bool) {
+	profiles := f.copyProfiles[f.call]
+	f.call++
+
+	if len(p) >= len(profiles) {
+		copy(p, profiles)
+		return len(profiles), true
+	}
+
+	return len(profiles), false
+}
+
+func sampleProfile(in int64) runtime.MemProfileRecord {
+	return runtime.MemProfileRecord{
+		AllocBytes:   in,
+		FreeBytes:    0,
+		AllocObjects: 1,
+		FreeObjects:  0,
+	}
+}
+
+type fakeLimitSetter struct {
+	limit int64
+}
+
+func (f *fakeLimitSetter) SetMemoryLimit(newLimit int64) int64 {
+	if newLimit >= 0 {
+		panic("should have been read only")
+	}
+
+	return f.limit
+}


### PR DESCRIPTION
## What it is

This uses the Go memProfile tooling to calculate the current heap usage. It then uses `GOMEMLIMIT` to determine what the maximum memory usage would be and calculates a ratio. The code is currently not used anywhere outside of its own tests.

## Why

This will enable us to use this as a factor for marking a shard read-only. Similar to 90% disk usage, we could also do something like 90% mem usage.

## Alternatives Considered

An alternative would be to use `runtime.Memstats` which would already have the heap in a single variable. The problem with this is that this value is independent of GC cycles, so if GOGC is 100 and GOMEMLIMIT is set to 4GiB, we could see any value between 2.00GiB and 3.99 GiB depending on when the GC last run. This would make it meaningless for the purpose above as 90% would be reached when the long-lived heap would be at 51%. 

By using the profiling approach we are getting cached data from the last (or one before) GC cycle. This means the profile only contains long-lived objects. Since `GOMEMLIMIT` already makes sure that the runtime adheres to the limit this is the value we really care about to make claims about a 90% threshold being crossed.


### Review checklist

- ~~Documentation has been updated, if necessary. Link to changed documentation~~
- ~~Chaos pipeline run or not necessary. Link to pipeline~~
- [x] All new code is covered by tests where it is reasonable.
- ~~Performance tests have been run or not necessary.~~
