### PR TITLE
Add support for HuggingFace Inference API

### DIFF
--- a/modules/text2vec-huggingface/ent/vectorization_config.go
+++ b/modules/text2vec-huggingface/ent/vectorization_config.go
@@ -12,6 +12,7 @@
 package ent
 
 type VectorizationConfig struct {
+	EndpointURL                    string
 	Model                          string
 	WaitForModel, UseGPU, UseCache bool
 }

--- a/modules/text2vec-huggingface/vectorizer/class_settings.go
+++ b/modules/text2vec-huggingface/vectorizer/class_settings.go
@@ -76,6 +76,10 @@ func (ic *classSettings) VectorizePropertyName(propName string) bool {
 	return asBool
 }
 
+func (ic *classSettings) EndpointURL() string {
+	return ic.getEndpointURL()
+}
+
 func (ic *classSettings) PassageModel() string {
 	model := ic.getPassageModel()
 	if model == "" {
@@ -143,6 +147,13 @@ func (ic *classSettings) Validate(class *models.Class) error {
 }
 
 func (ic *classSettings) validateClassSettings() error {
+	endpointURL := ic.getEndpointURL()
+	if endpointURL != "" {
+		// endpoint is set, should be used for feature extraction
+		// all other settings are not relevant
+		return nil
+	}
+
 	model := ic.getProperty("model")
 	passageModel := ic.getProperty("passageModel")
 	queryModel := ic.getProperty("queryModel")
@@ -176,6 +187,14 @@ func (ic *classSettings) getQueryModel() string {
 		model = ic.getProperty("queryModel")
 	}
 	return model
+}
+
+func (ic *classSettings) getEndpointURL() string {
+	endpointURL := ic.getProperty("endpointUrl")
+	if endpointURL == "" {
+		endpointURL = ic.getProperty("endpointURL")
+	}
+	return endpointURL
 }
 
 func (ic *classSettings) getOption(option string) *bool {

--- a/modules/text2vec-huggingface/vectorizer/class_settings_test.go
+++ b/modules/text2vec-huggingface/vectorizer/class_settings_test.go
@@ -27,6 +27,8 @@ func Test_classSettings_getPassageModel(t *testing.T) {
 		wantWaitForModel bool
 		wantUseGPU       bool
 		wantUseCache     bool
+		wantEndpointURL  string
+		wantError        error
 	}{
 		{
 			name: "CShorten/CORD-19-Title-Abstracts",
@@ -73,6 +75,34 @@ func Test_classSettings_getPassageModel(t *testing.T) {
 			wantUseGPU:       false,
 			wantUseCache:     true,
 		},
+		{
+			name: "Hugging Face Inference API - endpointURL",
+			cfg: fakeClassConfig{
+				classConfig: map[string]interface{}{
+					"endpointURL": "http://endpoint.cloud",
+				},
+			},
+			wantPassageModel: "",
+			wantQueryModel:   "",
+			wantWaitForModel: false,
+			wantUseGPU:       false,
+			wantUseCache:     true,
+			wantEndpointURL:  "http://endpoint.cloud",
+		},
+		{
+			name: "Hugging Face Inference API - endpointUrl",
+			cfg: fakeClassConfig{
+				classConfig: map[string]interface{}{
+					"endpointUrl": "http://endpoint.cloud",
+				},
+			},
+			wantPassageModel: "",
+			wantQueryModel:   "",
+			wantWaitForModel: false,
+			wantUseGPU:       false,
+			wantUseCache:     true,
+			wantEndpointURL:  "http://endpoint.cloud",
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -82,6 +112,8 @@ func Test_classSettings_getPassageModel(t *testing.T) {
 			assert.Equal(t, tt.wantWaitForModel, ic.OptionWaitForModel())
 			assert.Equal(t, tt.wantUseGPU, ic.OptionUseGPU())
 			assert.Equal(t, tt.wantUseCache, ic.OptionUseCache())
+			assert.Equal(t, tt.wantEndpointURL, ic.EndpointURL())
+			assert.Equal(t, tt.wantError, ic.validateClassSettings())
 		})
 	}
 }

--- a/modules/text2vec-huggingface/vectorizer/fakes_for_test.go
+++ b/modules/text2vec-huggingface/vectorizer/fakes_for_test.go
@@ -52,6 +52,7 @@ type fakeSettings struct {
 	excludedProperty               string
 	passageModel, queryModel       string
 	waitForModel, useGPU, useCache bool
+	endpointURL                    string
 }
 
 func (f *fakeSettings) PropertyIndexed(propName string) bool {
@@ -64,6 +65,10 @@ func (f *fakeSettings) VectorizePropertyName(propName string) bool {
 
 func (f *fakeSettings) VectorizeClassName() bool {
 	return f.vectorizeClassName
+}
+
+func (f *fakeSettings) EndpointURL() string {
+	return f.endpointURL
 }
 
 func (f *fakeSettings) PassageModel() string {

--- a/modules/text2vec-huggingface/vectorizer/objects.go
+++ b/modules/text2vec-huggingface/vectorizer/objects.go
@@ -44,6 +44,7 @@ type ClassSettings interface {
 	PropertyIndexed(property string) bool
 	VectorizePropertyName(propertyName string) bool
 	VectorizeClassName() bool
+	EndpointURL() string
 	PassageModel() string
 	QueryModel() string
 	OptionWaitForModel() bool
@@ -120,6 +121,7 @@ func (v *Vectorizer) object(ctx context.Context, className string,
 
 	text := strings.Join(corpi, " ")
 	res, err := v.client.Vectorize(ctx, text, ent.VectorizationConfig{
+		EndpointURL:  icheck.EndpointURL(),
 		Model:        icheck.PassageModel(),
 		WaitForModel: icheck.OptionWaitForModel(),
 		UseGPU:       icheck.OptionUseGPU(),

--- a/modules/text2vec-huggingface/vectorizer/objects_test.go
+++ b/modules/text2vec-huggingface/vectorizer/objects_test.go
@@ -33,6 +33,7 @@ func TestVectorizingObjects(t *testing.T) {
 		excludedProperty         string // to simulate a schema where property names aren't vectorized
 		excludedClass            string // to simulate a schema where class names aren't vectorized
 		passageModel             string
+		endpointURL              string
 	}
 
 	tests := []testCase{
@@ -168,6 +169,15 @@ func TestVectorizingObjects(t *testing.T) {
 			},
 			expectedClientCall: "super car brand of the car best brand review a very great car",
 		},
+		{
+			name: "empty object with HF Inference Endpoint",
+			input: &models.Object{
+				Class: "Car",
+			},
+			endpointURL:              "https://url.cloud",
+			expectedHuggingFaceModel: "",
+			expectedClientCall:       "car",
+		},
 	}
 
 	for _, test := range tests {
@@ -181,6 +191,7 @@ func TestVectorizingObjects(t *testing.T) {
 				skippedProperty:    test.noindex,
 				vectorizeClassName: test.excludedClass != "Car",
 				passageModel:       test.passageModel,
+				endpointURL:        test.endpointURL,
 			}
 			err := v.Object(context.Background(), test.input, ic)
 

--- a/modules/text2vec-huggingface/vectorizer/texts.go
+++ b/modules/text2vec-huggingface/vectorizer/texts.go
@@ -23,6 +23,7 @@ func (v *Vectorizer) Texts(ctx context.Context, inputs []string,
 	settings ClassSettings,
 ) ([]float32, error) {
 	res, err := v.client.VectorizeQuery(ctx, v.joinSentences(inputs), ent.VectorizationConfig{
+		EndpointURL:  settings.EndpointURL(),
 		Model:        settings.QueryModel(),
 		WaitForModel: settings.OptionWaitForModel(),
 		UseGPU:       settings.OptionUseGPU(),

--- a/modules/text2vec-huggingface/vectorizer/texts_test.go
+++ b/modules/text2vec-huggingface/vectorizer/texts_test.go
@@ -27,6 +27,7 @@ func TestVectorizingTexts(t *testing.T) {
 		expectedClientCall       string
 		expectedHuggingFaceModel string
 		huggingFaceModel         string
+		huggingFaceEndpointURL   string
 	}
 
 	tests := []testCase{
@@ -79,6 +80,13 @@ func TestVectorizingTexts(t *testing.T) {
 			expectedHuggingFaceModel: "sentence-transformers/gtr-t5-xl",
 			expectedClientCall:       "this is sentence 1, and here's number 2",
 		},
+		{
+			name:                     "single word with inference url",
+			input:                    []string{"hello"},
+			huggingFaceEndpointURL:   "http://url.cloud",
+			expectedHuggingFaceModel: "",
+			expectedClientCall:       "hello",
+		},
 	}
 
 	for _, test := range tests {
@@ -88,7 +96,8 @@ func TestVectorizingTexts(t *testing.T) {
 			v := New(client)
 
 			settings := &fakeSettings{
-				queryModel: test.huggingFaceModel,
+				queryModel:  test.huggingFaceModel,
+				endpointURL: test.huggingFaceEndpointURL,
 			}
 			vec, err := v.Texts(context.Background(), test.input, settings)
 


### PR DESCRIPTION
### What's being changed:

Added support for HuggingFace Inference API (addresses #2324).
Removed mandatory setting for `HUGGINGFACE_API_KEY` to be present in requests.

### Review checklist

- [x] All new code is covered by tests where it is reasonable.
