### PR TITLE
Fix empty references bug

### DIFF
--- a/adapters/repos/db/crud_integration_test.go
+++ b/adapters/repos/db/crud_integration_test.go
@@ -1941,16 +1941,16 @@ func TestCRUDWithEmptyArrays(t *testing.T) {
 			Class: classNameWithRefs,
 			Properties: map[string]interface{}{
 				"stringProp": "some prop",
-				// due to the fix introduced in https://github.com/semi-technologies/weaviate/pull/2285,
-				// MultipleRef's will appear as empty []string when no actual refs are provided for an
-				// object's reference property.
+				// due to the fix introduced in https://github.com/semi-technologies/weaviate/pull/2320,
+				// MultipleRef's can appear as empty []interface{} when no actual refs are provided for
+				// an object's reference property.
 				//
-				// when this obj1 is unmarshalled from storage, refProp will be represented as []string,
+				// when obj1 is unmarshalled from storage, refProp will be represented as []interface{},
 				// because it is an empty reference property. so when comparing obj1 with the result of
-				// repo.Object, we need this refProp here to be a []string. Note that this is due to our
-				// usage of storobj.Object.MarshallerVersion 1, and future MarshallerVersions may not
-				// have this ambiguous property type limitation.
-				"refProp": []string{},
+				// repo.Object, we need this refProp here to be a []interface{}. Note that this is due
+				// to our usage of storobj.Object.MarshallerVersion 1, and future MarshallerVersions may
+				// not have this ambiguous property type limitation.
+				"refProp": []interface{}{},
 			},
 		}
 		obj2ID := strfmt.UUID("a0b55b05-bc5b-4cc9-b646-1452d1390a63")

