### PR TITLE
Assign backup operations to coordinators (part 1)

### DIFF
--- a/adapters/handlers/rest/configure_api.go
+++ b/adapters/handlers/rest/configure_api.go
@@ -208,8 +208,8 @@ func configureAPI(api *operations.WeaviateAPI) http.Handler {
 	appState.SchemaManager = schemaManager
 
 	appState.RemoteIncoming = sharding.NewRemoteIndexIncoming(repo)
-
-	backupManager := backup.NewManager(appState.Logger, appState.Authorizer,
+	node := appState.Cluster.LocalName()
+	backupManager := backup.NewManager(node, appState.Logger, appState.Authorizer,
 		schemaManager, repo, appState.Modules)
 	appState.BackupManager = backupManager
 

--- a/usecases/backup/auth_test.go
+++ b/usecases/backup/auth_test.go
@@ -84,7 +84,7 @@ func Test_Authorization(t *testing.T) {
 		for _, test := range tests {
 			t.Run(test.methodName, func(t *testing.T) {
 				authorizer := &authDenier{}
-				manager := NewManager(logger, authorizer, nil, nil, nil)
+				manager := NewManager("", logger, authorizer, nil, nil, nil)
 				require.NotNil(t, manager)
 
 				args := append([]interface{}{context.Background(), principal}, test.additionalArgs...)

--- a/usecases/backup/backupper_test.go
+++ b/usecases/backup/backupper_test.go
@@ -26,6 +26,10 @@ import (
 	"github.com/stretchr/testify/mock"
 )
 
+const (
+	nodeName = "Node-1"
+)
+
 func TestBackupStatus(t *testing.T) {
 	t.Parallel()
 	var (
@@ -709,5 +713,5 @@ func createManager(sourcer Sourcer, schema schemaManger, backend modulecapabilit
 	}
 
 	logger, _ := test.NewNullLogger()
-	return NewManager(logger, &fakeAuthorizer{}, schema, sourcer, backends)
+	return NewManager(nodeName, logger, &fakeAuthorizer{}, schema, sourcer, backends)
 }

--- a/usecases/backup/scheduler.go
+++ b/usecases/backup/scheduler.go
@@ -1,0 +1,141 @@
+package backup
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/semi-technologies/weaviate/entities/backup"
+	"github.com/semi-technologies/weaviate/entities/models"
+	"github.com/sirupsen/logrus"
+)
+
+// Scheduler assigns backup operations to coordinators.
+type Scheduler struct {
+	// deps
+	logger     logrus.FieldLogger
+	authorizer authorizer
+	backupper  *coordinator
+	restorer   *coordinator
+	backends   BackupBackendProvider
+}
+
+// NewScheduler creates a new scheduler with two coordinators
+func NewScheduler(
+	authorizer authorizer,
+	client client,
+	sourcer selector,
+	backends BackupBackendProvider,
+	nodeResolver nodeResolver,
+	logger logrus.FieldLogger,
+) *Scheduler {
+	m := &Scheduler{
+		logger:     logger,
+		authorizer: authorizer,
+		backends:   backends,
+		backupper: newCoordinator(
+			sourcer,
+			client,
+			logger, nodeResolver),
+		restorer: newCoordinator(
+			sourcer,
+			client,
+			logger, nodeResolver),
+	}
+	return m
+}
+
+func (s *Scheduler) Backup(ctx context.Context, pr *models.Principal, req *BackupRequest,
+) (*models.BackupCreateResponse, error) {
+	path := fmt.Sprintf("backups/%s/%s", req.Backend, req.ID)
+	if err := s.authorizer.Authorize(pr, "add", path); err != nil {
+		return nil, err
+	}
+	store, err := coordBackend(s.backends, req.Backend, req.ID)
+	if err != nil {
+		err = fmt.Errorf("no backup backend %q, did you enable the right module?", req.Backend)
+		return nil, backup.NewErrUnprocessable(err)
+	}
+
+	classes, err := s.validateBackupRequest(ctx, store, req)
+	if err != nil {
+		return nil, backup.NewErrUnprocessable(err)
+	}
+
+	if err := store.Initialize(ctx); err != nil {
+		return nil, backup.NewErrUnprocessable(fmt.Errorf("init uploader: %w", err))
+	}
+	breq := Request{
+		Method:  OpCreate,
+		ID:      req.ID,
+		Backend: req.Backend,
+		Classes: classes,
+	}
+	if err := s.backupper.Backup(ctx, store, &breq); err != nil {
+		return nil, backup.NewErrUnprocessable(err)
+	} else {
+		st := s.backupper.lastOp.get()
+		status := string(st.Status)
+		return &models.BackupCreateResponse{
+			Classes: classes,
+			ID:      req.ID,
+			Backend: req.Backend,
+			Status:  &status,
+			Path:    st.Path,
+		}, nil
+	}
+}
+
+func (s *Scheduler) Restore(ctx context.Context, pr *models.Principal,
+	req *BackupRequest,
+) (*models.BackupRestoreResponse, error) {
+	return nil, backup.NewErrUnprocessable(fmt.Errorf("not implemented"))
+}
+
+func (m *Scheduler) BackupStatus(ctx context.Context, principal *models.Principal,
+	backend, backupID string,
+) (*models.BackupCreateStatusResponse, error) {
+	return nil, backup.NewErrUnprocessable(fmt.Errorf("not implemented"))
+}
+
+func (m *Scheduler) RestorationStatus(ctx context.Context, principal *models.Principal, backend, ID string,
+) (_ RestoreStatus, err error) {
+	return RestoreStatus{}, backup.NewErrUnprocessable(fmt.Errorf("not implemented"))
+}
+
+func coordBackend(provider BackupBackendProvider, backend, id string) (coordStore, error) {
+	caps, err := provider.BackupBackend(backend)
+	if err != nil {
+		return coordStore{}, err
+	}
+	return coordStore{objStore{b: caps, BasePath: id}}, nil
+}
+
+func (s *Scheduler) validateBackupRequest(ctx context.Context, store coordStore, req *BackupRequest) ([]string, error) {
+	if err := validateID(req.ID); err != nil {
+		return nil, err
+	}
+	if len(req.Include) > 0 && len(req.Exclude) > 0 {
+		return nil, fmt.Errorf("malformed request: 'include' and 'exclude' cannot be both empty")
+	}
+	classes := req.Include
+	if len(classes) == 0 {
+		classes = s.backupper.selector.ListClasses(ctx)
+	}
+	if classes = filterClasses(classes, req.Exclude); len(classes) == 0 {
+		return nil, fmt.Errorf("empty class list: please choose from : %v", classes)
+	}
+
+	if err := s.backupper.selector.Backupable(ctx, classes); err != nil {
+		return nil, err
+	}
+	destPath := store.HomeDir()
+	// there is no backup with given id on the backend, regardless of its state (valid or corrupted)
+	_, err := store.GlobalMeta(ctx, req.ID)
+	if err == nil {
+		return nil, fmt.Errorf("backup %q already exists at %q", req.ID, destPath)
+	}
+	if _, ok := err.(backup.ErrNotFound); !ok {
+		return nil, fmt.Errorf("check if backup %q exists at %q: %w", req.ID, destPath, err)
+	}
+	return classes, nil
+}

--- a/usecases/backup/scheduler_test.go
+++ b/usecases/backup/scheduler_test.go
@@ -1,0 +1,268 @@
+package backup
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/semi-technologies/weaviate/entities/backup"
+	"github.com/semi-technologies/weaviate/entities/models"
+	"github.com/sirupsen/logrus"
+	"github.com/sirupsen/logrus/hooks/test"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+)
+
+func TestSchedulerValidateCreateBackup(t *testing.T) {
+	t.Parallel()
+	var (
+		cls         = "MyClass"
+		backendName = "s3"
+		s           = newFakeScheduler().scheduler()
+		ctx         = context.Background()
+		id          = "123"
+		path        = "root/123"
+	)
+	t.Run("ValidateEmptyID", func(t *testing.T) {
+		_, err := s.Backup(ctx, nil, &BackupRequest{
+			Backend: backendName,
+			ID:      "",
+			Include: []string{cls},
+		})
+		assert.NotNil(t, err)
+	})
+	t.Run("ValidateID", func(t *testing.T) {
+		_, err := s.Backup(ctx, nil, &BackupRequest{
+			Backend: backendName,
+			ID:      "A*:",
+			Include: []string{cls},
+		})
+		assert.NotNil(t, err)
+	})
+	t.Run("IncludeExclude", func(t *testing.T) {
+		_, err := s.Backup(ctx, nil, &BackupRequest{
+			Backend: backendName,
+			ID:      "1234",
+			Include: []string{cls},
+			Exclude: []string{cls},
+		})
+		assert.NotNil(t, err)
+	})
+	t.Run("ResultingClassListIsEmpty", func(t *testing.T) {
+		// return one class and exclude it in the request
+		fs := newFakeScheduler()
+		fs.selector.On("ListClasses", ctx).Return([]string{cls})
+		_, err := fs.scheduler().Backup(ctx, nil, &BackupRequest{
+			Backend: backendName,
+			ID:      "1234",
+			Include: []string{},
+			Exclude: []string{cls},
+		})
+		assert.NotNil(t, err)
+	})
+	t.Run("ClassNotBackupable", func(t *testing.T) {
+		// return an error in case index doesn't exist or a shard has multiple nodes
+		fs := newFakeScheduler()
+		fs.selector.On("ListClasses", ctx).Return([]string{cls})
+		fs.selector.On("Backupable", ctx, []string{cls}).Return(ErrAny)
+		_, err := fs.scheduler().Backup(ctx, nil, &BackupRequest{
+			Backend: backendName,
+			ID:      "1234",
+			Include: []string{},
+		})
+		assert.NotNil(t, err)
+	})
+
+	t.Run("GetMetadataFails", func(t *testing.T) {
+		fs := newFakeScheduler()
+		fs.selector.On("Backupable", ctx, []string{cls}).Return(nil)
+		fs.backend.On("HomeDir", mock.Anything).Return(path)
+		fs.backend.On("GetObject", ctx, id, GlobalBackupFile).Return(nil, errors.New("can not be read"))
+		meta, err := fs.scheduler().Backup(ctx, nil, &BackupRequest{
+			Backend: backendName,
+			ID:      id,
+			Include: []string{cls},
+		})
+
+		assert.Nil(t, meta)
+		assert.NotNil(t, err)
+		assert.Contains(t, err.Error(), fmt.Sprintf("check if backup %q exists", id))
+		assert.IsType(t, backup.ErrUnprocessable{}, err)
+	})
+	t.Run("MetadataNotFound", func(t *testing.T) {
+		fs := newFakeScheduler()
+		fs.selector.On("Backupable", ctx, []string{cls}).Return(nil)
+		fs.backend.On("HomeDir", mock.Anything).Return(path)
+		bytes := marshalMeta(backup.BackupDescriptor{ID: id})
+		fs.backend.On("GetObject", ctx, id, GlobalBackupFile).Return(bytes, nil)
+		meta, err := fs.scheduler().Backup(ctx, nil, &BackupRequest{
+			Backend: backendName,
+			ID:      id,
+			Include: []string{cls},
+		})
+
+		assert.Nil(t, meta)
+		assert.NotNil(t, err)
+		assert.Contains(t, err.Error(), fmt.Sprintf("backup %q already exists", id))
+		assert.IsType(t, backup.ErrUnprocessable{}, err)
+	})
+}
+
+func TestSchedulerCreateBackup(t *testing.T) {
+	t.Parallel()
+	var (
+		cls         = "Class-A"
+		node        = "Node-A"
+		backendName = "gcs"
+		backupID    = "1"
+		any         = mock.Anything
+		ctx         = context.Background()
+		path        = "dst/path"
+		req         = BackupRequest{
+			ID:      backupID,
+			Include: []string{cls},
+			Backend: backendName,
+		}
+		cresp = &CanCommitResponse{Method: OpCreate, ID: backupID, Timeout: 1}
+		sReq  = &StatusRequest{OpCreate, backupID, backendName}
+		sresp = &StatusResponse{Status: backup.Success, ID: backupID, Method: OpCreate}
+	)
+
+	t.Run("AnotherBackupIsInProgress", func(t *testing.T) {
+		req1 := BackupRequest{
+			ID:      backupID,
+			Include: []string{cls},
+			Backend: backendName,
+		}
+
+		fs := newFakeScheduler()
+		// first
+		fs.selector.On("Backupable", ctx, req1.Include).Return(nil)
+		fs.selector.On("Shards", ctx, cls).Return([]string{node})
+
+		fs.backend.On("GetObject", ctx, backupID, GlobalBackupFile).Return(nil, backup.ErrNotFound{})
+		fs.backend.On("HomeDir", mock.Anything).Return(path)
+		fs.backend.On("Initialize", ctx, mock.Anything).Return(nil)
+		fs.client.On("CanCommit", any, node, any).Return(cresp, nil)
+		fs.client.On("Commit", any, node, sReq).Return(nil)
+		fs.client.On("Status", any, node, sReq).Return(sresp, nil)
+		fs.backend.On("PutObject", any, backupID, GlobalBackupFile, any).Return(nil).Once()
+		m := fs.scheduler()
+		resp1, err := m.Backup(ctx, nil, &req1)
+		assert.Nil(t, err)
+		status1 := string(backup.Started)
+		want1 := &models.BackupCreateResponse{
+			Backend: backendName,
+			Classes: req1.Include,
+			ID:      backupID,
+			Status:  &status1,
+			Path:    path,
+		}
+		assert.Equal(t, resp1, want1)
+		resp2, err := m.Backup(ctx, nil, &req1)
+		assert.NotNil(t, err)
+		assert.Contains(t, err.Error(), "already in progress")
+		assert.IsType(t, backup.ErrUnprocessable{}, err)
+		assert.Nil(t, resp2)
+	})
+
+	t.Run("BackendUnregistered", func(t *testing.T) {
+		classes := []string{cls}
+		backendError := errors.New("I do not exist")
+		fs := newFakeScheduler()
+		fs.backendErr = backendError
+		meta, err := fs.scheduler().Backup(ctx, nil, &BackupRequest{
+			Backend: backendName,
+			ID:      backupID,
+			Include: classes,
+		})
+
+		assert.Nil(t, meta)
+		assert.NotNil(t, err)
+		assert.Contains(t, err.Error(), backendName)
+		assert.IsType(t, backup.ErrUnprocessable{}, err)
+	})
+
+	t.Run("InitMetadata", func(t *testing.T) {
+		classes := []string{cls}
+		fs := newFakeScheduler()
+		fs.selector.On("Backupable", ctx, classes).Return(nil)
+		fs.backend.On("HomeDir", mock.Anything).Return(path)
+		fs.backend.On("GetObject", ctx, backupID, GlobalBackupFile).Return(nil, backup.NewErrNotFound(errors.New("not found")))
+		fs.backend.On("Initialize", ctx, backupID).Return(errors.New("init meta failed"))
+		meta, err := fs.scheduler().Backup(ctx, nil, &BackupRequest{
+			Backend: backendName,
+			ID:      backupID,
+			Include: classes,
+		})
+
+		assert.Nil(t, meta)
+		assert.NotNil(t, err)
+		assert.Contains(t, err.Error(), "init")
+		assert.IsType(t, backup.ErrUnprocessable{}, err)
+	})
+
+	t.Run("Success", func(t *testing.T) {
+		fs := newFakeScheduler()
+		fs.selector.On("Backupable", ctx, req.Include).Return(nil)
+		fs.selector.On("Shards", ctx, cls).Return([]string{node})
+
+		fs.backend.On("GetObject", ctx, backupID, GlobalBackupFile).Return(nil, backup.ErrNotFound{})
+		fs.backend.On("HomeDir", mock.Anything).Return(path)
+		fs.backend.On("Initialize", ctx, mock.Anything).Return(nil)
+		fs.client.On("CanCommit", any, node, any).Return(cresp, nil)
+		fs.client.On("Commit", any, node, sReq).Return(nil)
+		fs.client.On("Status", any, node, sReq).Return(sresp, nil)
+		fs.backend.On("PutObject", any, backupID, GlobalBackupFile, any).Return(nil).Once()
+		s := fs.scheduler()
+		resp, err := s.Backup(ctx, nil, &req)
+		assert.Nil(t, err)
+		status1 := string(backup.Started)
+		want1 := &models.BackupCreateResponse{
+			Backend: backendName,
+			Classes: req.Include,
+			ID:      backupID,
+			Status:  &status1,
+			Path:    path,
+		}
+		assert.Equal(t, resp, want1)
+
+		for i := 0; i < 10; i++ {
+			time.Sleep(time.Millisecond * 50)
+			if i > 0 && s.backupper.lastOp.get().Status == "" {
+				break
+			}
+		}
+		assert.Equal(t, fs.backend.glMeta.Status, backup.Success)
+		assert.Equal(t, fs.backend.glMeta.Error, "")
+	})
+}
+
+type fakeScheduler struct {
+	selector   fakeSelector
+	client     fakeClient
+	backend    *fakeBackend
+	backendErr error
+	auth       *fakeAuthorizer
+	log        logrus.FieldLogger
+}
+
+func newFakeScheduler() *fakeScheduler {
+	fc := fakeScheduler{}
+	fc.backend = newFakeBackend()
+	fc.backendErr = nil
+	logger, _ := test.NewNullLogger()
+	fc.auth = &fakeAuthorizer{}
+	fc.log = logger
+	return &fc
+}
+
+func (f *fakeScheduler) scheduler() *Scheduler {
+	provider := &fakeBackupBackendProvider{f.backend, f.backendErr}
+	c := NewScheduler(f.auth, &f.client, &f.selector, provider, nil, f.log)
+	c.backupper.timeoutNextRound = time.Millisecond * 200
+	c.restorer.timeoutNextRound = time.Millisecond * 200
+	return c
+}


### PR DESCRIPTION
PR is part of a series (#264) of PRs to implement distributed backup operations

### What's being changed:
Create Scheduler to handle reset endpoints for backup instead of Handler.
Customise object store for coordinator

### Review checklist

- [x] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [x] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.
