### PR TITLE
Add TTLs to cluster-wide transactions (Schema, Classifications)

### DIFF
--- a/adapters/clients/cluster_schema.go
+++ b/adapters/clients/cluster_schema.go
@@ -39,9 +39,10 @@ func (c *ClusterSchema) OpenTransaction(ctx context.Context, host string,
 	url := url.URL{Scheme: "http", Host: host, Path: path}
 
 	pl := txPayload{
-		Type:    tx.Type,
-		ID:      tx.ID,
-		Payload: tx.Payload,
+		Type:          tx.Type,
+		ID:            tx.ID,
+		Payload:       tx.Payload,
+		DeadlineMilli: tx.Deadline.UnixMilli(),
 	}
 
 	jsonBytes, err := json.Marshal(pl)
@@ -150,9 +151,10 @@ func (c *ClusterSchema) CommitTransaction(ctx context.Context, host string,
 }
 
 type txPayload struct {
-	Type    cluster.TransactionType `json:"type"`
-	ID      string                  `json:"id"`
-	Payload interface{}             `json:"payload"`
+	Type          cluster.TransactionType `json:"type"`
+	ID            string                  `json:"id"`
+	Payload       interface{}             `json:"payload"`
+	DeadlineMilli int64                   `json:"deadlineMilli"`
 }
 
 type txResponsePayload struct {

--- a/adapters/handlers/rest/clusterapi/transactions.go
+++ b/adapters/handlers/rest/clusterapi/transactions.go
@@ -16,6 +16,7 @@ import (
 	"encoding/json"
 	"net/http"
 	"strings"
+	"time"
 
 	"github.com/pkg/errors"
 	"github.com/semi-technologies/weaviate/usecases/cluster"
@@ -29,9 +30,10 @@ type txManager interface {
 }
 
 type txPayload struct {
-	ID      string
-	Type    cluster.TransactionType
-	Payload json.RawMessage
+	ID            string                  `json:"id"`
+	Type          cluster.TransactionType `json:"type"`
+	Payload       json.RawMessage         `json:"payload"`
+	DeadlineMilli int64                   `json:"deadlineMilli"`
 }
 
 type txHandler struct {
@@ -105,9 +107,10 @@ func (h *txHandler) incomingTransaction() http.Handler {
 		}
 
 		tx := &cluster.Transaction{
-			ID:      payload.ID,
-			Type:    payload.Type,
-			Payload: txPayload,
+			ID:       payload.ID,
+			Type:     payload.Type,
+			Payload:  txPayload,
+			Deadline: time.UnixMilli(payload.DeadlineMilli),
 		}
 
 		if err := h.manager.IncomingBeginTransaction(r.Context(), tx); err != nil {

--- a/adapters/repos/classifications/distributed_repo.go
+++ b/adapters/repos/classifications/distributed_repo.go
@@ -14,6 +14,7 @@ package classifications
 import (
 	"context"
 	"sync"
+	"time"
 
 	"github.com/go-openapi/strfmt"
 	"github.com/pkg/errors"
@@ -22,6 +23,8 @@ import (
 	"github.com/semi-technologies/weaviate/usecases/cluster"
 	"github.com/sirupsen/logrus"
 )
+
+const DefaultTxTTL = 60 * time.Second
 
 type DistributedRepo struct {
 	sync.RWMutex
@@ -68,7 +71,7 @@ func (r *DistributedRepo) Put(ctx context.Context,
 	tx, err := r.txRemote.BeginTransaction(ctx, classification.TransactionPut,
 		classification.TransactionPutPayload{
 			Classification: pl,
-		})
+		}, DefaultTxTTL)
 	if err != nil {
 		return errors.Wrap(err, "open cluster-wide transaction")
 	}

--- a/usecases/cluster/transactions_test.go
+++ b/usecases/cluster/transactions_test.go
@@ -88,7 +88,7 @@ func TestTryingToCommitTransactionPastTTL(t *testing.T) {
 	expiredTx := &Transaction{ID: tx1.ID}
 
 	// give the cancel handler some time to run
-	time.Sleep(50 * time.Microsecond)
+	time.Sleep(50 * time.Millisecond)
 
 	err = man.CommitWriteTransaction(ctx, expiredTx)
 	require.NotNil(t, err)
@@ -118,7 +118,7 @@ func TestTryingToCommitIncommingTransactionPastTTL(t *testing.T) {
 	man.IncomingBeginTransaction(context.Background(), tx)
 
 	// give the cancel handler some time to run
-	time.Sleep(100 * time.Microsecond)
+	time.Sleep(50 * time.Millisecond)
 
 	err := man.IncomingCommitTransaction(ctx, tx)
 	require.NotNil(t, err)
@@ -140,7 +140,7 @@ func TestLettingATransactionExpire(t *testing.T) {
 	require.Nil(t, err)
 
 	// give the cancel handler some time to run
-	time.Sleep(50 * time.Microsecond)
+	time.Sleep(50 * time.Millisecond)
 
 	// try to open a new one
 	_, err = man.BeginTransaction(context.Background(), trType, payload, 0)

--- a/usecases/cluster/transactions_test.go
+++ b/usecases/cluster/transactions_test.go
@@ -395,7 +395,7 @@ func TestTxWithDeadline(t *testing.T) {
 		tx, err := man.BeginTransaction(ctx, trType, payload, 1*time.Nanosecond)
 		require.Nil(t, err)
 
-		ctx, cancel := ContextFromTx(tx)
+		ctx, cancel := context.WithDeadline(context.Background(), tx.Deadline)
 		defer cancel()
 
 		assert.NotNil(t, ctx.Err())
@@ -412,7 +412,7 @@ func TestTxWithDeadline(t *testing.T) {
 		tx, err := man.BeginTransaction(ctx, trType, payload, 10*time.Second)
 		require.Nil(t, err)
 
-		ctx, cancel := ContextFromTx(tx)
+		ctx, cancel := context.WithDeadline(context.Background(), tx.Deadline)
 		defer cancel()
 
 		assert.Nil(t, ctx.Err())

--- a/usecases/cluster/transactions_test.go
+++ b/usecases/cluster/transactions_test.go
@@ -81,7 +81,7 @@ func TestTryingToCommitTransactionPastTTL(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), time.Microsecond)
 	defer cancel()
 
-	man := NewTxManager(&fakeBroadcaster{})
+	man := newTestTxManager()
 
 	tx1, err := man.BeginTransaction(ctx, trType, payload)
 	require.Nil(t, err)
@@ -106,7 +106,7 @@ func TestLettingATransactionExpire(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), time.Microsecond)
 	defer cancel()
 
-	man := NewTxManager(&fakeBroadcaster{})
+	man := newTestTxManager()
 
 	tx1, err := man.BeginTransaction(ctx, trType, payload)
 	require.Nil(t, err)

--- a/usecases/cluster/transactions_test.go
+++ b/usecases/cluster/transactions_test.go
@@ -106,7 +106,7 @@ func TestTryingToCommitIncommingTransactionPastTTL(t *testing.T) {
 
 	man := newTestTxManager()
 
-	dl := time.Now().Add(10 * time.Microsecond)
+	dl := time.Now().Add(1 * time.Microsecond)
 
 	tx := &Transaction{
 		ID:       "123456",
@@ -118,7 +118,7 @@ func TestTryingToCommitIncommingTransactionPastTTL(t *testing.T) {
 	man.IncomingBeginTransaction(context.Background(), tx)
 
 	// give the cancel handler some time to run
-	time.Sleep(50 * time.Microsecond)
+	time.Sleep(100 * time.Microsecond)
 
 	err := man.IncomingCommitTransaction(ctx, tx)
 	require.NotNil(t, err)

--- a/usecases/schema/add.go
+++ b/usecases/schema/add.go
@@ -138,7 +138,7 @@ func (m *Manager) addClass(ctx context.Context, class *models.Class,
 	}
 
 	tx, err := m.cluster.BeginTransaction(ctx, AddClass,
-		AddClassPayload{class, shardState})
+		AddClassPayload{class, shardState}, DefaultTxTTL)
 	if err != nil {
 		// possible causes for errors could be nodes down (we expect every node to
 		// the up for a schema transaction) or concurrent transactions from other

--- a/usecases/schema/add_property.go
+++ b/usecases/schema/add_property.go
@@ -56,7 +56,7 @@ func (m *Manager) addClassProperty(ctx context.Context,
 	}
 
 	tx, err := m.cluster.BeginTransaction(ctx, AddProperty,
-		AddPropertyPayload{className, prop})
+		AddPropertyPayload{className, prop}, DefaultTxTTL)
 	if err != nil {
 		// possible causes for errors could be nodes down (we expect every node to
 		// the up for a schema transaction) or concurrent transactions from other

--- a/usecases/schema/delete.go
+++ b/usecases/schema/delete.go
@@ -34,7 +34,7 @@ func (m *Manager) deleteClass(ctx context.Context, className string) error {
 	defer m.Unlock()
 
 	tx, err := m.cluster.BeginTransaction(ctx, DeleteClass,
-		DeleteClassPayload{className})
+		DeleteClassPayload{className}, DefaultTxTTL)
 	if err != nil {
 		// possible causes for errors could be nodes down (we expect every node to
 		// the up for a schema transaction) or concurrent transactions from other

--- a/usecases/schema/startup_cluster_sync.go
+++ b/usecases/schema/startup_cluster_sync.go
@@ -88,7 +88,7 @@ func (m *Manager) startupHandleSingleNode(ctx context.Context,
 func (m *Manager) startupJoinCluster(ctx context.Context,
 	localSchema *State,
 ) error {
-	tx, err := m.cluster.BeginTransaction(ctx, ReadSchema, nil)
+	tx, err := m.cluster.BeginTransaction(ctx, ReadSchema, nil, DefaultTxTTL)
 	if err != nil {
 		return fmt.Errorf("read schema: open transaction: %w", err)
 	}
@@ -123,7 +123,7 @@ func (m *Manager) startupJoinCluster(ctx context.Context,
 func (m *Manager) validateSchemaCorruption(ctx context.Context,
 	localSchema *State,
 ) error {
-	tx, err := m.cluster.BeginTransaction(ctx, ReadSchema, nil)
+	tx, err := m.cluster.BeginTransaction(ctx, ReadSchema, nil, DefaultTxTTL)
 	if err != nil {
 		return fmt.Errorf("read schema: open transaction: %w", err)
 	}

--- a/usecases/schema/transactions.go
+++ b/usecases/schema/transactions.go
@@ -13,6 +13,7 @@ package schema
 
 import (
 	"encoding/json"
+	"time"
 
 	"github.com/pkg/errors"
 	"github.com/semi-technologies/weaviate/entities/models"
@@ -29,6 +30,8 @@ const (
 
 	// read-only
 	ReadSchema cluster.TransactionType = "read_schema"
+
+	DefaultTxTTL = 60 * time.Second
 )
 
 type AddClassPayload struct {

--- a/usecases/schema/update.go
+++ b/usecases/schema/update.go
@@ -83,7 +83,7 @@ func (m *Manager) UpdateClass(ctx context.Context, principal *models.Principal,
 	}
 
 	tx, err := m.cluster.BeginTransaction(ctx, UpdateClass,
-		UpdateClassPayload{className, updated, updatedState})
+		UpdateClassPayload{className, updated, updatedState}, DefaultTxTTL)
 	if err != nil {
 		// possible causes for errors could be nodes down (we expect every node to
 		// the up for a schema transaction) or concurrent transactions from other


### PR DESCRIPTION
### What's being changed:

* Add TTL support for both outgoing and incoming cluster transactions
* Set default TTL for schema & classification tx to 60s

### Review checklist

- ~~Documentation has been updated, if necessary. Link to changed documentation:~~
- [x] Chaos pipeline run or not necessary. Link to pipeline: https://app.travis-ci.com/github/semi-technologies/weaviate-chaos-engineering/builds/257846555
- [x] All new code is covered by tests where it is reasonable.
- ~~Performance tests have been run or not necessary.~~
