### PR TITLE
Add default vector distance metric

### DIFF
--- a/usecases/config/auto_schema_test.go
+++ b/usecases/config/auto_schema_test.go
@@ -1,3 +1,14 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2022 SeMI Technologies B.V. All rights reserved.
+//
+//  CONTACT: hello@semi.technology
+//
+
 package config
 
 import (

--- a/usecases/config/auto_schema_test.go
+++ b/usecases/config/auto_schema_test.go
@@ -1,0 +1,53 @@
+package config
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestConfig_AutoSchema(t *testing.T) {
+	t.Run("invalid DefaultNumber", func(t *testing.T) {
+		auth := AutoSchema{
+			DefaultNumber: "float",
+			DefaultString: "string",
+			DefaultDate:   "date",
+		}
+		expected := fmt.Errorf("autoSchema.defaultNumber must be either 'int' or 'number")
+		err := auth.Validate()
+		assert.Equal(t, expected, err)
+	})
+
+	t.Run("invalid DefaultString", func(t *testing.T) {
+		auth := AutoSchema{
+			DefaultNumber: "int",
+			DefaultString: "body",
+			DefaultDate:   "date",
+		}
+		expected := fmt.Errorf("autoSchema.defaultString must be either 'string' or 'text")
+		err := auth.Validate()
+		assert.Equal(t, expected, err)
+	})
+
+	t.Run("invalid DefaultDate", func(t *testing.T) {
+		auth := AutoSchema{
+			DefaultNumber: "int",
+			DefaultString: "string",
+			DefaultDate:   "int",
+		}
+		expected := fmt.Errorf("autoSchema.defaultDate must be either 'date' or 'string' or 'text")
+		err := auth.Validate()
+		assert.Equal(t, expected, err)
+	})
+
+	t.Run("all valid AutoSchema configurations", func(t *testing.T) {
+		auth := AutoSchema{
+			DefaultNumber: "int",
+			DefaultString: "string",
+			DefaultDate:   "date",
+		}
+		err := auth.Validate()
+		assert.Nil(t, err, "should not error")
+	})
+}

--- a/usecases/config/config_handler.go
+++ b/usecases/config/config_handler.go
@@ -117,17 +117,12 @@ func (c Config) validateDefaultVectorizerModule(modProv moduleProvider) error {
 }
 
 func (c Config) validateDefaultVectorDistanceMetric() error {
-	if c.DefaultVectorDistanceMetric == "" {
+	switch c.DefaultVectorDistanceMetric {
+	case "", hnsw.DistanceCosine, hnsw.DistanceDot, hnsw.DistanceL2Squared, hnsw.DistanceManhattan, hnsw.DistanceHamming:
 		return nil
-	}
-
-	if c.DefaultVectorDistanceMetric != hnsw.DistanceCosine && c.DefaultVectorDistanceMetric != hnsw.DistanceDot &&
-		c.DefaultVectorDistanceMetric != hnsw.DistanceL2Squared && c.DefaultVectorDistanceMetric != hnsw.DistanceManhattan &&
-		c.DefaultVectorDistanceMetric != hnsw.DistanceHamming {
+	default:
 		return fmt.Errorf("must be one of [\"cosine\", \"dot\", \"l2-squared\", \"manhattan\",\"hamming\"]")
 	}
-
-	return nil
 }
 
 type AutoSchema struct {

--- a/usecases/config/config_handler.go
+++ b/usecases/config/config_handler.go
@@ -20,6 +20,7 @@ import (
 	"github.com/go-openapi/swag"
 	"github.com/pkg/errors"
 	"github.com/semi-technologies/weaviate/deprecations"
+	"github.com/semi-technologies/weaviate/entities/vectorindex/hnsw"
 	"github.com/semi-technologies/weaviate/usecases/cluster"
 	"github.com/sirupsen/logrus"
 	"gopkg.in/yaml.v2"
@@ -76,6 +77,7 @@ type Config struct {
 	Origin                           string         `json:"origin" yaml:"origin"`
 	Persistence                      Persistence    `json:"persistence" yaml:"persistence"`
 	DefaultVectorizerModule          string         `json:"default_vectorizer_module" yaml:"default_vectorizer_module"`
+	DefaultVectorDistanceMetric      string         `json:"default_vector_distance_metric" yaml:"default_vector_distance_metric"`
 	EnableModules                    string         `json:"enable_modules" yaml:"enable_modules"`
 	ModulesPath                      string         `json:"modules_path" yaml:"modules_path"`
 	AutoSchema                       AutoSchema     `json:"auto_schema" yaml:"auto_schema"`
@@ -99,6 +101,10 @@ func (c Config) Validate(modProv moduleProvider) error {
 		return errors.Wrap(err, "default vectorizer module")
 	}
 
+	if err := c.validateDefaultVectorDistanceMetric(); err != nil {
+		return errors.Wrap(err, "default vector distance metric")
+	}
+
 	return nil
 }
 
@@ -108,6 +114,20 @@ func (c Config) validateDefaultVectorizerModule(modProv moduleProvider) error {
 	}
 
 	return modProv.ValidateVectorizer(c.DefaultVectorizerModule)
+}
+
+func (c Config) validateDefaultVectorDistanceMetric() error {
+	if c.DefaultVectorDistanceMetric == "" {
+		return nil
+	}
+
+	if c.DefaultVectorDistanceMetric != hnsw.DistanceCosine && c.DefaultVectorDistanceMetric != hnsw.DistanceDot &&
+		c.DefaultVectorDistanceMetric != hnsw.DistanceL2Squared && c.DefaultVectorDistanceMetric != hnsw.DistanceManhattan &&
+		c.DefaultVectorDistanceMetric != hnsw.DistanceHamming {
+		return fmt.Errorf("must be one of [\"cosine\", \"dot\", \"l2-squared\", \"manhattan\",\"hamming\"]")
+	}
+
+	return nil
 }
 
 type AutoSchema struct {

--- a/usecases/config/config_handler_test.go
+++ b/usecases/config/config_handler_test.go
@@ -1,3 +1,14 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2022 SeMI Technologies B.V. All rights reserved.
+//
+//  CONTACT: hello@semi.technology
+//
+
 package config
 
 import (

--- a/usecases/config/config_handler_test.go
+++ b/usecases/config/config_handler_test.go
@@ -1,0 +1,75 @@
+package config
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestConfig(t *testing.T) {
+	t.Run("invalid DefaultVectorDistanceMetric", func(t *testing.T) {
+		moduleProvider := &fakeModuleProvider{
+			valid: []string{"text2vec-contextionary"},
+		}
+		config := Config{
+			DefaultVectorizerModule:     "text2vec-contextionary",
+			DefaultVectorDistanceMetric: "euclidean",
+		}
+		err := config.Validate(moduleProvider)
+		assert.EqualError(
+			t,
+			err,
+			"default vector distance metric: must be one of [\"cosine\", \"dot\", \"l2-squared\", \"manhattan\",\"hamming\"]",
+		)
+	})
+
+	t.Run("invalid DefaultVectorizerModule", func(t *testing.T) {
+		moduleProvider := &fakeModuleProvider{
+			valid: []string{"text2vec-contextionary"},
+		}
+		config := Config{
+			DefaultVectorizerModule:     "contextionary",
+			DefaultVectorDistanceMetric: "cosine",
+		}
+		err := config.Validate(moduleProvider)
+		assert.EqualError(
+			t,
+			err,
+			"default vectorizer module: invalid vectorizer \"contextionary\"",
+		)
+	})
+
+	t.Run("all valid configurations", func(t *testing.T) {
+		moduleProvider := &fakeModuleProvider{
+			valid: []string{"text2vec-contextionary"},
+		}
+		config := Config{
+			DefaultVectorizerModule:     "text2vec-contextionary",
+			DefaultVectorDistanceMetric: "l2-squared",
+		}
+		err := config.Validate(moduleProvider)
+		assert.Nil(t, err, "should not error")
+	})
+
+	t.Run("without DefaultVectorDistanceMetric", func(t *testing.T) {
+		moduleProvider := &fakeModuleProvider{
+			valid: []string{"text2vec-contextionary"},
+		}
+		config := Config{
+			DefaultVectorizerModule: "text2vec-contextionary",
+		}
+		err := config.Validate(moduleProvider)
+		assert.Nil(t, err, "should not error")
+	})
+
+	t.Run("with none DefaultVectorizerModule", func(t *testing.T) {
+		moduleProvider := &fakeModuleProvider{
+			valid: []string{"text2vec-contextionary"},
+		}
+		config := Config{
+			DefaultVectorizerModule: "none",
+		}
+		err := config.Validate(moduleProvider)
+		assert.Nil(t, err, "should not error")
+	})
+}

--- a/usecases/config/environment.go
+++ b/usecases/config/environment.go
@@ -167,6 +167,10 @@ func FromEnv(config *Config) error {
 		}
 	}
 
+	if v := os.Getenv("DEFAULT_VECTOR_DISTANCE_METRIC"); v != "" {
+		config.DefaultVectorDistanceMetric = v
+	}
+
 	if v := os.Getenv("ENABLE_MODULES"); v != "" {
 		config.EnableModules = v
 	}

--- a/usecases/config/environment_test.go
+++ b/usecases/config/environment_test.go
@@ -156,3 +156,20 @@ func TestEnvironmentParseClusterConfig(t *testing.T) {
 		})
 	}
 }
+
+func TestEnvironmentSetDefaultVectorDistanceMetric(t *testing.T) {
+	t.Run("DefaultVectorDistanceMetricIsEmpty", func(t *testing.T) {
+		os.Clearenv()
+		conf := Config{}
+		FromEnv(&conf)
+		require.Equal(t, "", conf.DefaultVectorDistanceMetric)
+	})
+
+	t.Run("NonEmptyDefaultVectorDistanceMetric", func(t *testing.T) {
+		os.Clearenv()
+		os.Setenv("DEFAULT_VECTOR_DISTANCE_METRIC", "l2-squared")
+		conf := Config{}
+		FromEnv(&conf)
+		require.Equal(t, "l2-squared", conf.DefaultVectorDistanceMetric)
+	})
+}

--- a/usecases/config/helpers_for_test.go
+++ b/usecases/config/helpers_for_test.go
@@ -1,0 +1,17 @@
+package config
+
+import "github.com/pkg/errors"
+
+type fakeModuleProvider struct {
+	valid []string
+}
+
+func (f *fakeModuleProvider) ValidateVectorizer(moduleName string) error {
+	for _, valid := range f.valid {
+		if moduleName == valid {
+			return nil
+		}
+	}
+
+	return errors.Errorf("invalid vectorizer %q", moduleName)
+}

--- a/usecases/config/helpers_for_test.go
+++ b/usecases/config/helpers_for_test.go
@@ -1,3 +1,14 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2022 SeMI Technologies B.V. All rights reserved.
+//
+//  CONTACT: hello@semi.technology
+//
+
 package config
 
 import "github.com/pkg/errors"

--- a/usecases/schema/add.go
+++ b/usecases/schema/add.go
@@ -177,6 +177,14 @@ func (m *Manager) setClassDefaults(class *models.Class) {
 		class.VectorIndexType = "hnsw"
 	}
 
+	if m.config.DefaultVectorDistanceMetric != "" {
+		if class.VectorIndexConfig == nil {
+			class.VectorIndexConfig = map[string]interface{}{"distance": m.config.DefaultVectorDistanceMetric}
+		} else if class.VectorIndexConfig.(map[string]interface{})["distance"] == nil {
+			class.VectorIndexConfig.(map[string]interface{})["distance"] = m.config.DefaultVectorDistanceMetric
+		}
+	}
+
 	if class.InvertedIndexConfig == nil {
 		class.InvertedIndexConfig = &models.InvertedIndexConfig{}
 	}

--- a/usecases/schema/add_test.go
+++ b/usecases/schema/add_test.go
@@ -543,4 +543,41 @@ func TestAddClass(t *testing.T) {
 			})
 		}
 	})