--- a/adapters/repos/db/crud_integration_test.go
+++ b/adapters/repos/db/crud_integration_test.go
@@ -1925,7 +1925,6 @@ func TestCRUDWithEmptyArrays(t *testing.T) {
 	})
 
 	t.Run("empty references", func(t *testing.T) {
-		t.Skip()
 		objRefID := strfmt.UUID("a0b55b05-bc5b-4cc9-b646-1452d1390000")
 		objRef := &models.Object{
 			ID:    objRefID,
@@ -1942,7 +1941,16 @@ func TestCRUDWithEmptyArrays(t *testing.T) {
 			Class: classNameWithRefs,
 			Properties: map[string]interface{}{
 				"stringProp": "some prop",
-				"refProp":    models.MultipleRef{},
+				// due to the fix introduced in https://github.com/semi-technologies/weaviate/pull/2285,
+				// MultipleRef's will appear as empty []string when no actual refs are provided for an
+				// object's reference property.
+				//
+				// when this obj1 is unmarshalled from storage, refProp will be represented as []string,
+				// because it is an empty reference property. so when comparing obj1 with the result of
+				// repo.Object, we need this refProp here to be a []string. Note that this is due to our
+				// usage of storobj.Object.MarshallerVersion 1, and future MarshallerVersions may not
+				// have this ambiguous property type limitation.
+				"refProp": []string{},
 			},
 		}
 		obj2ID := strfmt.UUID("a0b55b05-bc5b-4cc9-b646-1452d1390a63")

--- a/adapters/repos/db/inverted/objects.go
+++ b/adapters/repos/db/inverted/objects.go
@@ -460,12 +460,12 @@ func (a *Analyzer) extendPropertiesWithReference(properties *[]Property,
 	var asRefs models.MultipleRef
 	asRefs, ok = value.(models.MultipleRef)
 	if !ok {
-		// due to the fix introduced in https://github.com/semi-technologies/weaviate/pull/2285,
-		// MultipleRef's can appear as empty []string when no actual refs are provided for an
-		// object's reference property.
+		// due to the fix introduced in https://github.com/semi-technologies/weaviate/pull/2320,
+		// MultipleRef's can appear as empty []interface{} when no actual refs are provided for
+		// an object's reference property.
 		//
-		// if we encounter []string, we assume that it indicates an empty ref prop, and skip it.
-		_, ok := value.([]string)
+		// if we encounter []interface{}, assume it indicates an empty ref prop, and skip it.
+		_, ok := value.([]interface{})
 		if !ok {
 			return fmt.Errorf("expected property %q to be of type models.MutlipleRef,"+
 				" but got %T", prop.Name, value)

--- a/adapters/repos/db/inverted/objects_test.go
+++ b/adapters/repos/db/inverted/objects_test.go
@@ -515,6 +515,59 @@ func TestAnalyzeObject(t *testing.T) {
 			assert.ElementsMatch(t, expectedNumbers, actualNumbers, res)
 			assert.ElementsMatch(t, expectedUUID, actualUUID, res)
 		})
+
+		t.Run("when rep prop is stored as empty string slice", func(t *testing.T) {
+			uuid := "cf768bb0-03d8-4464-8f54-f787cf174c01"
+			name := "Transformers"
+			schema := map[string]interface{}{
+				"name":      name,
+				"reference": []string{},
+			}
+
+			props := []*models.Property{
+				{
+					Name:         "name",
+					DataType:     []string{"string"},
+					Tokenization: "word",
+				},
+				{
+					Name:     "reference",
+					DataType: []string{"SomeClass"},
+				},
+			}
+			res, err := a.Object(schema, props, strfmt.UUID(uuid))
+			require.Nil(t, err)
+
+			expectedUUID := []Countable{
+				{
+					Data:          []byte(uuid),
+					TermFrequency: 0,
+				},
+			}
+
+			expectedName := []Countable{
+				{
+					Data:          []byte(name),
+					TermFrequency: 1,
+				},
+			}
+
+			require.Len(t, res, 2)
+			var actualUUID []Countable
+			var actualName []Countable
+
+			for _, elem := range res {
+				switch elem.Name {
+				case "_id":
+					actualUUID = elem.Items
+				case "name":
+					actualName = elem.Items
+				}
+			}
+
+			assert.ElementsMatch(t, expectedUUID, actualUUID, res)
+			assert.ElementsMatch(t, expectedName, actualName, res)
+		})
 	})
 
 	t.Run("when objects are indexed by timestamps", func(t *testing.T) {

--- a/adapters/repos/db/inverted/objects_test.go
+++ b/adapters/repos/db/inverted/objects_test.go
@@ -522,7 +522,7 @@ func TestAnalyzeObject(t *testing.T) {
 		//
 		// this test asserts that reference properties do not break when they are unmarshalled
 		// as empty interface{} slices.
-		t.Run("when rep prop is stored as empty string slice", func(t *testing.T) {
+		t.Run("when rep prop is stored as empty interface{} slice", func(t *testing.T) {
 			uuid := "cf768bb0-03d8-4464-8f54-f787cf174c01"
 			name := "Transformers"
 			schema := map[string]interface{}{

--- a/adapters/repos/db/inverted/objects_test.go
+++ b/adapters/repos/db/inverted/objects_test.go
@@ -516,6 +516,12 @@ func TestAnalyzeObject(t *testing.T) {
 			assert.ElementsMatch(t, expectedUUID, actualUUID, res)
 		})
 
+		// due to the fix introduced in https://github.com/semi-technologies/weaviate/pull/2285,
+		// MultipleRef's can appear as empty []string when no actual refs are provided for an
+		// object's reference property.
+		//
+		// this test asserts that reference properties do not break when they are unmarshalled
+		// as empty string slices.
 		t.Run("when rep prop is stored as empty string slice", func(t *testing.T) {
 			uuid := "cf768bb0-03d8-4464-8f54-f787cf174c01"
 			name := "Transformers"

--- a/adapters/repos/db/inverted/objects_test.go
+++ b/adapters/repos/db/inverted/objects_test.go
@@ -516,18 +516,18 @@ func TestAnalyzeObject(t *testing.T) {
 			assert.ElementsMatch(t, expectedUUID, actualUUID, res)
 		})
 
-		// due to the fix introduced in https://github.com/semi-technologies/weaviate/pull/2285,
-		// MultipleRef's can appear as empty []string when no actual refs are provided for an
-		// object's reference property.
+		// due to the fix introduced in https://github.com/semi-technologies/weaviate/pull/2320,
+		// MultipleRef's can appear as empty []interface{} when no actual refs are provided for
+		// an object's reference property.
 		//
 		// this test asserts that reference properties do not break when they are unmarshalled
-		// as empty string slices.
+		// as empty interface{} slices.
 		t.Run("when rep prop is stored as empty string slice", func(t *testing.T) {
 			uuid := "cf768bb0-03d8-4464-8f54-f787cf174c01"
 			name := "Transformers"
 			schema := map[string]interface{}{
 				"name":      name,
-				"reference": []string{},
+				"reference": []interface{}{},
 			}
 
 			props := []*models.Property{

--- a/entities/storobj/enrich_schema_datatypes.go
+++ b/entities/storobj/enrich_schema_datatypes.go
@@ -52,9 +52,12 @@ func (ko *Object) enrichSchemaTypes(schema map[string]interface{}) error {
 					schema[propName] = parsed
 				}
 			} else if len(typed) == 0 {
-				// empty arrays. Their exact type cannot be determined => use string as a dummy.
-				// This is wrong, but the best we can do here.
-				schema[propName] = make([]string, 0)
+				// empty arrays. Here we use []interface{} as a placeholder
+				// type for an empty array, since we cannot determine its
+				// actual type. in the future, we should persist the schema
+				// property type information alongside the value to avoid
+				// this situation
+				schema[propName] = typed
 			} else {
 				parsed, err := parseCrossRef(typed)
 				if err != nil {

--- a/modules/ref2vec-centroid/vectorizer/vectorizer.go
+++ b/modules/ref2vec-centroid/vectorizer/vectorizer.go
@@ -122,9 +122,18 @@ func beaconsForVectorization(allProps map[string]interface{},
 	// object, like when caller is AddObject/UpdateObject
 	for prop, val := range allProps {
 		if _, ok := targetRefProps[prop]; ok {
-			refs := val.(models.MultipleRef)
-			for _, ref := range refs {
-				beacons = append(beacons, ref.Beacon)
+			switch refs := val.(type) {
+			case []string:
+				// due to the fix introduced in https://github.com/semi-technologies/weaviate/pull/2285,
+				// MultipleRef's can appear as empty []string when no actual refs are provided for an
+				// object's reference property.
+				//
+				// if we encounter []string, we assume that it indicates an empty ref prop, and skip it.
+				continue
+			case models.MultipleRef:
+				for _, ref := range refs {
+					beacons = append(beacons, ref.Beacon)
+				}
 			}
 		}
 	}

--- a/modules/ref2vec-centroid/vectorizer/vectorizer.go
+++ b/modules/ref2vec-centroid/vectorizer/vectorizer.go
@@ -123,12 +123,12 @@ func beaconsForVectorization(allProps map[string]interface{},
 	for prop, val := range allProps {
 		if _, ok := targetRefProps[prop]; ok {
 			switch refs := val.(type) {
-			case []string:
-				// due to the fix introduced in https://github.com/semi-technologies/weaviate/pull/2285,
-				// MultipleRef's can appear as empty []string when no actual refs are provided for an
-				// object's reference property.
+			case []interface{}:
+				// due to the fix introduced in https://github.com/semi-technologies/weaviate/pull/2320,
+				// MultipleRef's can appear as empty []interface{} when no actual refs are provided for
+				// an object's reference property.
 				//
-				// if we encounter []string, we assume that it indicates an empty ref prop, and skip it.
+				// if we encounter []interface{}, assume it indicates an empty ref prop, and skip it.
 				continue
 			case models.MultipleRef:
 				for _, ref := range refs {

--- a/modules/ref2vec-centroid/vectorizer/vectorizer_test.go
+++ b/modules/ref2vec-centroid/vectorizer/vectorizer_test.go
@@ -145,4 +145,19 @@ func TestVectorizer_Object(t *testing.T) {
 			})
 		}
 	})
+
+	t.Run("when rep prop is stored as empty string slice", func(t *testing.T) {
+		ctx := context.Background()
+		repo := &fakeObjectsRepo{}
+		refProps := []interface{}{"toRef"}
+		cfg := fakeClassConfig{"method": "mean", "referenceProperties": refProps}
+
+		obj := &models.Object{
+			Properties: map[string]interface{}{"toRef": []string{}},
+		}
+
+		err := New(cfg, repo.Object).Object(ctx, obj)
+		assert.Nil(t, err)
+		assert.Nil(t, obj.Vector)
+	})
 }

--- a/modules/ref2vec-centroid/vectorizer/vectorizer_test.go
+++ b/modules/ref2vec-centroid/vectorizer/vectorizer_test.go
@@ -146,6 +146,12 @@ func TestVectorizer_Object(t *testing.T) {
 		}
 	})
 
+	// due to the fix introduced in https://github.com/semi-technologies/weaviate/pull/2285,
+	// MultipleRef's can appear as empty []string when no actual refs are provided for an
+	// object's reference property.
+	//
+	// this test asserts that reference properties do not break when they are unmarshalled
+	// as empty string slices.
 	t.Run("when rep prop is stored as empty string slice", func(t *testing.T) {
 		ctx := context.Background()
 		repo := &fakeObjectsRepo{}

--- a/modules/ref2vec-centroid/vectorizer/vectorizer_test.go
+++ b/modules/ref2vec-centroid/vectorizer/vectorizer_test.go
@@ -152,7 +152,7 @@ func TestVectorizer_Object(t *testing.T) {
 	//
 	// this test asserts that reference properties do not break when they are unmarshalled
 	// as empty interface{} slices.
-	t.Run("when rep prop is stored as empty string slice", func(t *testing.T) {
+	t.Run("when rep prop is stored as empty interface{} slice", func(t *testing.T) {
 		ctx := context.Background()
 		repo := &fakeObjectsRepo{}
 		refProps := []interface{}{"toRef"}

--- a/modules/ref2vec-centroid/vectorizer/vectorizer_test.go
+++ b/modules/ref2vec-centroid/vectorizer/vectorizer_test.go
@@ -146,12 +146,12 @@ func TestVectorizer_Object(t *testing.T) {
 		}
 	})
 
-	// due to the fix introduced in https://github.com/semi-technologies/weaviate/pull/2285,
-	// MultipleRef's can appear as empty []string when no actual refs are provided for an
-	// object's reference property.
+	// due to the fix introduced in https://github.com/semi-technologies/weaviate/pull/2320,
+	// MultipleRef's can appear as empty []interface{} when no actual refs are provided for
+	// an object's reference property.
 	//
 	// this test asserts that reference properties do not break when they are unmarshalled
-	// as empty string slices.
+	// as empty interface{} slices.
 	t.Run("when rep prop is stored as empty string slice", func(t *testing.T) {
 		ctx := context.Background()
 		repo := &fakeObjectsRepo{}
@@ -159,7 +159,7 @@ func TestVectorizer_Object(t *testing.T) {
 		cfg := fakeClassConfig{"method": "mean", "referenceProperties": refProps}
 
 		obj := &models.Object{
-			Properties: map[string]interface{}{"toRef": []string{}},
+			Properties: map[string]interface{}{"toRef": []interface{}{}},
 		}
 
 		err := New(cfg, repo.Object).Object(ctx, obj)

--- a/test/modules/ref2vec-centroid/centroid_test.go
+++ b/test/modules/ref2vec-centroid/centroid_test.go
@@ -24,7 +24,6 @@ import (
 )
 
 func TestCentroid(t *testing.T) {
-	t.Skip()
 	helper.SetupClient(os.Getenv(weaviateEndpoint))
 
 	paragraphClass := articles.ParagraphsClass()

--- a/usecases/schema/authorization_test.go
+++ b/usecases/schema/authorization_test.go
@@ -99,7 +99,6 @@ func Test_Schema_Authorization(t *testing.T) {
 	}
 
 	t.Run("verify that a test for every public method exists", func(t *testing.T) {
-		// t.Skip()
 		testedMethods := make([]string, len(tests))
 		for i, test := range tests {
 			testedMethods[i] = test.methodName

--- a/usecases/traverser/grouper/grouper_test.go
+++ b/usecases/traverser/grouper/grouper_test.go
@@ -15,6 +15,8 @@ import (
 	"testing"
 
 	"github.com/go-openapi/strfmt"
+	"github.com/semi-technologies/weaviate/entities/schema/crossref"
+
 	"github.com/semi-technologies/weaviate/entities/models"
 	"github.com/semi-technologies/weaviate/entities/search"
 	"github.com/sirupsen/logrus/hooks/test"
@@ -252,6 +254,147 @@ func TestGrouper_ModeMerge(t *testing.T) {
 	}
 }
 
+// Since reference properties can be represented both as models.MultipleRef
+// and []interface{}, we need to test for both cases. TestGrouper_ModeMerge
+// above tests the case of []interface{}, so this test handles the other case.
+// see https://github.com/semi-technologies/weaviate/pull/2320 for more info
+func Test_Grouper_ModeMerge_MultipleRef(t *testing.T) {
+	in := []search.Result{
+		{
+			ClassName: "Foo",
+			Vector:    []float32{0.1, 0.1, 0.98},
+			Schema: map[string]interface{}{
+				"name":    "A1",
+				"count":   10.0,
+				"illegal": true,
+				"location": &models.GeoCoordinates{
+					Latitude:  ptFloat32(20),
+					Longitude: ptFloat32(20),
+				},
+				"relatedTo": models.MultipleRef{
+					&models.SingleRef{
+						Beacon: strfmt.URI(crossref.NewLocalhost("Foo", "3dc4417d-1508-4914-9929-8add49684b9f").String()),
+						Class:  "Foo",
+					},
+					&models.SingleRef{
+						Beacon: strfmt.URI(crossref.NewLocalhost("Foo", "f1d6df98-33a7-40bb-bcb4-57c1f35d31ab").String()),
+						Class:  "Foo",
+					},
+				},
+			},
+		},
+		{
+			ClassName: "Foo",
+			Vector:    []float32{0.1, 0.1, 0.96},
+			Schema: map[string]interface{}{
+				"name":    "A2",
+				"count":   11.0,
+				"illegal": true,
+			},
+		},
+		{
+			ClassName: "Foo",
+			Vector:    []float32{0.1, 0.1, 0.96},
+			Schema: map[string]interface{}{
+				"name":    "A2",
+				"count":   11.0,
+				"illegal": true,
+				"relatedTo": models.MultipleRef{
+					&models.SingleRef{
+						Beacon: strfmt.URI(crossref.NewLocalhost("Foo", "f280a7f7-7fab-46ed-b895-1490512660ae").String()),
+						Class:  "Foo",
+					},
+				},
+			},
+		},
+		{
+			ClassName: "Foo",
+			Vector:    []float32{0.1, 0.1, 0.93},
+			Schema: map[string]interface{}{
+				"name":    "A3",
+				"count":   12.0,
+				"illegal": false,
+				"location": &models.GeoCoordinates{
+					Latitude:  ptFloat32(22),
+					Longitude: ptFloat32(18),
+				},
+				"relatedTo": models.MultipleRef{
+					&models.SingleRef{
+						Beacon: strfmt.URI(crossref.NewLocalhost("Foo", "f1d6df98-33a7-40bb-bcb4-57c1f35d31ab").String()),
+						Class:  "Foo",
+					},
+				},
+			},
+		},
+		{
+			ClassName: "Foo",
+			Vector:    []float32{0.1, 0.98, 0.1},
+			Schema: map[string]interface{}{
+				"name": "B1",
+			},
+		},
+		{
+			ClassName: "Foo",
+			Vector:    []float32{0.1, 0.93, 0.1},
+			Schema: map[string]interface{}{
+				"name": "B2",
+			},
+		},
+		{
+			ClassName: "Foo",
+			Vector:    []float32{0.1, 0.92, 0.1},
+			Schema: map[string]interface{}{
+				"name": "B3",
+			},
+		},
+	}
+
+	expectedOut := []search.Result{
+		{
+			ClassName: "Foo",
+			Vector:    []float32{0.1, 0.1, 0.95750004}, // centroid position of all inputs
+			Schema: map[string]interface{}{
+				"name":    "A1 (A2, A3)", // note that A2 is only contained once, even though its twice in the input set
+				"count":   11.0,          // mean of all inputs
+				"illegal": true,          // the most common input value, with a bias towards true on equal count
+				"location": &models.GeoCoordinates{
+					Latitude:  ptFloat32(21),
+					Longitude: ptFloat32(19),
+				},
+				"relatedTo": []interface{}{
+					&models.SingleRef{
+						Beacon: strfmt.URI(crossref.NewLocalhost("Foo", "3dc4417d-1508-4914-9929-8add49684b9f").String()),
+						Class:  "Foo",
+					},
+					&models.SingleRef{
+						Beacon: strfmt.URI(crossref.NewLocalhost("Foo", "f1d6df98-33a7-40bb-bcb4-57c1f35d31ab").String()),
+						Class:  "Foo",
+					},
+					&models.SingleRef{
+						Beacon: strfmt.URI(crossref.NewLocalhost("Foo", "f280a7f7-7fab-46ed-b895-1490512660ae").String()),
+						Class:  "Foo",
+					},
+				},
+			},
+		},
+		{
+			ClassName: "Foo",
+			Vector:    []float32{0.1, 0.9433334, 0.1},
+			Schema: map[string]interface{}{
+				"name": "B1 (B2, B3)",
+			},
+		},
+	}
+
+	log, _ := test.NewNullLogger()
+	res, err := New(log).Group(in, "merge", 0.2)
+	require.Nil(t, err)
+	assert.Equal(t, expectedOut, res)
+	for i := range res {
+		assert.Equal(t, expectedOut[i].ClassName, res[i].ClassName)
+	}
+}
+
 func TestGrouper_ModeMergeFailWithIDTypeOtherThenUUID(t *testing.T) {
 	in := []search.Result{
 		{
@@ -290,6 +433,6 @@ func TestGrouper_ModeMergeFailWithIDTypeOtherThenUUID(t *testing.T) {
 	require.NotNil(t, err)
 	assert.Nil(t, res)
 	assert.EqualError(t, err,
-		"group 0: merge values: prop 'relatedTo': "+
+		"group 0: merge values: prop 'relatedTo': element 0: "+
 			"found a search.LocalRef, 'id' field type expected to be strfmt.UUID but got string")
 }


### PR DESCRIPTION
### What's being changed:

Due to the fix introduced in #2285, `MultipleRef`'s can appear as empty `[]string` when no actual refs are provided for an object's reference property.

This issue became apparent specifically with the introduction the the `ref2vec-centroid` module, as this deals with marshalling/unmarshalling objects with references in many different fashions.

This PR introduces a fix, which changes the use of `[]string` as a placeholder to `[]interface{}`, and interprets this type as an empty list of references, whenever the target property is expected to be a reference property.

### Review checklist

- [x] Documentation has been updated, if necessary. Link to changed documentation:
- [x] Chaos pipeline run or not necessary. Link to pipeline:
- [x] All new code is covered by tests where it is reasonable.
- [x] Performance tests have been run or not necessary.
