### PR TITLE
Implement scheduler’s endpoint for restoring distributed backups

### DIFF
--- a/adapters/repos/db/backup.go
+++ b/adapters/repos/db/backup.go
@@ -28,8 +28,6 @@ type BackupState struct {
 }
 
 // Backupable returns whether all given class can be backed up.
-//
-// A class cannot be backed up either if it doesn't exist or if it has more than one physical shard.
 func (db *DB) Backupable(ctx context.Context, classes []string) error {
 	for _, c := range classes {
 		idx := db.GetIndex(schema.ClassName(c))
@@ -41,15 +39,10 @@ func (db *DB) Backupable(ctx context.Context, classes []string) error {
 }
 
 // ListBackupable returns a list of all classes which can be backed up.
-//
-// A class cannot be backed up either if it doesn't exist or if it has more than one physical shard.
 func (db *DB) ListBackupable() []string {
 	cs := make([]string, 0, len(db.indices))
 	for _, idx := range db.indices {
 		cls := string(idx.Config.ClassName)
-		if n := db.schemaGetter.ShardingState(cls).CountPhysicalShards(); n > 1 {
-			continue
-		}
 		cs = append(cs, cls)
 	}
 	return cs

--- a/entities/backup/descriptor_test.go
+++ b/entities/backup/descriptor_test.go
@@ -12,6 +12,7 @@
 package backup
 
 import (
+	"sort"
 	"testing"
 	"time"
 
@@ -176,6 +177,187 @@ func TestValidateBackup(t *testing.T) {
 					DocIDCounter: bytes, Version: bytes, PropLengthTracker: bytes, Files: []string{"file"},
 				}},
 			}},
+		}, success: true},
+	}
+	for i, tc := range tests {
+		err := tc.desc.Validate()
+		if got := err == nil; got != tc.success {
+			t.Errorf("%d. validate(%+v): want=%v got=%v err=%v", i, tc.desc, tc.success, got, err)
+		}
+	}
+}
+
+func TestDistributedBackup(t *testing.T) {
+	d := DistributedBackupDescriptor{
+		Nodes: map[string]*NodeDescriptor{
+			"N1": {Classes: []string{"1", "2"}},
+			"N2": {Classes: []string{"3", "4"}},
+		},
+	}
+	if n := d.Len(); n != 2 {
+		t.Errorf("#nodes got:%v want:%v", n, 2)
+	}
+	if n := d.Count(); n != 4 {
+		t.Errorf("#classes got:%v want:%v", n, 4)
+	}
+	d.Exclude([]string{"3", "4"})
+	d.RemoveEmpty()
+	if n := d.Len(); n != 1 {
+		t.Errorf("#nodes got:%v want:%v", n, 2)
+	}
+	if n := d.Count(); n != 2 {
+		t.Errorf("#classes got:%v want:%v", n, 4)
+	}
+}
+
+func TestDistributedBackupExcludeClasses(t *testing.T) {
+	tests := []struct {
+		in  DistributedBackupDescriptor
+		xs  []string
+		out []string
+	}{
+		{
+			in:  DistributedBackupDescriptor{},
+			xs:  []string{},
+			out: []string{},
+		},
+		{
+			in: DistributedBackupDescriptor{
+				Nodes: map[string]*NodeDescriptor{
+					"N1": {Classes: []string{"a"}},
+				},
+			},
+			xs:  []string{},
+			out: []string{"a"},
+		},
+		{
+			in: DistributedBackupDescriptor{
+				Nodes: map[string]*NodeDescriptor{
+					"N1": {Classes: []string{"a"}},
+				},
+			},
+			xs:  []string{"a"},
+			out: []string{},
+		},
+		{
+			in: DistributedBackupDescriptor{
+				Nodes: map[string]*NodeDescriptor{
+					"N1": {Classes: []string{"1", "2"}},
+					"N2": {Classes: []string{"3", "4"}},
+				},
+			},
+			xs:  []string{"2", "3"},
+			out: []string{"1", "4"},
+		},
+
+		{
+			in: DistributedBackupDescriptor{
+				Nodes: map[string]*NodeDescriptor{
+					"N1": {Classes: []string{"1", "2"}},
+					"N2": {Classes: []string{"3"}},
+				},
+			},
+			xs:  []string{"1", "3"},
+			out: []string{"2"},
+		},
+	}
+
+	for _, tc := range tests {
+		tc.in.Exclude(tc.xs)
+		lst := tc.in.Classes()
+		sort.Strings(lst)
+		assert.Equal(t, tc.out, lst)
+	}
+}
+
+func TestDistributedBackupIncludeClasses(t *testing.T) {
+	tests := []struct {
+		in  DistributedBackupDescriptor
+		xs  []string
+		out []string
+	}{
+		{
+			in:  DistributedBackupDescriptor{},
+			xs:  []string{},
+			out: []string{},
+		},
+		{
+			in: DistributedBackupDescriptor{
+				Nodes: map[string]*NodeDescriptor{
+					"N1": {Classes: []string{"a"}},
+				},
+			},
+			xs:  []string{},
+			out: []string{"a"},
+		},
+		{
+			in: DistributedBackupDescriptor{
+				Nodes: map[string]*NodeDescriptor{
+					"N1": {Classes: []string{"a"}},
+				},
+			},
+			xs:  []string{"a"},
+			out: []string{"a"},
+		},
+		{
+			in: DistributedBackupDescriptor{
+				Nodes: map[string]*NodeDescriptor{
+					"N1": {Classes: []string{"1", "2"}},
+					"N2": {Classes: []string{"3", "4"}},
+				},
+			},
+			xs:  []string{"2", "3"},
+			out: []string{"2", "3"},
+		},
+
+		{
+			in: DistributedBackupDescriptor{
+				Nodes: map[string]*NodeDescriptor{
+					"N1": {Classes: []string{"1", "2"}},
+					"N2": {Classes: []string{"3"}},
+				},
+			},
+			xs:  []string{"1", "3"},
+			out: []string{"1", "3"},
+		},
+	}
+	for _, tc := range tests {
+		tc.in.Include(tc.xs)
+		lst := tc.in.Classes()
+		sort.Strings(lst)
+		assert.Equal(t, tc.out, lst)
+	}
+}
+
+func TestDistributedBackupAllExist(t *testing.T) {
+	x := DistributedBackupDescriptor{Nodes: map[string]*NodeDescriptor{"N1": {Classes: []string{"a"}}}}
+	if y := x.AllExist(nil); y != "" {
+		t.Errorf("x.AllExists(nil) got=%v want=%v", y, "")
+	}
+	if y := x.AllExist([]string{"a"}); y != "" {
+		t.Errorf("x.AllExists(['a']) got=%v want=%v", y, "")
+	}
+	if y := x.AllExist([]string{"b"}); y != "b" {
+		t.Errorf("x.AllExists(['a']) got=%v want=%v", y, "b")
+	}
+}
+
+func TestDistributedBackupValidate(t *testing.T) {
+	timept := time.Now().UTC()
+	tests := []struct {
+		desc    DistributedBackupDescriptor
+		success bool
+	}{
+		// first level check
+		{desc: DistributedBackupDescriptor{}},
+		{desc: DistributedBackupDescriptor{ID: "1"}},
+		{desc: DistributedBackupDescriptor{ID: "1", Version: "1"}},
+		{desc: DistributedBackupDescriptor{ID: "1", Version: "1", ServerVersion: "1"}},
+		{desc: DistributedBackupDescriptor{ID: "1", Version: "1", ServerVersion: "1", StartedAt: timept, Error: "err"}},
+		{desc: DistributedBackupDescriptor{ID: "1", Version: "1", ServerVersion: "1", StartedAt: timept}},
+		{desc: DistributedBackupDescriptor{
+			ID: "1", Version: "1", ServerVersion: "1", StartedAt: timept,
+			Nodes: map[string]*NodeDescriptor{"N": {}},
 		}, success: true},
 	}
 	for i, tc := range tests {

--- a/usecases/backup/backupper.go
+++ b/usecases/backup/backupper.go
@@ -132,7 +132,7 @@ func (b *backupper) backup(ctx context.Context,
 	if prevID := b.lastOp.renew(id, store.HomeDir()); prevID != "" {
 		return ret, fmt.Errorf("backup %s already in progress", prevID)
 	}
-	b.waitingForCoodinatorToCommit.Store(true) // is set to false by wait()
+	b.waitingForCoordinatorToCommit.Store(true) // is set to false by wait()
 
 	go func() {
 		defer b.lastOp.reset()

--- a/usecases/backup/coordinator.go
+++ b/usecases/backup/coordinator.go
@@ -49,7 +49,7 @@ const (
 	_MaxNumberConns     = 16
 )
 
-type nodeMap map[string]backup.NodeDescriptor
+type nodeMap map[string]*backup.NodeDescriptor
 
 // participantStatus tracks status of a participant in a DBRO
 type participantStatus struct {
@@ -174,10 +174,18 @@ func (c *coordinator) Backup(ctx context.Context, store coordStore, req *Request
 
 // Restore coordinates a distributed restoration among participants
 func (c *coordinator) Restore(ctx context.Context, store coordStore, req *backup.DistributedBackupDescriptor) error {
+	// make sure there is no active backup
+	if prevID := c.lastOp.renew(req.ID, store.HomeDir()); prevID != "" {
+		return fmt.Errorf("restoration %s already in progress", prevID)
+	}
 	c.descriptor = *req
+	for key := range c.Participants {
+		delete(c.Participants, key)
+	}
 	c.descriptor.StartedAt = time.Now().UTC()
 	nodes, err := c.canCommit(ctx, OpRestore)
 	if err != nil {
+		c.lastOp.reset()
 		return err
 	}
 
@@ -186,8 +194,8 @@ func (c *coordinator) Restore(ctx context.Context, store coordStore, req *backup
 		ID:      req.ID,
 		Backend: req.Backend,
 	}
-
 	go func() {
+		defer c.lastOp.reset()
 		c.commit(context.Background(), &statusReq, nodes)
 		if err := store.PutMeta(ctx, GlobalRestoreFile, &c.descriptor); err != nil {
 			c.log.WithField("action", OpCreate).
@@ -430,7 +438,7 @@ func (c *coordinator) groupByShard(ctx context.Context, classes []string) (nodeM
 		for _, node := range nodes {
 			nd, ok := m[node]
 			if !ok {
-				nd = backup.NodeDescriptor{Classes: make([]string, 0, 5)}
+				nd = &backup.NodeDescriptor{Classes: make([]string, 0, 5)}
 			}
 			nd.Classes = append(nd.Classes, cls)
 			m[node] = nd

--- a/usecases/backup/coordinator_test.go
+++ b/usecases/backup/coordinator_test.go
@@ -85,7 +85,7 @@ func TestCoordinatedBackup(t *testing.T) {
 			Status:        backup.Success,
 			Version:       Version,
 			ServerVersion: config.ServerVersion,
-			Nodes: map[string]backup.NodeDescriptor{
+			Nodes: map[string]*backup.NodeDescriptor{
 				nodes[0]: {
 					Classes: classes,
 					Status:  backup.Success,
@@ -166,7 +166,7 @@ func TestCoordinatedBackup(t *testing.T) {
 			Error:         got.Nodes[nodes[1]].Error,
 			Version:       Version,
 			ServerVersion: config.ServerVersion,
-			Nodes: map[string]backup.NodeDescriptor{
+			Nodes: map[string]*backup.NodeDescriptor{
 				nodes[0]: {
 					Classes: classes,
 					Status:  backup.Success,
@@ -216,7 +216,7 @@ func TestCoordinatedBackup(t *testing.T) {
 			Error:         got.Nodes[nodes[0]].Error,
 			Version:       Version,
 			ServerVersion: config.ServerVersion,
-			Nodes: map[string]backup.NodeDescriptor{
+			Nodes: map[string]*backup.NodeDescriptor{
 				nodes[1]: {
 					Classes: classes,
 					Status:  backup.Success,
@@ -239,6 +239,7 @@ func TestCoordinatedRestore(t *testing.T) {
 		backendName  = "s3"
 		any          = mock.Anything
 		backupID     = "1"
+		path         = "backups/1"
 		ctx          = context.Background()
 		nodes        = []string{"N1", "N2"}
 		classes      = []string{"Class-A", "Class-B"}
@@ -252,7 +253,7 @@ func TestCoordinatedRestore(t *testing.T) {
 				Status:        backup.Success,
 				Version:       Version,
 				ServerVersion: config.ServerVersion,
-				Nodes: map[string]backup.NodeDescriptor{
+				Nodes: map[string]*backup.NodeDescriptor{
 					nodes[0]: {
 						Classes: classes,
 						Status:  backup.Success,
@@ -305,6 +306,7 @@ func TestCoordinatedRestore(t *testing.T) {
 		fc := newFakeCoordinator(nodeResolver)
 		fc.client.On("CanCommit", any, nodes[0], creq).Return(cresp, nil)
 		fc.client.On("CanCommit", any, nodes[1], creq).Return(&CanCommitResponse{}, nil)
+		fc.backend.On("HomeDir", mock.Anything).Return(path)
 		fc.client.On("Abort", any, nodes[0], abortReq).Return(nil)
 
 		coordinator := *fc.coordinator()

--- a/usecases/backup/fakes_test.go
+++ b/usecases/backup/fakes_test.go
@@ -84,7 +84,7 @@ func (s *fakeBackend) PutObject(ctx context.Context, backupID, key string, bytes
 	args := s.Called(ctx, backupID, key, bytes)
 	if key == BackupFile {
 		json.Unmarshal(bytes, &s.meta)
-	} else if key == GlobalBackupFile {
+	} else if key == GlobalBackupFile || key == GlobalRestoreFile {
 		json.Unmarshal(bytes, &s.glMeta)
 		close(s.doneChan)
 	}

--- a/usecases/backup/handler.go
+++ b/usecases/backup/handler.go
@@ -155,7 +155,7 @@ func (m *Manager) Restore(ctx context.Context, pr *models.Principal,
 		err = fmt.Errorf("no backup backend %q, did you enable the right module?", req.Backend)
 		return nil, backup.NewErrUnprocessable(err)
 	}
-	meta, err := m.validateRestoreRequst(ctx, store, req)
+	meta, err := m.validateRestoreRequest(ctx, store, req)
 	if err != nil {
 		return nil, err
 	}
@@ -325,7 +325,7 @@ func (m *Manager) validateBackupRequest(ctx context.Context, store nodeStore, re
 	return classes, nil
 }
 
-func (m *Manager) validateRestoreRequst(ctx context.Context, store nodeStore, req *BackupRequest) (*backup.BackupDescriptor, error) {
+func (m *Manager) validateRestoreRequest(ctx context.Context, store nodeStore, req *BackupRequest) (*backup.BackupDescriptor, error) {
 	if len(req.Include) > 0 && len(req.Exclude) > 0 {
 		err := fmt.Errorf("malformed request: 'include' and 'exclude' cannot be both empty")
 		return nil, backup.NewErrUnprocessable(err)

--- a/usecases/backup/restorer.go
+++ b/usecases/backup/restorer.go
@@ -97,7 +97,7 @@ func (r *restorer) restore(ctx context.Context,
 		err := fmt.Errorf("restore %s already in progress", prevID)
 		return ret, err
 	}
-	r.waitingForCoodinatorToCommit.Store(true) // is set to false by wait()
+	r.waitingForCoordinatorToCommit.Store(true) // is set to false by wait()
 
 	go func() {
 		var err error

--- a/usecases/backup/restorer_test.go
+++ b/usecases/backup/restorer_test.go
@@ -125,7 +125,7 @@ func TestRestoreRequestValidation(t *testing.T) {
 		assert.Contains(t, err.Error(), backendName)
 	})
 
-	t.Run("GetMetdataFile", func(t *testing.T) {
+	t.Run("GetMetadataFile", func(t *testing.T) {
 		backend := &fakeBackend{}
 		backend.On("GetObject", ctx, nodeHome, BackupFile).Return(nil, ErrAny)
 		backend.On("HomeDir", mock.Anything).Return(path)
@@ -182,7 +182,7 @@ func TestRestoreRequestValidation(t *testing.T) {
 		assert.Contains(t, err.Error(), "wrong backup file")
 	})
 
-	t.Run("UknownClass", func(t *testing.T) {
+	t.Run("UnknownClass", func(t *testing.T) {
 		backend := &fakeBackend{}
 		bytes := marshalMeta(meta)
 		backend.On("GetObject", ctx, nodeHome, BackupFile).Return(bytes, nil)


### PR DESCRIPTION
Make restoring mutually exclusive

Enable listing sharded classes during backup

PR is part of a series (#264) of PRs to implement distributed backup operations

### What's being changed:


### Review checklist

- [x] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [x] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.