+
+	t.Run("with default vector distance metric", func(t *testing.T) {
+		mgr := newSchemaManager()
+
+		expected := fakeVectorConfig{raw: nil}
+
+		err := mgr.AddClass(context.Background(),
+			nil, &models.Class{Class: "NewClass"})
+		require.Nil(t, err)
+
+		require.NotNil(t, mgr.state.ObjectSchema)
+		require.NotEmpty(t, mgr.state.ObjectSchema.Classes)
+		require.Equal(t, "NewClass", mgr.state.ObjectSchema.Classes[0].Class)
+		require.Equal(t, expected, mgr.state.ObjectSchema.Classes[0].VectorIndexConfig)
+	})
+
+	t.Run("with customized distance metric", func(t *testing.T) {
+		mgr := newSchemaManager()
+
+		expected := fakeVectorConfig{
+			raw: map[string]interface{}{"distance": "l2-squared"},
+		}
+
+		err := mgr.AddClass(context.Background(),
+			nil, &models.Class{
+				Class: "NewClass",
+				VectorIndexConfig: map[string]interface{}{
+					"distance": "l2-squared",
+				},
+			})
+		require.Nil(t, err)
+
+		require.NotNil(t, mgr.state.ObjectSchema)
+		require.NotEmpty(t, mgr.state.ObjectSchema.Classes)
+		require.Equal(t, "NewClass", mgr.state.ObjectSchema.Classes[0].Class)
+		require.Equal(t, expected, mgr.state.ObjectSchema.Classes[0].VectorIndexConfig)
+	})
 }

