### PR TITLE
Remove obsolete invertedIndexConfig.cleanupIntervalSeconds

### DIFF
--- a/adapters/repos/db/helper_for_test.go
+++ b/adapters/repos/db/helper_for_test.go
@@ -213,7 +213,7 @@ func testShard(t *testing.T, ctx context.Context, className string, indexOpts ..
 
 	idx := &Index{
 		Config:                IndexConfig{RootPath: tmpDir, ClassName: schema.ClassName(className), MaxImportGoroutinesFactor: 1.5},
-		invertedIndexConfig:   schema.InvertedIndexConfig{CleanupIntervalSeconds: 1},
+		invertedIndexConfig:   schema.InvertedIndexConfig{},
 		vectorIndexUserConfig: enthnsw.UserConfig{Skip: true},
 		logger:                logrus.New(),
 		getSchema:             schemaGetter,

--- a/adapters/repos/db/inverted/config.go
+++ b/adapters/repos/db/inverted/config.go
@@ -42,7 +42,6 @@ func ValidateConfig(conf *models.InvertedIndexConfig) error {
 func ConfigFromModel(iicm *models.InvertedIndexConfig) schema.InvertedIndexConfig {
 	var conf schema.InvertedIndexConfig
 
-	conf.CleanupIntervalSeconds = iicm.CleanupIntervalSeconds
 	conf.IndexTimestamps = iicm.IndexTimestamps
 	conf.IndexNullState = iicm.IndexNullState
 	conf.IndexPropertyLength = iicm.IndexPropertyLength

--- a/adapters/repos/db/inverted/config_test.go
+++ b/adapters/repos/db/inverted/config_test.go
@@ -33,18 +33,8 @@ func almostEqual(t *testing.T, a, b float64) bool {
 }
 
 func TestValidateConfig(t *testing.T) {
-	t.Run("with invalid cleanup interval", func(t *testing.T) {
-		in := &models.InvertedIndexConfig{
-			CleanupIntervalSeconds: -1,
-		}
-
-		err := ValidateConfig(in)
-		assert.EqualError(t, err, "cleanup interval seconds must be > 0")
-	})
-
 	t.Run("with invalid BM25.k1", func(t *testing.T) {
 		in := &models.InvertedIndexConfig{
-			CleanupIntervalSeconds: 1,
 			Bm25: &models.BM25Config{
 				K1: -1,
 				B:  0.7,
@@ -57,7 +47,6 @@ func TestValidateConfig(t *testing.T) {
 
 	t.Run("with invalid BM25.b", func(t *testing.T) {
 		in := &models.InvertedIndexConfig{
-			CleanupIntervalSeconds: 1,
 			Bm25: &models.BM25Config{
 				K1: 1,
 				B:  1.001,
@@ -70,7 +59,6 @@ func TestValidateConfig(t *testing.T) {
 
 	t.Run("with valid config", func(t *testing.T) {
 		in := &models.InvertedIndexConfig{
-			CleanupIntervalSeconds: 1,
 			Bm25: &models.BM25Config{
 				K1: 1,
 				B:  0.1,
@@ -83,7 +71,6 @@ func TestValidateConfig(t *testing.T) {
 
 	t.Run("with nonexistent stopword preset", func(t *testing.T) {
 		in := &models.InvertedIndexConfig{
-			CleanupIntervalSeconds: 1,
 			Stopwords: &models.StopwordConfig{
 				Preset: "DNE",
 			},
@@ -102,7 +89,6 @@ func TestValidateConfig(t *testing.T) {
 
 		for _, addList := range additions {
 			in := &models.InvertedIndexConfig{
-				CleanupIntervalSeconds: 1,
 				Stopwords: &models.StopwordConfig{
 					Additions: addList,
 				},
@@ -122,7 +108,6 @@ func TestValidateConfig(t *testing.T) {
 
 		for _, remList := range removals {
 			in := &models.InvertedIndexConfig{
-				CleanupIntervalSeconds: 1,
 				Stopwords: &models.StopwordConfig{
 					Removals: remList,
 				},
@@ -135,7 +120,6 @@ func TestValidateConfig(t *testing.T) {
 
 	t.Run("with shared additions/removals items", func(t *testing.T) {
 		in := &models.InvertedIndexConfig{
-			CleanupIntervalSeconds: 1,
 			Stopwords: &models.StopwordConfig{
 				Additions: []string{"some", "words", "are", "different"},
 				Removals:  []string{"and", "some", "the", "same"},
@@ -168,7 +152,6 @@ func TestValidateConfig(t *testing.T) {
 
 		for _, test := range tests {
 			in := &models.InvertedIndexConfig{
-				CleanupIntervalSeconds: 1,
 				Stopwords: &models.StopwordConfig{
 					Preset:    "en",
 					Additions: test.additions,
@@ -184,12 +167,10 @@ func TestValidateConfig(t *testing.T) {
 
 func TestConfigFromModel(t *testing.T) {
 	t.Run("with all fields set", func(t *testing.T) {
-		interval := int64(1)
 		k1 := 1.12
 		b := 0.7
 
 		in := &models.InvertedIndexConfig{
-			CleanupIntervalSeconds: interval,
 			Bm25: &models.BM25Config{
 				K1: float32(k1),
 				B:  float32(b),
@@ -200,7 +181,6 @@ func TestConfigFromModel(t *testing.T) {
 		}
 
 		expected := schema.InvertedIndexConfig{
-			CleanupIntervalSeconds: interval,
 			BM25: schema.BM25Config{
 				K1: k1,
 				B:  b,
@@ -211,7 +191,6 @@ func TestConfigFromModel(t *testing.T) {
 		}
 
 		conf := ConfigFromModel(in)
-		assert.Equal(t, expected.CleanupIntervalSeconds, conf.CleanupIntervalSeconds)
 		assert.True(t, almostEqual(t, conf.BM25.K1, expected.BM25.K1))
 		assert.True(t, almostEqual(t, conf.BM25.B, expected.BM25.B))
 		assert.Equal(t, expected.Stopwords, conf.Stopwords)
@@ -225,7 +204,6 @@ func TestConfigFromModel(t *testing.T) {
 		}
 
 		expected := schema.InvertedIndexConfig{
-			CleanupIntervalSeconds: interval,
 			BM25: schema.BM25Config{
 				K1: float64(config.DefaultBM25k1),
 				B:  float64(config.DefaultBM25b),
@@ -233,7 +211,6 @@ func TestConfigFromModel(t *testing.T) {
 		}
 
 		conf := ConfigFromModel(in)
-		assert.Equal(t, expected.CleanupIntervalSeconds, conf.CleanupIntervalSeconds)
 		assert.True(t, almostEqual(t, conf.BM25.K1, expected.BM25.K1))
 		assert.True(t, almostEqual(t, conf.BM25.B, expected.BM25.B))
 	})
@@ -246,14 +223,12 @@ func TestConfigFromModel(t *testing.T) {
 		}
 
 		expected := schema.InvertedIndexConfig{
-			CleanupIntervalSeconds: interval,
 			Stopwords: schema.StopwordConfig{
 				Preset: "en",
 			},
 		}
 
 		conf := ConfigFromModel(in)
-		assert.Equal(t, expected.CleanupIntervalSeconds, conf.CleanupIntervalSeconds)
 		assert.Equal(t, expected.Stopwords, conf.Stopwords)
 	})
 }

--- a/adapters/repos/db/shard.go
+++ b/adapters/repos/db/shard.go
@@ -57,7 +57,6 @@ type Shard struct {
 	promMetrics       *monitoring.PrometheusMetrics
 	propertyIndices   propertyspecific.Indices
 	deletedDocIDs     *docid.InMemDeletedTracker
-	cleanupInterval   time.Duration
 	propLengths       *inverted.PropertyLengthTracker
 	randomSource      *bufferedRandomGen
 	versioner         *shardVersioner
@@ -94,8 +93,6 @@ func NewShard(ctx context.Context, promMetrics *monitoring.PrometheusMetrics,
 		return nil, errors.Wrap(err, "init bufferend random generator")
 	}
 
-	invertedIndexConfig := index.getInvertedIndexConfig()
-
 	s := &Shard{
 		index:            index,
 		name:             shardName,
@@ -103,9 +100,7 @@ func NewShard(ctx context.Context, promMetrics *monitoring.PrometheusMetrics,
 		promMetrics:      promMetrics,
 		metrics: NewMetrics(index.logger, promMetrics,
 			string(index.Config.ClassName), shardName),
-		deletedDocIDs: docid.NewInMemDeletedTracker(),
-		cleanupInterval: time.Duration(invertedIndexConfig.
-			CleanupIntervalSeconds) * time.Second,
+		deletedDocIDs:       docid.NewInMemDeletedTracker(),
 		randomSource:        rand,
 		resourceScanState:   newResourceScanState(),
 		jobQueueCh:          make(chan job, 100000),

--- a/entities/schema/inverted_index_config.go
+++ b/entities/schema/inverted_index_config.go
@@ -12,12 +12,11 @@
 package schema
 
 type InvertedIndexConfig struct {
-	CleanupIntervalSeconds int64
-	BM25                   BM25Config
-	Stopwords              StopwordConfig
-	IndexTimestamps        bool
-	IndexNullState         bool
-	IndexPropertyLength    bool
+	BM25                BM25Config
+	Stopwords           StopwordConfig
+	IndexTimestamps     bool
+	IndexNullState      bool
+	IndexPropertyLength bool
 }
 
 type BM25Config struct {


### PR DESCRIPTION
### What's being changed:
* Remove the unused `invertedIndexConfig.cleanupIntervalSeconds`
* The prop is not removed from the swagger-generated `models.InvertedIndexConfig` type. This way Weaviate will not error if a user still provides that property (e.g. because they have a schema created with a previous version). However, Weaviate will no longer parse or set this prop as a default
* The above is not to be confused with `vectorIndexConfig.cleanupIntervalSeconds` which is used to control how often the HNSW cleanup logic runs. This property is not affected by this PR.

### Review checklist

- [x] Documentation has been updated, if necessary. Link to changed documentation:
- [x] Chaos pipeline run or not necessary. Link to pipeline: https://app.travis-ci.com/github/semi-technologies/weaviate-chaos-engineering/builds/257946968
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.
