### PR TITLE
adjusts batch size to decrease test execution time

### DIFF
--- a/adapters/repos/db/batch_integration_test.go
+++ b/adapters/repos/db/batch_integration_test.go
@@ -62,10 +62,10 @@ func TestBatchPutObjectsWithDimensions(t *testing.T) {
 	dimBefore := GetDimensionsFromRepo(repo, "ThingForBatching")
 	require.Equal(t, 0, dimBefore, "Dimensions are empty before import")
 
-	simpleInsertObjects(t, repo, "ThingForBatching", 603)
+	simpleInsertObjects(t, repo, "ThingForBatching", 123)
 
 	dimAfter := GetDimensionsFromRepo(repo, "ThingForBatching")
-	require.Equal(t, 1809, dimAfter, "Dimensions are present after import")
+	require.Equal(t, 369, dimAfter, "Dimensions are present after import")
 }
 
 func TestBatchPutObjects(t *testing.T) {


### PR DESCRIPTION
### What's being changed:
To decrease execution time of integration tests, number of object in the batch was adjusted in `TestBatchPutObjectsWithDimensions` test.

`-coverpkg` option used with `go test` command makes execution time of above test grow exponentially with increasing number of objects in batch (~1s for ~100 objects; ~70s for ~200 objects, ~280s for 400 objects)

### Review checklist

- [ ] ~Documentation has been updated, if necessary. Link to changed documentation:~
- [ ] ~Chaos pipeline run or not necessary. Link to pipeline:~
- [ ] ~All new code is covered by tests where it is reasonable.~
- [ ] ~Performance tests have been run or not necessary.~
