### PR TITLE
Fixes SEGFAULT error after compaction

### DIFF
--- a/adapters/repos/db/shard_write_merge.go
+++ b/adapters/repos/db/shard_write_merge.go
@@ -63,32 +63,38 @@ func (s *Shard) mergeObjectInStorage(merge objects.MergeDocument,
 	bucket := s.store.Bucket(helpers.ObjectsBucketLSM)
 
 	// see comment in shard_write_put.go::putObjectLSM
-	s.docIdLock[s.uuidToIdLockPoolId(idBytes)].Lock()
+	lock := &s.docIdLock[s.uuidToIdLockPoolId(idBytes)]
+	lock.Lock()
 	previous, err := bucket.Get(idBytes)
 	if err != nil {
+		lock.Unlock()
 		return nil, objectInsertStatus{}, errors.Wrap(err, "get bucket")
 	}
 
 	nextObj, _, err := s.mergeObjectData(previous, merge)
 	if err != nil {
+		lock.Unlock()
 		return nil, objectInsertStatus{}, errors.Wrap(err, "merge object data")
 	}
 
 	status, err := s.determineInsertStatus(previous, nextObj)
 	if err != nil {
+		lock.Unlock()
 		return nil, status, errors.Wrap(err, "check insert/update status")
 	}
 
 	nextObj.SetDocID(status.docID)
 	nextBytes, err := nextObj.MarshalBinary()
 	if err != nil {
+		lock.Unlock()
 		return nil, status, errors.Wrapf(err, "marshal object %s to binary", nextObj.ID())
 	}
 
 	if err := s.upsertObjectDataLSM(bucket, idBytes, nextBytes, status.docID); err != nil {
+		lock.Unlock()
 		return nil, status, errors.Wrap(err, "upsert object data")
 	}
-	s.docIdLock[s.uuidToIdLockPoolId(idBytes)].Unlock()
+	lock.Unlock()
 
 	if err := s.updateInvertedIndexLSM(nextObj, status, previous); err != nil {
 		return nil, status, errors.Wrap(err, "update inverted indices")
@@ -123,7 +129,10 @@ func (s *Shard) mutableMergeObjectLSM(merge objects.MergeDocument,
 	out := mutableMergeResult{}
 
 	// see comment in shard_write_put.go::putObjectLSM
-	s.docIdLock[s.uuidToIdLockPoolId(idBytes)].Lock()
+	lock := &s.docIdLock[s.uuidToIdLockPoolId(idBytes)]
+	lock.Lock()
+	defer lock.Unlock()
+
 	previous, err := bucket.Get(idBytes)
 	if err != nil {
 		return out, err
@@ -152,7 +161,6 @@ func (s *Shard) mutableMergeObjectLSM(merge objects.MergeDocument,
 	if err := s.upsertObjectDataLSM(bucket, idBytes, nextBytes, status.docID); err != nil {
 		return out, errors.Wrap(err, "upsert object data")
 	}
-	s.docIdLock[s.uuidToIdLockPoolId(idBytes)].Unlock()
 
 	// do not updated inverted index, since this requires delta analysis, which
 	// must be done by the caller!

--- a/adapters/repos/db/shard_write_put.go
+++ b/adapters/repos/db/shard_write_put.go
@@ -104,14 +104,17 @@ func (s *Shard) putObjectLSM(object *storobj.Object,
 
 	// First the object bucket is checked if already an object with the same uuid is present, to determine if it is new
 	// or an update. Afterwards the bucket is updates. To avoid races, only one goroutine can do this at once.
-	s.docIdLock[s.uuidToIdLockPoolId(idBytes)].Lock()
+	lock := &s.docIdLock[s.uuidToIdLockPoolId(idBytes)]
+	lock.Lock()
 	previous, err := bucket.Get(idBytes)
 	if err != nil {
+		lock.Unlock()
 		return objectInsertStatus{}, err
 	}
 
 	status, err := s.determineInsertStatus(previous, object)
 	if err != nil {
+		lock.Unlock()
 		return status, errors.Wrap(err, "check insert/update status")
 	}
 	s.metrics.PutObjectDetermineStatus(before)
@@ -119,14 +122,16 @@ func (s *Shard) putObjectLSM(object *storobj.Object,
 	object.SetDocID(status.docID)
 	data, err := object.MarshalBinary()
 	if err != nil {
+		lock.Unlock()
 		return status, errors.Wrapf(err, "marshal object %s to binary", object.ID())
 	}
 
 	before = time.Now()
 	if err := s.upsertObjectDataLSM(bucket, idBytes, data, status.docID); err != nil {
+		lock.Unlock()
 		return status, errors.Wrap(err, "upsert object data")
 	}
-	s.docIdLock[s.uuidToIdLockPoolId(idBytes)].Unlock()
+	lock.Unlock()
 	s.metrics.PutObjectUpsertObject(before)
 
 	if !skipInverted {


### PR DESCRIPTION
### What's being changed:

Added missing lock releases on error occurrences
Object's slice is copied after being read from bucket (replace strategy; already implemented for lists and maps)

### Review checklist

- [ ] ~Documentation has been updated, if necessary. Link to changed documentation:~
- [x] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] ~All new code is covered by tests where it is reasonable.~
- [x] Performance tests have been run or not necessary.
