### PR TITLE
Implement the coordinator selector

### DIFF
--- a/adapters/repos/db/backup_integration_test.go
+++ b/adapters/repos/db/backup_integration_test.go
@@ -93,6 +93,18 @@ func TestBackup_DBLevel(t *testing.T) {
 				assert.Nil(t, err)
 			}
 		})
+
+		t.Run("node names from shards", func(t *testing.T) {
+			res := db.Shards(ctx, className)
+			assert.Len(t, res, 1)
+			assert.Equal(t, "node1", res[0])
+		})
+
+		t.Run("get all classes", func(t *testing.T) {
+			res := db.ListClasses(ctx)
+			assert.Len(t, res, 1)
+			assert.Equal(t, className, res[0])
+		})
 	})
 
 	t.Run("failed backup creation from expired context", func(t *testing.T) {

--- a/adapters/repos/db/clusterintegrationtest/cluster_integration_test.go
+++ b/adapters/repos/db/clusterintegrationtest/cluster_integration_test.go
@@ -55,6 +55,7 @@ import (
 
 const (
 	vectorDims       = 20
+	numberOfNodes    = 10
 	distributedClass = "Distributed"
 )
 
@@ -76,7 +77,6 @@ func TestDistributedSetup(t *testing.T) {
 
 func testDistributed(t *testing.T, dirName string, batch bool) {
 	var nodes []*node
-	numberOfNodes := 10
 	numberOfObjects := 200
 
 	t.Run("setup", func(t *testing.T) {
@@ -536,6 +536,18 @@ func testDistributed(t *testing.T, dirName string, batch bool) {
 					}
 				}
 			})
+		}
+	})
+
+	t.Run("node names by shard", func(t *testing.T) {
+		for _, n := range nodes {
+			nodeSet := make(map[string]bool)
+			foundNodes := n.repo.Shards(context.Background(), distributedClass)
+			for _, found := range foundNodes {
+				nodeSet[found] = true
+			}
+			assert.Len(t, nodeSet, numberOfNodes, "expected %d nodes, got %d",
+				numberOfNodes, len(foundNodes))
 		}
 	})
 

--- a/usecases/backup/coordinator.go
+++ b/usecases/backup/coordinator.go
@@ -60,7 +60,7 @@ type participantStatus struct {
 type selector interface {
 	// Shards gets all nodes on which this class is sharded
 	Shards(ctx context.Context, class string) []string
-	// ListClasses returns a list of all existig classes
+	// ListClasses returns a list of all existing classes
 	// This will be need if user doesn't include any classes
 	ListClasses(ctx context.Context) []string
 }


### PR DESCRIPTION
### What's being changed:

This PR implements the `selector` interface with the `db.DB` type to be used by the backup coordinator.
### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.
