### PR TITLE
Backup manager get node name from schema manager

### DIFF
--- a/adapters/handlers/rest/configure_api.go
+++ b/adapters/handlers/rest/configure_api.go
@@ -213,9 +213,8 @@ func configureAPI(api *operations.WeaviateAPI) http.Handler {
 
 	appState.RemoteIndexIncoming = sharding.NewRemoteIndexIncoming(repo)
 	appState.RemoteNodeIncoming = sharding.NewRemoteNodeIncoming(repo)
-	node := appState.Cluster.LocalName()
 
-	backupManager := backup.NewManager(node, appState.Logger, appState.Authorizer,
+	backupManager := backup.NewManager(appState.Logger, appState.Authorizer,
 		schemaManager, repo, appState.Modules)
 	appState.BackupManager = backupManager
 

--- a/adapters/repos/db/clusterintegrationtest/backup_coordinator_integration_test.go
+++ b/adapters/repos/db/clusterintegrationtest/backup_coordinator_integration_test.go
@@ -29,7 +29,6 @@ import (
 )
 
 func TestDistributedBackups(t *testing.T) {
-	t.Skip()
 	var (
 		dirName = setupDirectory(t)
 		numObjs = 100

--- a/adapters/repos/db/clusterintegrationtest/fakes_for_test.go
+++ b/adapters/repos/db/clusterintegrationtest/fakes_for_test.go
@@ -88,7 +88,7 @@ func (n *node) init(dirName string, shardStateRaw []byte,
 
 	backendProvider := newFakeBackupBackendProvider(localDir)
 	n.backupManager = ubak.NewManager(
-		n.name, logger, &fakeAuthorizer{}, n.schemaManager, n.repo, backendProvider)
+		logger, &fakeAuthorizer{}, n.schemaManager, n.repo, backendProvider)
 
 	backupClient := clients.NewClusterBackups(&http.Client{})
 	n.scheduler = ubak.NewScheduler(

--- a/usecases/backup/auth_test.go
+++ b/usecases/backup/auth_test.go
@@ -84,7 +84,8 @@ func Test_Authorization(t *testing.T) {
 		for _, test := range tests {
 			t.Run(test.methodName, func(t *testing.T) {
 				authorizer := &authDenier{}
-				manager := NewManager("", logger, authorizer, nil, nil, nil)
+				schema := &fakeSchemaManger{nodeName: nodeName}
+				manager := NewManager(logger, authorizer, schema, nil, nil)
 				require.NotNil(t, manager)
 
 				args := append([]interface{}{context.Background(), principal}, test.additionalArgs...)

--- a/usecases/backup/backupper_test.go
+++ b/usecases/backup/backupper_test.go
@@ -710,9 +710,9 @@ func createManager(sourcer Sourcer, schema schemaManger, backend modulecapabilit
 		sourcer = &fakeSourcer{}
 	}
 	if schema == nil {
-		schema = &fakeSchemaManger{}
+		schema = &fakeSchemaManger{nodeName: nodeName}
 	}
 
 	logger, _ := test.NewNullLogger()
-	return NewManager(nodeName, logger, &fakeAuthorizer{}, schema, sourcer, backends)
+	return NewManager(logger, &fakeAuthorizer{}, schema, sourcer, backends)
 }

--- a/usecases/backup/handler.go
+++ b/usecases/backup/handler.go
@@ -45,6 +45,7 @@ type authorizer interface {
 
 type schemaManger interface {
 	RestoreClass(ctx context.Context, d *backup.ClassDescriptor) error
+	NodeName() string
 }
 
 type nodeResolver interface {
@@ -70,13 +71,13 @@ type Manager struct {
 }
 
 func NewManager(
-	node string,
 	logger logrus.FieldLogger,
 	authorizer authorizer,
 	schema schemaManger,
 	sourcer Sourcer,
 	backends BackupBackendProvider,
 ) *Manager {
+	node := schema.NodeName()
 	m := &Manager{
 		node:       node,
 		logger:     logger,

--- a/usecases/backup/handler_test.go
+++ b/usecases/backup/handler_test.go
@@ -23,11 +23,16 @@ import (
 
 type fakeSchemaManger struct {
 	errRestoreClass error
+	nodeName        string
 }
 
 func (f *fakeSchemaManger) RestoreClass(context.Context, *backup.ClassDescriptor,
 ) error {
 	return f.errRestoreClass
+}
+
+func (f *fakeSchemaManger) NodeName() string {
+	return f.nodeName
 }
 
 type fakeAuthorizer struct{}

--- a/usecases/backup/restorer_test.go
+++ b/usecases/backup/restorer_test.go
@@ -393,7 +393,7 @@ func TestManagerRestoreBackup(t *testing.T) {
 		}
 		backend := &fakeBackend{}
 		sourcer := &fakeSourcer{}
-		schema := fakeSchemaManger{errRestoreClass: ErrAny}
+		schema := fakeSchemaManger{errRestoreClass: ErrAny, nodeName: nodeName}
 		sourcer.On("ClassExists", cls).Return(false)
 		bytes := marshalMeta(meta2)
 		backend.On("GetObject", ctx, nodeHome, BackupFile).Return(bytes, nil)


### PR DESCRIPTION
### What's being changed:

With the changes made for the new nodes API (#2249), the backup manager can get the node name directly from the schema manager, rather than relying on global app state

### Review checklist

- [x] All new code is covered by tests where it is reasonable.

