### PR TITLE
Remove vector_index_dimensions_total metric in favor of using vector_dimensions_sum metric

### DIFF
--- a/adapters/repos/db/init.go
+++ b/adapters/repos/db/init.go
@@ -56,6 +56,7 @@ func (d *DB) init(ctx context.Context) error {
 				QueryMaximumResults:       d.config.QueryMaximumResults,
 				MaxImportGoroutinesFactor: d.config.MaxImportGoroutinesFactor,
 				FlushIdleAfter:            d.config.FlushIdleAfter,
+				TrackVectorDimensions:     d.config.TrackVectorDimensions,
 			}, d.schemaGetter.ShardingState(class.Class),
 				inverted.ConfigFromModel(invertedConfig),
 				class.VectorIndexConfig.(schema.VectorIndexConfig),

--- a/adapters/repos/db/vector/hnsw/delete.go
+++ b/adapters/repos/db/vector/hnsw/delete.go
@@ -37,7 +37,6 @@ func (h *hnsw) Delete(id uint64) error {
 	defer h.metrics.TrackDelete(before, "total")
 
 	h.metrics.DeleteVector()
-	h.metrics.DeleteVectorDimensions(h.cache.dimensions(id))
 	if err := h.addTombstone(id); err != nil {
 		return err
 	}

--- a/adapters/repos/db/vector/hnsw/insert.go
+++ b/adapters/repos/db/vector/hnsw/insert.go
@@ -26,7 +26,6 @@ func (h *hnsw) Add(id uint64, vector []float32) error {
 	}
 
 	h.metrics.InsertVector()
-	h.metrics.InsertVectorDimensions(len(vector))
 	defer h.insertMetrics.total(before)
 
 	node := &vertex{

--- a/adapters/repos/db/vector/hnsw/metrics.go
+++ b/adapters/repos/db/vector/hnsw/metrics.go
@@ -23,10 +23,8 @@ type Metrics struct {
 	tombstones       prometheus.Gauge
 	threads          prometheus.Gauge
 	insert           prometheus.Gauge
-	insertDimensions prometheus.Counter
 	insertTime       prometheus.ObserverVec
 	delete           prometheus.Gauge
-	deleteDimensions prometheus.Counter
 	deleteTime       prometheus.ObserverVec
 	cleaned          prometheus.Counter
 	size             prometheus.Gauge
@@ -64,12 +62,6 @@ func NewMetrics(prom *monitoring.PrometheusMetrics,
 		"operation":  "create",
 	})
 
-	insertDimensions := prom.VectorIndexDimensionOperations.With(prometheus.Labels{
-		"class_name": className,
-		"shard_name": shardName,
-		"operation":  "create",
-	})
-
 	insertTime := prom.VectorIndexDurations.MustCurryWith(prometheus.Labels{
 		"class_name": className,
 		"shard_name": shardName,
@@ -77,12 +69,6 @@ func NewMetrics(prom *monitoring.PrometheusMetrics,
 	})
 
 	del := prom.VectorIndexOperations.With(prometheus.Labels{
-		"class_name": className,
-		"shard_name": shardName,
-		"operation":  "delete",
-	})
-
-	delDimensions := prom.VectorIndexDimensionOperations.With(prometheus.Labels{
 		"class_name": className,
 		"shard_name": shardName,
 		"operation":  "delete",
@@ -127,10 +113,8 @@ func NewMetrics(prom *monitoring.PrometheusMetrics,
 		threads:          threads,
 		cleaned:          cleaned,
 		insert:           insert,
-		insertDimensions: insertDimensions,
 		insertTime:       insertTime,
 		delete:           del,
-		deleteDimensions: delDimensions,
 		deleteTime:       deleteTime,
 		size:             size,
 		grow:             grow,
@@ -188,28 +172,12 @@ func (m *Metrics) InsertVector() {
 	m.insert.Inc()
 }
 
-func (m *Metrics) InsertVectorDimensions(d int) {
-	if !m.enabled {
-		return
-	}
-
-	m.insertDimensions.Add(float64(d))
-}
-
 func (m *Metrics) DeleteVector() {
 	if !m.enabled {
 		return
 	}
 
 	m.delete.Inc()
-}
-
-func (m *Metrics) DeleteVectorDimensions(d int) {
-	if !m.enabled {
-		return
-	}
-
-	m.deleteDimensions.Add(float64(d))
 }
 
 func (m *Metrics) SetSize(size int) {

--- a/adapters/repos/db/vector/hnsw/vector_cache_prefiller.go
+++ b/adapters/repos/db/vector/hnsw/vector_cache_prefiller.go
@@ -35,7 +35,6 @@ type cache interface {
 	drop()
 	updateMaxSize(size int64)
 	copyMaxSize() int64
-	dimensions(id uint64) int
 }
 
 func newVectorCachePrefiller(cache cache, index *hnsw,

--- a/adapters/repos/db/vector/hnsw/vector_cache_prefiller_test.go
+++ b/adapters/repos/db/vector/hnsw/vector_cache_prefiller_test.go
@@ -90,10 +90,6 @@ func (f *fakeCache) delete(ctx context.Context, id uint64) {
 	panic("not implemented")
 }
 
-func (f *fakeCache) dimensions(id uint64) int {
-	return 0
-}
-
 func (f *fakeCache) preload(id uint64, vec []float32) {
 	panic("not implemented")
 }

--- a/usecases/config/config_handler.go
+++ b/usecases/config/config_handler.go
@@ -87,7 +87,7 @@ type Config struct {
 	ResourceUsage                    ResourceUsage  `json:"resource_usage" yaml:"resource_usage"`
 	MaxImportGoroutinesFactor        float64        `json:"max_import_goroutine_factor" yaml:"max_import_goroutine_factor"`
 	TrackVectorDimensions            bool           `json:"track_vector_dimensions" yaml:"track_vector_dimensions"`
-	ReindexVectorDimensionsAtStartup bool           `json:"want_dimensions_reindex" yaml:"want_dimensions_reindex"`
+	ReindexVectorDimensionsAtStartup bool           `json:"reindex_vector_dimensions_at_startup" yaml:"reindex_vector_dimensions_at_startup"`
 }
 
 type moduleProvider interface {

--- a/usecases/monitoring/prometheus.go
+++ b/usecases/monitoring/prometheus.go
@@ -34,7 +34,6 @@ type PrometheusMetrics struct {
 	VectorIndexTombstoneCleanupThreads *prometheus.GaugeVec
 	VectorIndexTombstoneCleanedCount   *prometheus.CounterVec
 	VectorIndexOperations              *prometheus.GaugeVec
-	VectorIndexDimensionOperations     *prometheus.CounterVec
 	VectorIndexDurations               *prometheus.HistogramVec
 	VectorIndexSize                    *prometheus.GaugeVec
 	VectorIndexMaintenanceDurations    *prometheus.HistogramVec
@@ -155,10 +154,6 @@ func newPrometheusMetrics() *PrometheusMetrics {
 			Name: "vector_index_operations",
 			Help: "Total number of mutating operations on the vector index",
 		}, []string{"operation", "class_name", "shard_name"}),
-		VectorIndexDimensionOperations: promauto.NewCounterVec(prometheus.CounterOpts{
-			Name: "vector_index_dimensions_total",
-			Help: "Total number of mutating operations multiplied with dimensions on the vector index",
-		}, []string{"operation", "class_name", "shard_name"}),
 		VectorIndexSize: promauto.NewGaugeVec(prometheus.GaugeOpts{
 			Name: "vector_index_size",
 			Help: "The size of the vector index. Typically larger than number of vectors, as it grows proactively.",
@@ -173,6 +168,10 @@ func newPrometheusMetrics() *PrometheusMetrics {
 			Help:    "Duration of typical vector index operations (insert, delete)",
 			Buckets: prometheus.ExponentialBuckets(0.1, 1.5, 30),
 		}, []string{"operation", "step", "class_name", "shard_name"}),
+		VectorDimensionsSum: promauto.NewGaugeVec(prometheus.GaugeOpts{
+			Name: "vector_dimensions_sum",
+			Help: "Total dimensions in a shard",
+		}, []string{"class_name", "shard_name"}),
 
 		StartupProgress: promauto.NewGaugeVec(prometheus.GaugeOpts{
 			Name: "startup_progress",
@@ -231,10 +230,6 @@ func newPrometheusMetrics() *PrometheusMetrics {
 			Name: "backup_store_data_transferred",
 			Help: "Total number of bytes transferred during a backup store",
 		}, []string{"backend_name", "class_name"}),
-		VectorDimensionsSum: promauto.NewGaugeVec(prometheus.GaugeOpts{
-			Name: "vector_dimensions_sum",
-			Help: "Total dimensions in a shard",
-		}, []string{"class_name", "shard_name"}),
 	}
 }
 


### PR DESCRIPTION
### What's being changed:

Removed obsolete `vector_index_dimensions_total` metric (and the code behind it in vector cache) switched to `vector_dimensions_sum` instead.

### Review checklist

- [x] All new code is covered by tests where it is reasonable.
