### PR TITLE
Fix releasing resources associated with time.Ticker in the code base

### DIFF
--- a/adapters/repos/db/lsmkv/bucket.go
+++ b/adapters/repos/db/lsmkv/bucket.go
@@ -618,12 +618,13 @@ func (b *Bucket) Shutdown(ctx context.Context) error {
 	}
 
 	// it seems we still need to wait for someone to finish flushing
-	t := time.Tick(50 * time.Millisecond)
+	t := time.NewTicker(50 * time.Millisecond)
+	defer t.Stop()
 	for {
 		select {
 		case <-ctx.Done():
 			return ctx.Err()
-		case <-t:
+		case <-t.C:
 			if b.flushing == nil {
 				return nil
 			}

--- a/adapters/repos/db/resource_use.go
+++ b/adapters/repos/db/resource_use.go
@@ -47,12 +47,13 @@ func (d *DB) scanResourceUsage() {
 		runtime.MemProfile, debug.SetMemoryLimit, runtime.MemProfileRate)
 
 	go func() {
-		t := time.Tick(time.Second * 30)
+		t := time.NewTicker(time.Second * 30)
+		defer t.Stop()
 		for {
 			select {
 			case <-d.shutdown:
 				return
-			case <-t:
+			case <-t.C:
 				d.indexLock.Lock()
 				for _, i := range d.indices {
 					for _, s := range i.Shards {

--- a/adapters/repos/db/vector/hnsw/vector_cache.go
+++ b/adapters/repos/db/vector/hnsw/vector_cache.go
@@ -193,12 +193,13 @@ func (n *shardedLockCache) deleteAllVectors() {
 
 func (c *shardedLockCache) watchForDeletion() {
 	go func() {
-		t := time.Tick(3 * time.Second)
+		t := time.NewTicker(3 * time.Second)
+		defer t.Stop()
 		for {
 			select {
 			case <-c.cancel:
 				return
-			case <-t:
+			case <-t.C:
 				c.replaceIfFull()
 			}
 		}

--- a/modules/img2vec-neural/clients/startup.go
+++ b/modules/img2vec-neural/clients/startup.go
@@ -22,12 +22,13 @@ import (
 func (c *vectorizer) WaitForStartup(initCtx context.Context,
 	interval time.Duration,
 ) error {
-	t := time.Tick(interval)
+	t := time.NewTicker(interval)
+	defer t.Stop()
 	expired := initCtx.Done()
 	var lastErr error
 	for {
 		select {
-		case <-t:
+		case <-t.C:
 			lastErr = c.checkReady(initCtx)
 			if lastErr == nil {
 				return nil

--- a/modules/multi2vec-clip/clients/startup.go
+++ b/modules/multi2vec-clip/clients/startup.go
@@ -22,12 +22,13 @@ import (
 func (c *vectorizer) WaitForStartup(initCtx context.Context,
 	interval time.Duration,
 ) error {
-	t := time.Tick(interval)
+	t := time.NewTicker(interval)
+	defer t.Stop()
 	expired := initCtx.Done()
 	var lastErr error
 	for {
 		select {
-		case <-t:
+		case <-t.C:
 			lastErr = c.checkReady(initCtx)
 			if lastErr == nil {
 				return nil

--- a/modules/ner-transformers/clients/startup.go
+++ b/modules/ner-transformers/clients/startup.go
@@ -22,12 +22,13 @@ import (
 func (c *ner) WaitForStartup(initCtx context.Context,
 	interval time.Duration,
 ) error {
-	t := time.Tick(interval)
+	t := time.NewTicker(interval)
+	defer t.Stop()
 	expired := initCtx.Done()
 	var lastErr error
 	for {
 		select {
-		case <-t:
+		case <-t.C:
 			lastErr = c.checkReady(initCtx)
 			if lastErr == nil {
 				return nil

--- a/modules/qna-transformers/clients/startup.go
+++ b/modules/qna-transformers/clients/startup.go
@@ -22,12 +22,13 @@ import (
 func (c *qna) WaitForStartup(initCtx context.Context,
 	interval time.Duration,
 ) error {
-	t := time.Tick(interval)
+	t := time.NewTicker(interval)
+	defer t.Stop()
 	expired := initCtx.Done()
 	var lastErr error
 	for {
 		select {
-		case <-t:
+		case <-t.C:
 			lastErr = c.checkReady(initCtx)
 			if lastErr == nil {
 				return nil

--- a/modules/sum-transformers/client/startup.go
+++ b/modules/sum-transformers/client/startup.go
@@ -23,6 +23,7 @@ func (c *client) WaitForStartup(initCtx context.Context,
 	interval time.Duration,
 ) error {
 	t := time.NewTicker(interval)
+	defer t.Stop()
 	expired := initCtx.Done()
 	var lastErr error
 	for {

--- a/modules/text-spellcheck/clients/startup.go
+++ b/modules/text-spellcheck/clients/startup.go
@@ -22,12 +22,13 @@ import (
 func (s *spellCheck) WaitForStartup(initCtx context.Context,
 	interval time.Duration,
 ) error {
-	t := time.Tick(interval)
+	t := time.NewTicker(interval)
+	defer t.Stop()
 	expired := initCtx.Done()
 	var lastErr error
 	for {
 		select {
-		case <-t:
+		case <-t.C:
 			lastErr = s.checkReady(initCtx)
 			if lastErr == nil {
 				return nil

--- a/modules/text2vec-transformers/clients/startup.go
+++ b/modules/text2vec-transformers/clients/startup.go
@@ -57,7 +57,8 @@ func (v *vectorizer) WaitForStartup(initCtx context.Context,
 }
 
 func (v *vectorizer) waitFor(initCtx context.Context, interval time.Duration, endpoint string, serviceName string) error {
-	tick := time.Tick(interval)
+	ticker := time.NewTicker(interval)
+	defer ticker.Stop()
 	expired := initCtx.Done()
 	var lastErr error
 	prefix := ""
@@ -67,7 +68,7 @@ func (v *vectorizer) waitFor(initCtx context.Context, interval time.Duration, en
 
 	for {
 		select {
-		case <-tick:
+		case <-ticker.C:
 			lastErr = v.checkReady(initCtx, endpoint, serviceName)
 			if lastErr == nil {
 				return nil

--- a/usecases/classification/classifier_run.go
+++ b/usecases/classification/classifier_run.go
@@ -73,6 +73,7 @@ func (c *Classifier) monitorClassification(ctx context.Context, cancelFn context
 	className schema.ClassName,
 ) {
 	ticker := time.NewTicker(100 * time.Millisecond)
+	defer ticker.Stop()
 	for {
 		select {
 		case <-ctx.Done():


### PR DESCRIPTION


### What's being changed:
Replace time.Tick with time.Ticker to avoid leaking resources
Free time.Ticker resources after use

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.