--- a/usecases/schema/add_test.go
+++ b/usecases/schema/add_test.go
@@ -547,10 +547,33 @@ func TestAddClass(t *testing.T) {
 	t.Run("with default vector distance metric", func(t *testing.T) {
 		mgr := newSchemaManager()
 
-		expected := fakeVectorConfig{raw: nil}
+		expected := fakeVectorConfig{raw: map[string]interface{}{"distance": "cosine"}}
 
 		err := mgr.AddClass(context.Background(),
 			nil, &models.Class{Class: "NewClass"})
+		require.Nil(t, err)
+
+		require.NotNil(t, mgr.state.ObjectSchema)
+		require.NotEmpty(t, mgr.state.ObjectSchema.Classes)
+		require.Equal(t, "NewClass", mgr.state.ObjectSchema.Classes[0].Class)
+		require.Equal(t, expected, mgr.state.ObjectSchema.Classes[0].VectorIndexConfig)
+	})
+
+	t.Run("with default vector distance metric when class already has VectorIndexConfig", func(t *testing.T) {
+		mgr := newSchemaManager()
+
+		expected := fakeVectorConfig{raw: map[string]interface{}{
+			"distance":               "cosine",
+			"otherVectorIndexConfig": "1234",
+		}}
+
+		err := mgr.AddClass(context.Background(),
+			nil, &models.Class{
+				Class: "NewClass",
+				VectorIndexConfig: map[string]interface{}{
+					"otherVectorIndexConfig": "1234",
+				},
+			})
 		require.Nil(t, err)
 
 		require.NotNil(t, mgr.state.ObjectSchema)

--- a/usecases/schema/manager_test.go
+++ b/usecases/schema/manager_test.go
@@ -135,7 +135,9 @@ func testAddObjectClass(t *testing.T, lsm *Manager) {
 			DataType: []string{"string"},
 			Name:     "dummy",
 		}},
-		VectorIndexConfig: "this should be parsed",
+		VectorIndexConfig: map[string]interface{}{
+			"dummy": "this should be parsed",
+		},
 	})
 
 	assert.Nil(t, err)
