### PR TITLE
Fix race conditions when adding objects and in HNSW

### DIFF
--- a/adapters/repos/db/shard.go
+++ b/adapters/repos/db/shard.go
@@ -70,6 +70,8 @@ type Shard struct {
 
 	status     storagestate.Status
 	statusLock sync.Mutex
+
+	docIdLock sync.Mutex
 }
 
 type job struct {

--- a/adapters/repos/db/shard_write_put.go
+++ b/adapters/repos/db/shard_write_put.go
@@ -104,7 +104,7 @@ func (s *Shard) putObjectLSM(object *storobj.Object,
 
 	// First the object bucket is checked if already an object with the same uuid is present, to determine if it is new
 	// or an update. Afterwards the bucket is updates. To avoid races, only one goroutine can do this at once.
-	s.docIdLock.Lock()
+	s.docIdLock[s.uuidToIdLockPoolId(idBytes)].Lock()
 	previous, err := bucket.Get(idBytes)
 	if err != nil {
 		return objectInsertStatus{}, err
@@ -126,7 +126,7 @@ func (s *Shard) putObjectLSM(object *storobj.Object,
 	if err := s.upsertObjectDataLSM(bucket, idBytes, data, status.docID); err != nil {
 		return status, errors.Wrap(err, "upsert object data")
 	}
-	s.docIdLock.Unlock()
+	s.docIdLock[s.uuidToIdLockPoolId(idBytes)].Unlock()
 	s.metrics.PutObjectUpsertObject(before)
 
 	if !skipInverted {

--- a/adapters/repos/db/shard_write_put.go
+++ b/adapters/repos/db/shard_write_put.go
@@ -101,7 +101,11 @@ func (s *Shard) putObjectLSM(object *storobj.Object,
 	defer s.metrics.PutObject(before)
 
 	bucket := s.store.Bucket(helpers.ObjectsBucketLSM)
-	previous, err := bucket.Get([]byte(idBytes))
+
+	// First the object bucket is checked if already an object with the same uuid is present, to determine if it is new
+	// or an update. Afterwards the bucket is updates. To avoid races, only one goroutine can do this at once.
+	s.docIdLock.Lock()
+	previous, err := bucket.Get(idBytes)
 	if err != nil {
 		return objectInsertStatus{}, err
 	}
@@ -122,6 +126,7 @@ func (s *Shard) putObjectLSM(object *storobj.Object,
 	if err := s.upsertObjectDataLSM(bucket, idBytes, data, status.docID); err != nil {
 		return status, errors.Wrap(err, "upsert object data")
 	}
+	s.docIdLock.Unlock()
 	s.metrics.PutObjectUpsertObject(before)
 
 	if !skipInverted {

--- a/adapters/repos/db/vector/hnsw/insert.go
+++ b/adapters/repos/db/vector/hnsw/insert.go
@@ -66,6 +66,7 @@ func (h *hnsw) insertInitialElement(node *vertex, nodeVec []float32) error {
 	}
 
 	h.nodes[node.id] = node
+	h.cache.preload(node.id, nodeVec)
 
 	// go h.insertHook(node.id, 0, node.connections)
 	return nil


### PR DESCRIPTION
### What's being changed:

Fixes two bugs (in seperate commits):
- A race condition which could result in the same object being added more than once (from different batches) with different docIDs
- The initial node in the hsnw was not loaded into the cache. This could result in a panic, if a second node tried to use the first one as the entry point, but the first one was already deleted in the meantime

Note, that both bugs can be reproduced using a [stress-test](https://github.com/semi-technologies/weaviate/pull/2188), but there are more problems that have not yet been fixed and therefore the test can not be commited yet.

### Review checklist

- [x] Documentation has been updated, if necessary. Link to changed documentation:
- [x] Chaos pipeline run or not necessary. Link to pipeline: https://github.com/semi-technologies/weaviate-chaos-engineering/runs/8663586825
- [x] All new code is covered by tests where it is reasonable.
- [x] Performance tests have been run or not necessary.
