### PR TITLE
Fix vector_index_size metric

### DIFF
--- a/adapters/repos/db/vector/hnsw/startup.go
+++ b/adapters/repos/db/vector/hnsw/startup.go
@@ -39,6 +39,12 @@ func (h *hnsw) init(cfg Config) error {
 
 	h.commitLog = cl
 
+	// report the vector_index_size at server startup.
+	// otherwise on server restart, prometheus reports
+	// a vector_index_size of 0 until more vectors are
+	// added.
+	h.metrics.SetSize(len(h.nodes))
+
 	return nil
 }
 


### PR DESCRIPTION
### What's being changed:

On a new (not restarted) Weaviate instance, `vector_index_size` accurately reflects the number of vectors in the vector index. However on a restart, the `vector_index_size` is reported as `0` until further inserts are made into the index.

This PR adds an additional setting of the `vector_index_size` metric on server startup to ensure that the correct number of vectors is always reported.

### Review checklist

- [x] Documentation has been updated, if necessary. Link to changed documentation:
- [x] Chaos pipeline run or not necessary. Link to pipeline:
- [x] All new code is covered by tests where it is reasonable.
- [x] Performance tests have been run or not necessary.