@@ -147,7 +149,10 @@ func testAddObjectClass(t *testing.T, lsm *Manager) {
 	require.Len(t, objectClasses, 1)
 	assert.Equal(t, config.VectorizerModuleNone, objectClasses[0].Vectorizer)
 	assert.Equal(t, fakeVectorConfig{
-		raw: "this should be parsed",
+		raw: map[string]interface{}{
+			"distance": "cosine",
+			"dummy":    "this should be parsed",
+		},
 	}, objectClasses[0].VectorIndexConfig)
 	assert.Equal(t, int64(60), objectClasses[0].InvertedIndexConfig.CleanupIntervalSeconds,
 		"the default was set")
@@ -472,9 +477,12 @@ func newSchemaManager() *Manager {
 	vectorizerValidator := &fakeVectorizerValidator{
 		valid: []string{"text2vec-contextionary", "model1", "model2"},
 	}
+	dummyConfig := config.Config{
+		DefaultVectorizerModule:     config.VectorizerModuleNone,
+		DefaultVectorDistanceMetric: "cosine",
+	}
 	sm, err := NewManager(&NilMigrator{}, newFakeRepo(), logger, &fakeAuthorizer{},
-		config.Config{DefaultVectorizerModule: config.VectorizerModuleNone},
-		dummyParseVectorConfig, // only option for now
+		dummyConfig, dummyParseVectorConfig, // only option for now
 		vectorizerValidator, dummyValidateInvertedConfig,
 		&fakeModuleConfig{}, &fakeClusterState{},
 		&fakeTxClient{},

--- a/usecases/schema/update_test.go
+++ b/usecases/schema/update_test.go
@@ -278,6 +278,7 @@ func TestClassUpdates(t *testing.T) {
 				expectedErrMsg := "vector index config: don't think so!"
 				expectedValidateCalledWith := fakeVectorConfig{
 					raw: map[string]interface{}{
+						"distance":  "cosine",
 						"setting-1": "updated-value",
 					},
 				}
@@ -316,11 +317,13 @@ func TestClassUpdates(t *testing.T) {
 					})
 				expectedValidateCalledWith := fakeVectorConfig{
 					raw: map[string]interface{}{
+						"distance":  "cosine",
 						"setting-1": "updated-value",
 					},
 				}
 				expectedUpdateCalledWith := fakeVectorConfig{
 					raw: map[string]interface{}{
+						"distance":  "cosine",
 						"setting-1": "updated-value",
 					},
 				}
@@ -337,6 +340,7 @@ func TestClassUpdates(t *testing.T) {
 				require.NotNil(t, class)
 				expectedVectorIndexConfig := fakeVectorConfig{
 					raw: map[string]interface{}{
+						"distance":  "cosine",
 						"setting-1": "updated-value",
 					},
 				}


### PR DESCRIPTION
### What's being changed:
Adds support for a `DEFAULT_VECTOR_DISTANCE_METRIC` environment variable (or `default_vector_distance_metric` in the `./weaviate.conf.json` file). Any auto-schema generated class and any explicitly created class with no `distance` set in its `VectorIndexConfig` will use this value.

Resolves #2290 

### Notes from a first time contributor
I wanted to go beyond the unit tests I added by adding an integration test or acceptance test for this feature (eg. adding to the `test/acceptance/objects/auto_schema_test.go`) but I wasn't sure where / which type would be best to add. I would think there should be an integration test for each env var that the server supports but it seems like they're baked into a tests for other purposes.

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.