### PR TITLE
Fix updating empty arrays

### DIFF
--- a/adapters/repos/db/crud_integration_test.go
+++ b/adapters/repos/db/crud_integration_test.go
@@ -1827,6 +1827,83 @@ func Test_PutPatchRestart(t *testing.T) {
 	})
 }
 
+func TestCRUDWithEmptyArrays(t *testing.T) {
+	rand.Seed(time.Now().UnixNano())
+	dirName := t.TempDir()
+
+	logger, _ := test.NewNullLogger()
+
+	class := &models.Class{
+		Class:               "TestClass",
+		VectorIndexConfig:   enthnsw.NewDefaultUserConfig(),
+		InvertedIndexConfig: invertedConfig(),
+		Properties: []*models.Property{
+			{
+				Name:     "stringArray",
+				DataType: []string{string(schema.DataTypeStringArray)},
+			},
+			{
+				Name:     "NumberArray",
+				DataType: []string{string(schema.DataTypeNumberArray)},
+			},
+			{
+				Name:     "BoolArray",
+				DataType: []string{string(schema.DataTypeBooleanArray)},
+			},
+		},
+	}
+	schemaGetter := &fakeSchemaGetter{shardState: singleShardState()}
+	repo := New(logger, Config{
+		RootPath:                  dirName,
+		QueryMaximumResults:       10,
+		DiskUseWarningPercentage:  config.DefaultDiskUseWarningPercentage,
+		DiskUseReadOnlyPercentage: config.DefaultDiskUseReadonlyPercentage,
+		MaxImportGoroutinesFactor: 1,
+	}, &fakeRemoteClient{}, &fakeNodeResolver{}, nil)
+	repo.SetSchemaGetter(schemaGetter)
+	err := repo.WaitForStartup(testCtx())
+	require.Nil(t, err)
+	defer repo.Shutdown(context.Background())
+	migrator := NewMigrator(repo, logger)
+	require.Nil(t,
+		migrator.AddClass(context.Background(), class, schemaGetter.shardState))
+
+	// update schema getter so it's in sync with class
+	schemaGetter.schema = schema.Schema{
+		Objects: &models.Schema{
+			Classes: []*models.Class{class},
+		},
+	}
+
+	ID := strfmt.UUID("a0b55b05-bc5b-4cc9-b646-1452d1390a62")
+	obj1 := &models.Object{
+		ID:    ID,
+		Class: "TestClass",
+		Properties: map[string]interface{}{
+			"stringArray": []string{},
+			"NumberArray": []float64{},
+			"BoolArray":   []bool{},
+		},
+	}
+	obj2 := &models.Object{
+		ID:    ID,
+		Class: "TestClass",
+		Properties: map[string]interface{}{
+			"stringArray": []string{"value"},
+			"NumberArray": []float64{0.5},
+			"BoolArray":   []bool{true},
+		},
+	}
+
+	assert.Nil(t, repo.PutObject(context.Background(), obj1, []float32{1, 3, 5, 0.4}))
+	assert.Nil(t, repo.PutObject(context.Background(), obj2, []float32{1, 3, 5, 0.4}))
+
+	res, err := repo.ObjectByID(context.Background(), ID, nil,
+		additional.Properties{})
+	require.Nil(t, err)
+	assert.Equal(t, obj2.Properties, res.ObjectWithVector(false).Properties)
+}
+
 func findID(list []search.Result, id strfmt.UUID) (search.Result, bool) {
 	for _, item := range list {
 		if item.ID == id {

--- a/entities/storobj/enrich_schema_datatypes.go
+++ b/entities/storobj/enrich_schema_datatypes.go
@@ -51,6 +51,10 @@ func (ko *Object) enrichSchemaTypes(schema map[string]interface{}) error {
 
 					schema[propName] = parsed
 				}
+			} else if len(typed) == 0 {
+				// empty arrays. Their exact type cannot be determined => use string as a dummy.
+				// This is wrong, but the best we can do here.
+				schema[propName] = make([]string, 0)
 			} else {
 				parsed, err := parseCrossRef(typed)
 				if err != nil {


### PR DESCRIPTION
### What's being changed:
Empty arrays were wrongly detected as MultiRef in (entities/storobj/enrich_schema_datatypes.go::enrichSchemaTypes) which caused an error somewhere else. This wasn't an issue in 1.15.0 because the code where the error appeared was not there, yet.

### Review checklist

- [x] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline: https://github.com/semi-technologies/weaviate-chaos-engineering/runs/8829870514
- [x] All new code is covered by tests where it is reasonable.
- [x] Performance tests have been run or not necessary.
