### PR TITLE
Enable aggregation integration tests with filters

### DIFF
--- a/adapters/repos/db/aggregations_integration_test.go
+++ b/adapters/repos/db/aggregations_integration_test.go
@@ -102,9 +102,8 @@ func Test_Aggregations_MultiShard(t *testing.T) {
 	t.Run("numerical aggregations without grouping (formerly Meta)",
 		testNumericalAggregationsWithoutGrouping(repo, false))
 
-	// TODO: does not work currently, part of https://semi-technology.atlassian.net/browse/WEAVIATE-328
-	// t.Run("numerical aggregations with filters",
-	//	testNumericalAggregationsWithFilters(repo))
+	t.Run("numerical aggregations with filters",
+		testNumericalAggregationsWithFilters(repo))
 
 	t.Run("date aggregations with grouping",
 		testDateAggregationsWithGrouping(repo, true))


### PR DESCRIPTION
### What's being changed:

Enables tests that had previously failed. They were probably fixed by one of the earlier aggregation fixes :)

