### PR TITLE
UX: No error message on empty schema

### DIFF
--- a/adapters/handlers/graphql/local/aggregate/aggregate.go
+++ b/adapters/handlers/graphql/local/aggregate/aggregate.go
@@ -17,6 +17,7 @@ import (
 	"github.com/graphql-go/graphql"
 	"github.com/semi-technologies/weaviate/adapters/handlers/graphql/descriptions"
 	"github.com/semi-technologies/weaviate/adapters/handlers/graphql/local/common_filters"
+	"github.com/semi-technologies/weaviate/adapters/handlers/graphql/utils"
 	"github.com/semi-technologies/weaviate/entities/aggregation"
 	"github.com/semi-technologies/weaviate/entities/models"
 	"github.com/semi-technologies/weaviate/entities/schema"
@@ -33,7 +34,7 @@ func Build(dbSchema *schema.Schema, config config.Config,
 	modulesProvider ModulesProvider,
 ) (*graphql.Field, error) {
 	if len(dbSchema.Objects.Classes) == 0 {
-		return nil, fmt.Errorf("there are no Objects classes defined yet")
+		return nil, utils.ErrEmptySchema
 	}
 
 	var err error

--- a/adapters/handlers/graphql/local/get/get.go
+++ b/adapters/handlers/graphql/local/get/get.go
@@ -12,11 +12,10 @@
 package get
 
 import (
-	"fmt"
-
 	"github.com/graphql-go/graphql"
 	"github.com/graphql-go/graphql/language/ast"
 	"github.com/semi-technologies/weaviate/adapters/handlers/graphql/descriptions"
+	"github.com/semi-technologies/weaviate/adapters/handlers/graphql/utils"
 	"github.com/semi-technologies/weaviate/entities/models"
 	"github.com/semi-technologies/weaviate/entities/schema"
 	"github.com/sirupsen/logrus"
@@ -35,7 +34,7 @@ func Build(schema *schema.Schema, logger logrus.FieldLogger,
 	modulesProvider ModulesProvider,
 ) (*graphql.Field, error) {
 	if len(schema.Objects.Classes) == 0 {
-		return nil, fmt.Errorf("there are no Objects classes defined yet")
+		return nil, utils.ErrEmptySchema
 	}
 
 	cb := newClassBuilder(schema, logger, modulesProvider)

--- a/adapters/handlers/graphql/utils/helper_objects.go
+++ b/adapters/handlers/graphql/utils/helper_objects.go
@@ -13,6 +13,8 @@
 package utils
 
 import (
+	"errors"
+
 	"github.com/graphql-go/graphql"
 )
 
@@ -36,3 +38,5 @@ type FilterContainer struct {
 	WeaviateNetworkWhereKeywordsInpObj          *graphql.InputObject            // Object containing a global filter element
 	WeaviateNetworkIntrospectPropertiesObjField *graphql.Field                  // Object containing a global filter element
 }
+
+var ErrEmptySchema = errors.New("there are no classes defined yet")

--- a/adapters/handlers/rest/configure_server.go
+++ b/adapters/handlers/rest/configure_server.go
@@ -13,12 +13,12 @@ package rest
 
 import (
 	"context"
-	"fmt"
 	"net/http"
 	"os"
 	"time"
 
 	"github.com/semi-technologies/weaviate/adapters/handlers/graphql"
+	"github.com/semi-technologies/weaviate/adapters/handlers/graphql/utils"
 	"github.com/semi-technologies/weaviate/adapters/handlers/rest/state"
 	"github.com/semi-technologies/weaviate/entities/schema"
 	"github.com/semi-technologies/weaviate/usecases/auth/authentication/anonymous"
@@ -51,7 +51,7 @@ func makeUpdateSchemaCall(logger logrus.FieldLogger, appState *state.State, trav
 			traverser,
 			appState.Modules,
 		)
-		if err != nil {
+		if err != nil && err != utils.ErrEmptySchema {
 			logger.WithField("action", "graphql_rebuild").
 				WithError(err).Error("could not (re)build graphql provider")
 		}
@@ -64,7 +64,7 @@ func rebuildGraphQL(updatedSchema schema.Schema, logger logrus.FieldLogger,
 ) (graphql.GraphQL, error) {
 	updatedGraphQL, err := graphql.Build(&updatedSchema, traverser, logger, config, modulesProvider)
 	if err != nil {
-		return nil, fmt.Errorf("Could not re-generate GraphQL schema, because: %v", err)
+		return nil, err
 	}
 
 	logger.WithField("action", "graphql_rebuild").Debug("successfully rebuild graphql schema")

--- a/go.mod
+++ b/go.mod
@@ -114,7 +114,7 @@ require (
 	github.com/sean-/seed v0.0.0-20170313163322-e2103e2c3529 // indirect
 	github.com/stretchr/objx v0.4.0 // indirect
 	github.com/willf/bitset v1.1.11 // indirect
-	go.mongodb.org/mongo-driver v1.10.4 // indirect
+	go.mongodb.org/mongo-driver v1.11.0 // indirect
 	go.opencensus.io v0.23.0 // indirect
 	golang.org/x/crypto v0.0.0-20220622213112-05595931fe9d // indirect
 	golang.org/x/xerrors v0.0.0-20220609144429-65e65417b02f // indirect

--- a/go.sum
+++ b/go.sum
@@ -940,6 +940,8 @@ go.mongodb.org/mongo-driver v1.10.3 h1:XDQEvmh6z1EUsXuIkXE9TaVeqHw6SwS1uf93jFs0H
 go.mongodb.org/mongo-driver v1.10.3/go.mod h1:z4XpeoU6w+9Vht+jAFyLgVrD+jGSQQe0+CBWFHNiHt8=
 go.mongodb.org/mongo-driver v1.10.4 h1:taPWsSsfn723M05lMyd/TAQe0kU9PsEYQ15WslnBtQw=
 go.mongodb.org/mongo-driver v1.10.4/go.mod h1:z4XpeoU6w+9Vht+jAFyLgVrD+jGSQQe0+CBWFHNiHt8=
+go.mongodb.org/mongo-driver v1.11.0 h1:FZKhBSTydeuffHj9CBjXlR8vQLee1cQyTWYPA6/tqiE=
+go.mongodb.org/mongo-driver v1.11.0/go.mod h1:s7p5vEtfbeR1gYi6pnj3c3/urpbLv2T5Sfd6Rp2HBB8=
 go.mozilla.org/pkcs7 v0.0.0-20200128120323-432b2356ecb1/go.mod h1:SNgMg+EgDFwmvSmLRTNKC5fegJjB7v23qTQ0XLGUNHk=
 go.opencensus.io v0.21.0/go.mod h1:mSImk1erAIZhrmZN+AvHh14ztQfjbGwt4TtuofqLduU=
 go.opencensus.io v0.22.0/go.mod h1:+kGneAE2xo2IficOXnaByMWTGM9T73dGwxeWcUqIpI8=


### PR DESCRIPTION
### What's being changed:

Previously Weaviate would start up with the error message:

> ERRO[0000] could not (re)build graphql provider          action=graphql_rebuild error="Could not re-generate GraphQL schema, because: there are no Objects classes defined yet"

It is confusing for users to see an error message on startup as this doesn't represent an actionable error. This pull requests creates a new error type for when the schema is empty and doesn't log an error in this scenario.