### PR TITLE
Update version to v1.17.0-prealpha

### DIFF
--- a/adapters/handlers/rest/doc.go
+++ b/adapters/handlers/rest/doc.go
@@ -18,7 +18,7 @@
 //	  https
 //	Host: localhost
 //	BasePath: /v1
-//	Version: 1.16.3
+//	Version: 1.17.0-prealpha
 //	Contact: Weaviate<hello@semi.technology> https://github.com/semi-technologies
 //
 //	Consumes:

--- a/adapters/handlers/rest/embedded_spec.go
+++ b/adapters/handlers/rest/embedded_spec.go
@@ -48,7 +48,7 @@ func init() {
       "url": "https://github.com/semi-technologies",
       "email": "hello@semi.technology"
     },
-    "version": "1.16.3"
+    "version": "1.17.0-prealpha"
   },
   "basePath": "/v1",
   "paths": {
@@ -4195,7 +4195,7 @@ func init() {
       "url": "https://github.com/semi-technologies",
       "email": "hello@semi.technology"
     },
-    "version": "1.16.3"
+    "version": "1.17.0-prealpha"
   },
   "basePath": "/v1",
   "paths": {

--- a/openapi-specs/schema.json
+++ b/openapi-specs/schema.json
@@ -1531,7 +1531,7 @@
     },
     "description": "Cloud-native, modular vector search engine",
     "title": "Weaviate",
-    "version": "1.16.3"
+    "version": "1.17.0-prealpha"
   },
   "parameters": {
     "CommonOffsetParameterQuery": {


### PR DESCRIPTION
This PR already sets the version on `master` to `v1.17.0-prealpha`.

If a user receives a preview build from `master` or another branch that was branched off of (or rebased onto) `master`, the build will already report `v1.17.0-prealpha` which is much more accurate than `v1.16.0`. 