### PR TITLE
Fix single-node backups to work without needing cluster env vars

### DIFF
--- a/adapters/handlers/rest/clusterapi/serve.go
+++ b/adapters/handlers/rest/clusterapi/serve.go
@@ -21,9 +21,6 @@ import (
 
 func Serve(appState *state.State) {
 	port := appState.ServerConfig.Config.Cluster.DataBindPort
-	if port <= 0 {
-		port = 7946
-	}
 
 	appState.Logger.WithField("port", port).
 		WithField("action", "cluster_api_startup").

--- a/test/docker/compose.go
+++ b/test/docker/compose.go
@@ -231,6 +231,11 @@ func (d *Compose) Start(ctx context.Context) (*DockerCompose, error) {
 	if d.withWeaviate {
 		image := os.Getenv(envTestWeaviateImage)
 		hostname := Weaviate
+		if d.withWeaviateCluster {
+			envSettings["CLUSTER_HOSTNAME"] = "node1"
+			envSettings["CLUSTER_GOSSIP_BIND_PORT"] = "7100"
+			envSettings["CLUSTER_DATA_BIND_PORT"] = "7101"
+		}
 		container, err := startWeaviate(ctx, d.enableModules, d.defaultVectorizerModule,
 			envSettings, networkName, image, hostname)
 		if err != nil {

--- a/test/docker/weaviate.go
+++ b/test/docker/weaviate.go
@@ -56,9 +56,6 @@ func startWeaviate(ctx context.Context,
 		"QUERY_DEFAULTS_LIMIT":      "20",
 		"PERSISTENCE_DATA_PATH":     "./data",
 		"DEFAULT_VECTORIZER_MODULE": "none",
-		"CLUSTER_HOSTNAME":          "node1",
-		"CLUSTER_GOSSIP_BIND_PORT":  "7100",
-		"CLUSTER_DATA_BIND_PORT":    "7101",
 	}
 	if len(enableModules) > 0 {
 		env["ENABLE_MODULES"] = strings.Join(enableModules, ",")

--- a/test/modules/backup-filesystem/backup_journey_test.go
+++ b/test/modules/backup-filesystem/backup_journey_test.go
@@ -31,24 +31,44 @@ func Test_BackupJourney(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Minute)
 	defer cancel()
 
-	compose, err := docker.New().
-		WithBackendFilesystem().
-		WithText2VecContextionary().
-		WithWeaviate().
-		WithWeaviateCluster().
-		Start(ctx)
-	require.Nil(t, err)
-	defer func() {
-		if err := compose.Terminate(ctx); err != nil {
-			t.Fatalf("failed to terminte test containers: %s", err.Error())
-		}
-	}()
+	t.Run("single node", func(t *testing.T) {
+		compose, err := docker.New().
+			WithBackendFilesystem().
+			WithText2VecContextionary().
+			WithWeaviate().
+			Start(ctx)
+		require.Nil(t, err)
 
-	t.Run("backup-filesystem", func(t *testing.T) {
-		journey.BackupJourneyTests_SingleNode(t, compose.GetWeaviate().URI(),
-			"filesystem", fsBackupJourneyClassName, fsBackupJourneyBackupIDSingleNode)
+		defer func() {
+			if err := compose.Terminate(ctx); err != nil {
+				t.Fatalf("failed to terminte test containers: %s", err.Error())
+			}
+		}()
 
-		journey.BackupJourneyTests_Cluster(t, "filesystem", fsBackupJourneyClassName,
-			fsBackupJourneyBackupIDCluster, compose.GetWeaviate().URI(), compose.GetWeaviateNode2().URI())
+		t.Run("backup-filesystem", func(t *testing.T) {
+			journey.BackupJourneyTests_SingleNode(t, compose.GetWeaviate().URI(),
+				"filesystem", fsBackupJourneyClassName, fsBackupJourneyBackupIDSingleNode)
+		})
+	})
+
+	t.Run("multiple nodes", func(t *testing.T) {
+		compose, err := docker.New().
+			WithBackendFilesystem().
+			WithText2VecContextionary().
+			WithWeaviate().
+			WithWeaviateCluster().
+			Start(ctx)
+		require.Nil(t, err)
+
+		defer func() {
+			if err := compose.Terminate(ctx); err != nil {
+				t.Fatalf("failed to terminte test containers: %s", err.Error())
+			}
+		}()
+
+		t.Run("backup-filesystem", func(t *testing.T) {
+			journey.BackupJourneyTests_Cluster(t, "filesystem", fsBackupJourneyClassName,
+				fsBackupJourneyBackupIDCluster, compose.GetWeaviate().URI(), compose.GetWeaviateNode2().URI())
+		})
 	})
 }

--- a/test/modules/backup-filesystem/backup_journey_test.go
+++ b/test/modules/backup-filesystem/backup_journey_test.go
@@ -55,7 +55,6 @@ func Test_BackupJourney(t *testing.T) {
 		compose, err := docker.New().
 			WithBackendFilesystem().
 			WithText2VecContextionary().
-			WithWeaviate().
 			WithWeaviateCluster().
 			Start(ctx)
 		require.Nil(t, err)

--- a/test/modules/backup-gcs/backup_journey_test.go
+++ b/test/modules/backup-gcs/backup_journey_test.go
@@ -41,39 +41,70 @@ func Test_BackupJourney(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Minute)
 	defer cancel()
 
-	t.Run("pre-instance env setup", func(t *testing.T) {
-		require.Nil(t, os.Setenv(envGCSCredentials, ""))
-		require.Nil(t, os.Setenv(envGCSProjectID, gcsBackupJourneyProjectID))
-		require.Nil(t, os.Setenv(envGCSBucket, gcsBackupJourneyBucketName))
+	t.Run("single node", func(t *testing.T) {
+		t.Run("pre-instance env setup", func(t *testing.T) {
+			require.Nil(t, os.Setenv(envGCSCredentials, ""))
+			require.Nil(t, os.Setenv(envGCSProjectID, gcsBackupJourneyProjectID))
+			require.Nil(t, os.Setenv(envGCSBucket, gcsBackupJourneyBucketName))
+		})
+
+		compose, err := docker.New().
+			WithBackendGCS(gcsBackupJourneyBucketName).
+			WithText2VecContextionary().
+			WithWeaviate().
+			Start(ctx)
+		require.Nil(t, err)
+		defer func() {
+			if err := compose.Terminate(ctx); err != nil {
+				t.Fatalf("failed to terminte test containers: %s", err.Error())
+			}
+		}()
+
+		t.Run("post-instance env setup", func(t *testing.T) {
+			require.Nil(t, os.Setenv(envGCSEndpoint, compose.GetGCS().URI()))
+			require.Nil(t, os.Setenv(envGCSStorageEmulatorHost, compose.GetGCS().URI()))
+
+			createBucket(ctx, t, gcsBackupJourneyProjectID, gcsBackupJourneyBucketName)
+			helper.SetupClient(compose.GetWeaviate().URI())
+		})
+
+		t.Run("backup-gcs", func(t *testing.T) {
+			journey.BackupJourneyTests_SingleNode(t, compose.GetWeaviate().URI(),
+				"gcs", gcsBackupJourneyClassName, gcsBackupJourneyBackupIDSingleNode)
+		})
 	})
 
-	compose, err := docker.New().
-		WithBackendGCS(gcsBackupJourneyBucketName).
-		WithText2VecContextionary().
-		WithWeaviate().
-		WithWeaviateCluster().
-		Start(ctx)
-	require.Nil(t, err)
-	defer func() {
-		if err := compose.Terminate(ctx); err != nil {
-			t.Fatalf("failed to terminte test containers: %s", err.Error())
-		}
-	}()
+	t.Run("multiple node", func(t *testing.T) {
+		t.Run("pre-instance env setup", func(t *testing.T) {
+			require.Nil(t, os.Setenv(envGCSCredentials, ""))
+			require.Nil(t, os.Setenv(envGCSProjectID, gcsBackupJourneyProjectID))
+			require.Nil(t, os.Setenv(envGCSBucket, gcsBackupJourneyBucketName))
+		})
 
-	t.Run("post-instance env setup", func(t *testing.T) {
-		require.Nil(t, os.Setenv(envGCSEndpoint, compose.GetGCS().URI()))
-		require.Nil(t, os.Setenv(envGCSStorageEmulatorHost, compose.GetGCS().URI()))
+		compose, err := docker.New().
+			WithBackendGCS(gcsBackupJourneyBucketName).
+			WithText2VecContextionary().
+			WithWeaviate().
+			WithWeaviateCluster().
+			Start(ctx)
+		require.Nil(t, err)
+		defer func() {
+			if err := compose.Terminate(ctx); err != nil {
+				t.Fatalf("failed to terminte test containers: %s", err.Error())
+			}
+		}()
 
-		createBucket(ctx, t, gcsBackupJourneyProjectID, gcsBackupJourneyBucketName)
-		helper.SetupClient(compose.GetWeaviate().URI())
-	})
+		t.Run("post-instance env setup", func(t *testing.T) {
+			require.Nil(t, os.Setenv(envGCSEndpoint, compose.GetGCS().URI()))
+			require.Nil(t, os.Setenv(envGCSStorageEmulatorHost, compose.GetGCS().URI()))
 
-	// journey tests
-	t.Run("backup-gcs", func(t *testing.T) {
-		journey.BackupJourneyTests_SingleNode(t, compose.GetWeaviate().URI(),
-			"gcs", gcsBackupJourneyClassName, gcsBackupJourneyBackupIDSingleNode)
+			createBucket(ctx, t, gcsBackupJourneyProjectID, gcsBackupJourneyBucketName)
+			helper.SetupClient(compose.GetWeaviate().URI())
+		})
 
-		journey.BackupJourneyTests_Cluster(t, "gcs", gcsBackupJourneyClassName,
-			gcsBackupJourneyBackupIDCluster, compose.GetWeaviate().URI(), compose.GetWeaviateNode2().URI())
+		t.Run("backup-gcs", func(t *testing.T) {
+			journey.BackupJourneyTests_Cluster(t, "gcs", gcsBackupJourneyClassName,
+				gcsBackupJourneyBackupIDCluster, compose.GetWeaviate().URI(), compose.GetWeaviateNode2().URI())
+		})
 	})
 }

--- a/test/modules/backup-gcs/backup_journey_test.go
+++ b/test/modules/backup-gcs/backup_journey_test.go
@@ -84,7 +84,6 @@ func Test_BackupJourney(t *testing.T) {
 		compose, err := docker.New().
 			WithBackendGCS(gcsBackupJourneyBucketName).
 			WithText2VecContextionary().
-			WithWeaviate().
 			WithWeaviateCluster().
 			Start(ctx)
 		require.Nil(t, err)

--- a/test/modules/backup-s3/backup_journey_test.go
+++ b/test/modules/backup-s3/backup_journey_test.go
@@ -40,39 +40,70 @@ const (
 )
 
 func Test_BackupJourney(t *testing.T) {
-	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Minute)
-	defer cancel()
+	t.Run("single node", func(t *testing.T) {
+		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Minute)
+		defer cancel()
 
-	t.Run("pre-instance env setup", func(t *testing.T) {
-		require.Nil(t, os.Setenv(envS3AccessKey, s3BackupJourneyAccessKey))
-		require.Nil(t, os.Setenv(envS3SecretKey, s3BackupJourneySecretKey))
-		require.Nil(t, os.Setenv(envS3Bucket, s3BackupJourneyBucketName))
+		t.Run("pre-instance env setup", func(t *testing.T) {
+			require.Nil(t, os.Setenv(envS3AccessKey, s3BackupJourneyAccessKey))
+			require.Nil(t, os.Setenv(envS3SecretKey, s3BackupJourneySecretKey))
+			require.Nil(t, os.Setenv(envS3Bucket, s3BackupJourneyBucketName))
+		})
+
+		compose, err := docker.New().
+			WithBackendS3(s3BackupJourneyBucketName).
+			WithText2VecContextionary().
+			WithWeaviate().
+			Start(ctx)
+		require.Nil(t, err)
+		defer func() {
+			if err := compose.Terminate(ctx); err != nil {
+				t.Fatalf("failed to terminte test containers: %s", err.Error())
+			}
+		}()
+
+		t.Run("post-instance env setup", func(t *testing.T) {
+			createBucket(ctx, t, compose.GetMinIO().URI(), s3BackupJourneyRegion, s3BackupJourneyBucketName)
+			helper.SetupClient(compose.GetWeaviate().URI())
+		})
+
+		t.Run("backup-s3", func(t *testing.T) {
+			journey.BackupJourneyTests_SingleNode(t, compose.GetWeaviate().URI(),
+				"s3", s3BackupJourneyClassName, s3BackupJourneyBackupIDSingleNode)
+		})
 	})
 
-	compose, err := docker.New().
-		WithBackendS3(s3BackupJourneyBucketName).
-		WithText2VecContextionary().
-		WithWeaviate().
-		WithWeaviateCluster().
-		Start(ctx)
-	require.Nil(t, err)
-	defer func() {
-		if err := compose.Terminate(ctx); err != nil {
-			t.Fatalf("failed to terminte test containers: %s", err.Error())
-		}
-	}()
+	t.Run("multiple node", func(t *testing.T) {
+		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Minute)
+		defer cancel()
 
-	t.Run("post-instance env setup", func(t *testing.T) {
-		createBucket(ctx, t, compose.GetMinIO().URI(), s3BackupJourneyRegion, s3BackupJourneyBucketName)
-		helper.SetupClient(compose.GetWeaviate().URI())
-	})
+		t.Run("pre-instance env setup", func(t *testing.T) {
+			require.Nil(t, os.Setenv(envS3AccessKey, s3BackupJourneyAccessKey))
+			require.Nil(t, os.Setenv(envS3SecretKey, s3BackupJourneySecretKey))
+			require.Nil(t, os.Setenv(envS3Bucket, s3BackupJourneyBucketName))
+		})
 
-	// journey tests
-	t.Run("backup-s3", func(t *testing.T) {
-		journey.BackupJourneyTests_SingleNode(t, compose.GetWeaviate().URI(),
-			"s3", s3BackupJourneyClassName, s3BackupJourneyBackupIDSingleNode)
+		compose, err := docker.New().
+			WithBackendS3(s3BackupJourneyBucketName).
+			WithText2VecContextionary().
+			WithWeaviate().
+			WithWeaviateCluster().
+			Start(ctx)
+		require.Nil(t, err)
+		defer func() {
+			if err := compose.Terminate(ctx); err != nil {
+				t.Fatalf("failed to terminte test containers: %s", err.Error())
+			}
+		}()
 
-		journey.BackupJourneyTests_Cluster(t, "s3", s3BackupJourneyClassName,
-			s3BackupJourneyBackupIDCluster, compose.GetWeaviate().URI(), compose.GetWeaviateNode2().URI())
+		t.Run("post-instance env setup", func(t *testing.T) {
+			createBucket(ctx, t, compose.GetMinIO().URI(), s3BackupJourneyRegion, s3BackupJourneyBucketName)
+			helper.SetupClient(compose.GetWeaviate().URI())
+		})
+
+		t.Run("backup-s3", func(t *testing.T) {
+			journey.BackupJourneyTests_Cluster(t, "s3", s3BackupJourneyClassName,
+				s3BackupJourneyBackupIDCluster, compose.GetWeaviate().URI(), compose.GetWeaviateNode2().URI())
+		})
 	})
 }

--- a/test/modules/backup-s3/backup_journey_test.go
+++ b/test/modules/backup-s3/backup_journey_test.go
@@ -86,7 +86,6 @@ func Test_BackupJourney(t *testing.T) {
 		compose, err := docker.New().
 			WithBackendS3(s3BackupJourneyBucketName).
 			WithText2VecContextionary().
-			WithWeaviate().
 			WithWeaviateCluster().
 			Start(ctx)
 		require.Nil(t, err)

--- a/tools/dev/run_dev_server.sh
+++ b/tools/dev/run_dev_server.sh
@@ -45,6 +45,8 @@ case $CONFIG in
       BACKUP_FILESYSTEM_PATH="${PWD}/backups" \
       ENABLE_MODULES="text2vec-contextionary,backup-filesystem" \
       CLUSTER_HOSTNAME="node1" \
+      CLUSTER_GOSSIP_BIND_PORT="7100" \
+      CLUSTER_DATA_BIND_PORT="7101" \
       go_run ./cmd/weaviate-server \
         --scheme http \
         --host "127.0.0.1" \
@@ -59,7 +61,7 @@ case $CONFIG in
       CLUSTER_HOSTNAME="node2" \
       CLUSTER_GOSSIP_BIND_PORT="7102" \
       CLUSTER_DATA_BIND_PORT="7103" \
-      CLUSTER_JOIN="localhost:7946" \
+      CLUSTER_JOIN="localhost:7100" \
       CONTEXTIONARY_URL=localhost:9999 \
       DEFAULT_VECTORIZER_MODULE=text2vec-contextionary \
       ENABLE_MODULES="text2vec-contextionary,backup-filesystem" \

--- a/tools/dev/run_dev_server.sh
+++ b/tools/dev/run_dev_server.sh
@@ -45,8 +45,6 @@ case $CONFIG in
       BACKUP_FILESYSTEM_PATH="${PWD}/backups" \
       ENABLE_MODULES="text2vec-contextionary,backup-filesystem" \
       CLUSTER_HOSTNAME="node1" \
-      CLUSTER_GOSSIP_BIND_PORT="7100" \
-      CLUSTER_DATA_BIND_PORT="7101" \
       go_run ./cmd/weaviate-server \
         --scheme http \
         --host "127.0.0.1" \
@@ -61,7 +59,7 @@ case $CONFIG in
       CLUSTER_HOSTNAME="node2" \
       CLUSTER_GOSSIP_BIND_PORT="7102" \
       CLUSTER_DATA_BIND_PORT="7103" \
-      CLUSTER_JOIN="localhost:7100" \
+      CLUSTER_JOIN="localhost:7946" \
       CONTEXTIONARY_URL=localhost:9999 \
       DEFAULT_VECTORIZER_MODULE=text2vec-contextionary \
       ENABLE_MODULES="text2vec-contextionary,backup-filesystem" \

--- a/usecases/config/environment.go
+++ b/usecases/config/environment.go
@@ -101,6 +101,8 @@ func FromEnv(config *Config) error {
 		}
 
 		config.Cluster.GossipBindPort = asInt
+	} else {
+		config.Cluster.GossipBindPort = DefaultGossipBindPort
 	}
 
 	if v := os.Getenv("CLUSTER_DATA_BIND_PORT"); v != "" {
@@ -110,6 +112,10 @@ func FromEnv(config *Config) error {
 		}
 
 		config.Cluster.DataBindPort = asInt
+	} else {
+		// it is convention in this server that the data bind point is
+		// equal to the data bind port + 1
+		config.Cluster.DataBindPort = config.Cluster.GossipBindPort + 1
 	}
 
 	if v := os.Getenv("PERSISTENCE_DATA_PATH"); v != "" {
@@ -233,6 +239,10 @@ const DefaultQueryMaximumResults = int64(10000)
 const DefaultPersistenceFlushIdleMemtablesAfter = 60
 
 const VectorizerModuleNone = "none"
+
+// DefaultGossipBindPort uses the hashicorp/memberlist default
+// port value assigned with the use of DefaultLocalConfig
+const DefaultGossipBindPort = 7496
 
 // TODO: This should be retrieved dynamically from all installed modules
 const VectorizerModuleText2VecContextionary = "text2vec-contextionary"

--- a/usecases/config/environment.go
+++ b/usecases/config/environment.go
@@ -223,7 +223,7 @@ const VectorizerModuleNone = "none"
 
 // DefaultGossipBindPort uses the hashicorp/memberlist default
 // port value assigned with the use of DefaultLocalConfig
-const DefaultGossipBindPort = 7496
+const DefaultGossipBindPort = 7946
 
 // TODO: This should be retrieved dynamically from all installed modules
 const VectorizerModuleText2VecContextionary = "text2vec-contextionary"

--- a/usecases/config/environment.go
+++ b/usecases/config/environment.go
@@ -12,11 +12,13 @@
 package config
 
 import (
+	"fmt"
 	"os"
 	"strconv"
 	"strings"
 
 	"github.com/pkg/errors"
+	"github.com/semi-technologies/weaviate/usecases/cluster"
 )
 
 // FromEnv takes a *Config as it will respect initial config that has been
@@ -91,32 +93,11 @@ func FromEnv(config *Config) error {
 		config.Authorization.AdminList.Users = users
 	}
 
-	config.Cluster.Hostname = os.Getenv("CLUSTER_HOSTNAME")
-	config.Cluster.Join = os.Getenv("CLUSTER_JOIN")
-
-	if v := os.Getenv("CLUSTER_GOSSIP_BIND_PORT"); v != "" {
-		asInt, err := strconv.Atoi(v)
-		if err != nil {
-			return errors.Wrapf(err, "parse CLUSTER_GOSSIP_BIND_PORT as int")
-		}
-
-		config.Cluster.GossipBindPort = asInt
-	} else {
-		config.Cluster.GossipBindPort = DefaultGossipBindPort
+	clusterCfg, err := parseClusterConfig()
+	if err != nil {
+		return err
 	}
-
-	if v := os.Getenv("CLUSTER_DATA_BIND_PORT"); v != "" {
-		asInt, err := strconv.Atoi(v)
-		if err != nil {
-			return errors.Wrapf(err, "parse CLUSTER_DATA_BIND_PORT as int")
-		}
-
-		config.Cluster.DataBindPort = asInt
-	} else {
-		// it is convention in this server that the data bind point is
-		// equal to the data bind port + 1
-		config.Cluster.DataBindPort = config.Cluster.GossipBindPort + 1
-	}
+	config.Cluster = clusterCfg
 
 	if v := os.Getenv("PERSISTENCE_DATA_PATH"); v != "" {
 		config.Persistence.DataPath = v
@@ -306,4 +287,43 @@ func parseResourceUsageEnvVars() (ResourceUsage, error) {
 	}
 
 	return ru, nil
+}
+
+func parseClusterConfig() (cluster.Config, error) {
+	cfg := cluster.Config{}
+
+	cfg.Hostname = os.Getenv("CLUSTER_HOSTNAME")
+	cfg.Join = os.Getenv("CLUSTER_JOIN")
+
+	gossipBind, gossipBindSet := os.LookupEnv("CLUSTER_GOSSIP_BIND_PORT")
+	dataBind, dataBindSet := os.LookupEnv("CLUSTER_DATA_BIND_PORT")
+
+	if gossipBindSet {
+		asInt, err := strconv.Atoi(gossipBind)
+		if err != nil {
+			return cfg, fmt.Errorf("parse CLUSTER_GOSSIP_BIND_PORT as int: %w", err)
+		}
+		cfg.GossipBindPort = asInt
+	} else {
+		cfg.GossipBindPort = DefaultGossipBindPort
+	}
+
+	if dataBindSet {
+		asInt, err := strconv.Atoi(dataBind)
+		if err != nil {
+			return cfg, fmt.Errorf("parse CLUSTER_DATA_BIND_PORT as int: %w", err)
+		}
+		cfg.DataBindPort = asInt
+	} else {
+		// it is convention in this server that the data bind point is
+		// equal to the data bind port + 1
+		cfg.DataBindPort = cfg.GossipBindPort + 1
+	}
+
+	if cfg.DataBindPort != cfg.GossipBindPort+1 {
+		return cfg, fmt.Errorf("CLUSTER_DATA_BIND_PORT must be one port " +
+			"number greater than CLUSTER_GOSSIP_BIND_PORT")
+	}
+
+	return cfg, nil
 }

--- a/usecases/config/environment_test.go
+++ b/usecases/config/environment_test.go
@@ -12,9 +12,12 @@
 package config
 
 import (
+	"errors"
 	"os"
 	"testing"
 
+	"github.com/semi-technologies/weaviate/usecases/cluster"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -78,6 +81,77 @@ func TestEnvironmentSetFlushAfter(t *testing.T) {
 				require.NotNil(t, err)
 			} else {
 				require.Equal(t, tt.expected, conf.Persistence.FlushIdleMemtablesAfter)
+			}
+		})
+	}
+}
+
+func TestEnvironmentParseClusterConfig(t *testing.T) {
+	tests := []struct {
+		name           string
+		envVars        map[string]string
+		expectedResult cluster.Config
+		expectedErr    error
+	}{
+		{
+			name: "valid cluster config - both ports provided",
+			envVars: map[string]string{
+				"CLUSTER_GOSSIP_BIND_PORT": "7100",
+				"CLUSTER_DATA_BIND_PORT":   "7101",
+			},
+			expectedResult: cluster.Config{
+				GossipBindPort: 7100,
+				DataBindPort:   7101,
+			},
+		},
+		{
+			name: "valid cluster config - no ports provided",
+			expectedResult: cluster.Config{
+				GossipBindPort: DefaultGossipBindPort,
+				DataBindPort:   DefaultGossipBindPort + 1,
+			},
+		},
+		{
+			name: "valid cluster config - only gossip bind port provided",
+			envVars: map[string]string{
+				"CLUSTER_GOSSIP_BIND_PORT": "7777",
+			},
+			expectedResult: cluster.Config{
+				GossipBindPort: 7777,
+				DataBindPort:   7778,
+			},
+		},
+		{
+			name: "invalid cluster config - both ports provided",
+			envVars: map[string]string{
+				"CLUSTER_GOSSIP_BIND_PORT": "7100",
+				"CLUSTER_DATA_BIND_PORT":   "7111",
+			},
+			expectedErr: errors.New("CLUSTER_DATA_BIND_PORT must be one port " +
+				"number greater than CLUSTER_GOSSIP_BIND_PORT"),
+		},
+		{
+			name: "invalid config - only data bind port provided",
+			envVars: map[string]string{
+				"CLUSTER_DATA_BIND_PORT": "7101",
+			},
+			expectedErr: errors.New("CLUSTER_DATA_BIND_PORT must be one port " +
+				"number greater than CLUSTER_GOSSIP_BIND_PORT"),
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			for k, v := range test.envVars {
+				t.Setenv(k, v)
+			}
+			cfg, err := parseClusterConfig()
+			if test.expectedErr != nil {
+				assert.EqualError(t, err, test.expectedErr.Error(),
+					"expected err: %v, got: %v", test.expectedErr, err)
+			} else {
+				assert.Nil(t, err, "expected nil, got: %v", err)
+				assert.EqualValues(t, test.expectedResult, cfg)
 			}
 		})
 	}


### PR DESCRIPTION
### What's being changed:

Setting default data/gossip bind ports allows us to run single node backup/restore operations without having to configure cluster-specific environment variables.

These defaults were chosen accordingly:
- `CLUSTER_GOSSIP_BIND_PORT`: if not provided, we use the hardcoded port `7946`, which is the default set in [hashisorp's memberlist default config](https://github.com/hashicorp/memberlist/blob/9c88db2ac173b1a01688c47b4444e7536b2d72fd/config.go#L298)
- `CLUSTER_DATA_BIND_PORT`: if not provided, uses the weaviate convention of setting to one port greater than the node's gossip bind port

So if the ports are not provided, the data and gossip bind ports will be `7946` and `7947` respectively. Also, extra validation was added to ensure that if provided, the ports are aligned with the weaviate "gossip bind port +1" convention.

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [x] Chaos pipeline run or not necessary. Link to pipeline:
- [x] All new code is covered by tests where it is reasonable.
- [x] Performance tests have been run or not necessary.
