### PR TITLE
Prevent IndexNullState and IndexPropertyLength to be updated

### DIFF
--- a/adapters/repos/db/inverted/config_update.go
+++ b/adapters/repos/db/inverted/config_update.go
@@ -26,6 +26,11 @@ func ValidateUserConfigUpdate(initial, updated *models.InvertedIndexConfig) erro
 		return err
 	}
 
+	err = validateInvertedIndexConfigUpdate(initial, updated)
+	if err != nil {
+		return err
+	}
+
 	err = validateStopwordsConfigUpdate(initial, updated)
 	if err != nil {
 		return err
@@ -46,6 +51,18 @@ func validateBM25ConfigUpdate(initial, updated *models.InvertedIndexConfig) erro
 	err := validateBM25Config(updated.Bm25)
 	if err != nil {
 		return err
+	}
+
+	return nil
+}
+
+func validateInvertedIndexConfigUpdate(initial, updated *models.InvertedIndexConfig) error {
+	if updated.IndexPropertyLength != initial.IndexPropertyLength {
+		return errors.New("IndexPropertyLength cannot be changed when updating a schema")
+	}
+
+	if updated.IndexNullState != initial.IndexNullState {
+		return errors.New("IndexNullState cannot be changed when updating a schema")
 	}
 
 	return nil

--- a/adapters/repos/db/inverted/config_update_test.go
+++ b/adapters/repos/db/inverted/config_update_test.go
@@ -120,4 +120,22 @@ func TestValidateUserConfigUpdate(t *testing.T) {
 		err := ValidateUserConfigUpdate(validInitial, updated)
 		require.EqualError(t, err, "found 'duplicate' in both stopwords.additions and stopwords.removals")
 	})
+
+	t.Run("with invalid updated inverted index null state change", func(t *testing.T) {
+		updated := &models.InvertedIndexConfig{
+			IndexNullState: true,
+		}
+
+		err := ValidateUserConfigUpdate(validInitial, updated)
+		require.EqualError(t, err, "IndexNullState cannot be changed when updating a schema")
+	})
+
+	t.Run("with invalid updated inverted index property length change", func(t *testing.T) {
+		updated := &models.InvertedIndexConfig{
+			IndexPropertyLength: true,
+		}
+
+		err := ValidateUserConfigUpdate(validInitial, updated)
+		require.EqualError(t, err, "IndexPropertyLength cannot be changed when updating a schema")
+	})
 }

--- a/test/acceptance/schema/add_class_test.go
+++ b/test/acceptance/schema/add_class_test.go
@@ -186,6 +186,40 @@ func TestUpdateHNSWSettingsAfterAddingRefProps(t *testing.T) {
 		_, err = helper.Client(t).Schema.SchemaObjectsUpdate(updateParams, nil)
 		assert.Nil(t, err)
 	})
+
+	t.Run("obtaining the class, making a change to IndexNullState (immutable) property and update", func(t *testing.T) {
+		params := schema.NewSchemaObjectsGetParams().
+			WithClassName(className)
+		res, err := helper.Client(t).Schema.SchemaObjectsGet(params, nil)
+		require.Nil(t, err)
+
+		class := res.Payload
+
+		// IndexNullState cannot be updated during runtime
+		class.InvertedIndexConfig.IndexNullState = true
+		updateParams := schema.NewSchemaObjectsUpdateParams().
+			WithClassName(className).
+			WithObjectClass(class)
+		_, err = helper.Client(t).Schema.SchemaObjectsUpdate(updateParams, nil)
+		assert.NotNil(t, err)
+	})
+
+	t.Run("obtaining the class, making a change to IndexPropertyLength (immutable) property and update", func(t *testing.T) {
+		params := schema.NewSchemaObjectsGetParams().
+			WithClassName(className)
+		res, err := helper.Client(t).Schema.SchemaObjectsGet(params, nil)
+		require.Nil(t, err)
+
+		class := res.Payload
+
+		// IndexPropertyLength cannot be updated during runtime
+		class.InvertedIndexConfig.IndexPropertyLength = true
+		updateParams := schema.NewSchemaObjectsUpdateParams().
+			WithClassName(className).
+			WithObjectClass(class)
+		_, err = helper.Client(t).Schema.SchemaObjectsUpdate(updateParams, nil)
+		assert.NotNil(t, err)
+	})
 }
 
 // TODO: https://github.com/semi-technologies/weaviate/issues/973


### PR DESCRIPTION
### What's being changed:

closes https://github.com/semi-technologies/weaviate/issues/2360

IndexNullState and IndexPropertyLength could be updated for an existing schema. This would create problems as existing objects are not reindexed

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
