### PR TITLE
Cancel restoration when failing to store initial metadata in the specified backend.

### DIFF
--- a/usecases/backup/restorer.go
+++ b/usecases/backup/restorer.go
@@ -145,7 +145,7 @@ func (r *restorer) restoreAll(ctx context.Context,
 		}
 		r.logger.WithField("action", "restore").
 			WithField("backup_id", desc.ID).
-			WithField("class", cdesc.Name)
+			WithField("class", cdesc.Name).Info("successfully restored")
 	}
 	return nil
 }
@@ -178,7 +178,7 @@ func (r *restorer) restoreOne(ctx context.Context,
 	}
 	if err := r.schema.RestoreClass(ctx, desc); err != nil {
 		if rerr := rollback(); rerr != nil {
-			r.logger.WithField("className", desc.Name).WithField("action", "rollback").WithError(rerr)
+			r.logger.WithField("className", desc.Name).WithField("action", "rollback").Error(rerr)
 		}
 		return fmt.Errorf("restore schema: %w", err)
 	}

--- a/usecases/backup/scheduler.go
+++ b/usecases/backup/scheduler.go
@@ -15,6 +15,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"time"
 
 	"github.com/semi-technologies/weaviate/entities/backup"
 	"github.com/semi-technologies/weaviate/entities/models"
@@ -63,7 +64,11 @@ func NewScheduler(
 }
 
 func (s *Scheduler) Backup(ctx context.Context, pr *models.Principal, req *BackupRequest,
-) (*models.BackupCreateResponse, error) {
+) (_ *models.BackupCreateResponse, err error) {
+	defer func(begin time.Time) {
+		logOperation(s.logger, "try_backup", req.ID, req.Backend, begin, err)
+	}(time.Now())
+
 	path := fmt.Sprintf("backups/%s/%s", req.Backend, req.ID)
 	if err := s.authorizer.Authorize(pr, "add", path); err != nil {
 		return nil, err
@@ -105,7 +110,10 @@ func (s *Scheduler) Backup(ctx context.Context, pr *models.Principal, req *Backu
 
 func (s *Scheduler) Restore(ctx context.Context, pr *models.Principal,
 	req *BackupRequest,
-) (*models.BackupRestoreResponse, error) {
+) (_ *models.BackupRestoreResponse, err error) {
+	defer func(begin time.Time) {
+		logOperation(s.logger, "try_restore", req.ID, req.Backend, begin, err)
+	}(time.Now())
 	path := fmt.Sprintf("backups/%s/%s/restore", req.Backend, req.ID)
 	if err := s.authorizer.Authorize(pr, "restore", path); err != nil {
 		return nil, err
@@ -142,7 +150,10 @@ func (s *Scheduler) Restore(ctx context.Context, pr *models.Principal,
 
 func (s *Scheduler) BackupStatus(ctx context.Context, principal *models.Principal,
 	backend, backupID string,
-) (*Status, error) {
+) (_ *Status, err error) {
+	defer func(begin time.Time) {
+		logOperation(s.logger, "backup_status", backupID, backend, begin, err)
+	}(time.Now())
 	path := fmt.Sprintf("backups/%s/%s", backend, backupID)
 	if err := s.authorizer.Authorize(principal, "get", path); err != nil {
 		return nil, err
@@ -163,6 +174,9 @@ func (s *Scheduler) BackupStatus(ctx context.Context, principal *models.Principa
 
 func (s *Scheduler) RestorationStatus(ctx context.Context, principal *models.Principal, backend, backupID string,
 ) (_ *Status, err error) {
+	defer func(begin time.Time) {
+		logOperation(s.logger, "restoration_status", backupID, backend, time.Now(), err)
+	}(time.Now())
 	path := fmt.Sprintf("backups/%s/%s/restore", backend, backupID)
 	if err := s.authorizer.Authorize(principal, "get", path); err != nil {
 		return nil, err
@@ -270,4 +284,15 @@ func isLocalFilesystemBackend(backend string) bool {
 		}
 	}
 	return false
+}
+
+func logOperation(logger logrus.FieldLogger, name, id, backend string, begin time.Time, err error) {
+	le := logger.WithField("action", name).
+		WithField("backup_id", id).WithField("backend", backend).
+		WithField("took", time.Since(begin))
+	if err != nil {
+		le.Error(err)
+	} else {
+		le.Info()
+	}
 }


### PR DESCRIPTION
### What's being changed:
[PR-2289](https://github.com/semi-technologies/weaviate/pull/2289) makes sure that metadata is written to the backend before executing the async part of the restoration operation so that other nodes is able to fetch the status from the backend.
However in the same PR the scheduler doesn’t cancel restoration even when it fails to write the initial metadata to the backend. Writing metadata to the backend is a prerequisite in order to communicate the status of a restoration operation and for other nodes to push their contents.

This PR:
1. Fix issue introduced by PR #2289
2. Log backup operations

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [x] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.
