### PR TITLE
Extend replication client with the remaining write operations

### DIFF
--- a/adapters/clients/replication_client.go
+++ b/adapters/clients/replication_client.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/semi-technologies/weaviate/adapters/handlers/rest/clusterapi"
 	"github.com/semi-technologies/weaviate/entities/storobj"
+	"github.com/semi-technologies/weaviate/usecases/objects"
 	"github.com/semi-technologies/weaviate/usecases/replica"
 )
 
@@ -97,16 +98,106 @@ func (c *ReplicationClient) PutObjects(ctx context.Context, host, index,
 	shard, requestID string, objects []*storobj.Object,
 ) (replica.SimpleResponse, error) {
 	var resp replica.SimpleResponse
-	marshalled, err := clusterapi.IndicesPayloads.ObjectList.Marshal(objects)
+	body, err := clusterapi.IndicesPayloads.ObjectList.Marshal(objects)
 	if err != nil {
 		return resp, fmt.Errorf("encode request: %w", err)
 	}
-	req, err := newHttpRequest(ctx, http.MethodPost, host, index, shard, requestID, "", bytes.NewReader(marshalled))
+	req, err := newHttpRequest(ctx, http.MethodPost, host, index, shard, requestID, "", bytes.NewReader(body))
 	if err != nil {
 		return resp, fmt.Errorf("create http request: %w", err)
 	}
 
 	clusterapi.IndicesPayloads.ObjectList.SetContentTypeHeaderReq(req)
+	res, err := c.client.Do(req)
+	if err != nil {
+		return resp, fmt.Errorf("connect: %w", err)
+	}
+	defer res.Body.Close()
+
+	if res.StatusCode != http.StatusOK {
+		return resp, fmt.Errorf("status code: %v", res.StatusCode)
+	}
+	if err := json.NewDecoder(res.Body).Decode(&resp); err != nil {
+		return resp, fmt.Errorf("decode response: %w", err)
+	}
+	return resp, nil
+}
+
+func (c *ReplicationClient) MergeObject(ctx context.Context, host, index, shard, requestID string,
+	doc *objects.MergeDocument,
+) (replica.SimpleResponse, error) {
+	var resp replica.SimpleResponse
+	body, err := clusterapi.IndicesPayloads.MergeDoc.Marshal(*doc)
+	if err != nil {
+		return resp, fmt.Errorf("encode request: %w", err)
+	}
+
+	req, err := newHttpRequest(ctx, http.MethodPatch, host, index, shard,
+		requestID, doc.ID.String(), bytes.NewReader(body))
+	if err != nil {
+		return resp, fmt.Errorf("create http request: %w", err)
+	}
+
+	clusterapi.IndicesPayloads.MergeDoc.SetContentTypeHeaderReq(req)
+	res, err := c.client.Do(req)
+	if err != nil {
+		return resp, fmt.Errorf("connect: %w", err)
+	}
+
+	defer res.Body.Close()
+	if res.StatusCode != http.StatusOK {
+		return resp, fmt.Errorf("status code: %v", res.StatusCode)
+	}
+	if err := json.NewDecoder(res.Body).Decode(&resp); err != nil {
+		return resp, fmt.Errorf("decode response: %w", err)
+	}
+	return resp, nil
+}
+
+func (c *ReplicationClient) AddReferences(ctx context.Context, host, index,
+	shard, requestID string, refs []objects.BatchReference,
+) (replica.SimpleResponse, error) {
+	var resp replica.SimpleResponse
+	body, err := clusterapi.IndicesPayloads.ReferenceList.Marshal(refs)
+	if err != nil {
+		return resp, fmt.Errorf("encode request: %w", err)
+	}
+	req, err := newHttpRequest(ctx, http.MethodPost, host, index, shard,
+		requestID, "references",
+		bytes.NewReader(body))
+	if err != nil {
+		return resp, fmt.Errorf("create http request: %w", err)
+	}
+
+	clusterapi.IndicesPayloads.ReferenceList.SetContentTypeHeaderReq(req)
+	res, err := c.client.Do(req)
+	if err != nil {
+		return resp, fmt.Errorf("connect: %w", err)
+	}
+	defer res.Body.Close()
+
+	if res.StatusCode != http.StatusOK {
+		return resp, fmt.Errorf("status code: %v", res.StatusCode)
+	}
+	if err := json.NewDecoder(res.Body).Decode(&resp); err != nil {
+		return resp, fmt.Errorf("decode response: %w", err)
+	}
+	return resp, nil
+}
+
+func (c *ReplicationClient) DeleteObjects(ctx context.Context, host, index, shard, requestID string,
+	docIDs []uint64, dryRun bool,
+) (resp replica.SimpleResponse, err error) {
+	body, err := clusterapi.IndicesPayloads.BatchDeleteParams.Marshal(docIDs, dryRun)
+	if err != nil {
+		return resp, fmt.Errorf("encode request: %w", err)
+	}
+	req, err := newHttpRequest(ctx, http.MethodDelete, host, index, shard, requestID, "", bytes.NewReader(body))
+	if err != nil {
+		return resp, fmt.Errorf("create http request: %w", err)
+	}
+
+	clusterapi.IndicesPayloads.BatchDeleteParams.SetContentTypeHeaderReq(req)
 	res, err := c.client.Do(req)
 	if err != nil {
 		return resp, fmt.Errorf("connect: %w", err)
@@ -167,10 +258,10 @@ func (c *ReplicationClient) Abort(ctx context.Context, host, index, shard, reque
 	return resp, nil
 }
 
-func newHttpRequest(ctx context.Context, method, host, index, shard, requestId, uuid string, body io.Reader) (*http.Request, error) {
-	path := fmt.Sprintf("/replica/indices/%s/shards/%s/objects", index, shard)
-	if uuid != "" {
-		path = fmt.Sprintf("%s/%s", path, uuid)
+func newHttpRequest(ctx context.Context, method, host, index, shard, requestId, suffix string, body io.Reader) (*http.Request, error) {
+	path := fmt.Sprintf("/replicas/%s/shards/%s/objects", index, shard)
+	if suffix != "" {
+		path = fmt.Sprintf("%s/%s", path, suffix)
 	}
 	url := url.URL{
 		Scheme:   "http",
@@ -183,7 +274,7 @@ func newHttpRequest(ctx context.Context, method, host, index, shard, requestId, 
 }
 
 func newHttpCMD(ctx context.Context, host, cmd, index, shard, requestId string, body io.Reader) (*http.Request, error) {
-	path := fmt.Sprintf("/replica/%s/%s:%s", index, shard, cmd)
+	path := fmt.Sprintf("/replicas/%s/shards/%s:%s", index, shard, cmd)
 	q := url.Values{replica.RequestKey: []string{requestId}}.Encode()
 	url := url.URL{Scheme: "http", Host: host, Path: path, RawQuery: q}
 	return http.NewRequestWithContext(ctx, http.MethodPost, url.String(), body)

--- a/usecases/replica/coordinator.go
+++ b/usecases/replica/coordinator.go
@@ -90,7 +90,6 @@ func (c *coordinator[T]) broadcast(ctx context.Context, replicas []string, op re
 
 // commitAll tells replicas to commit pending updates related to a specific request
 // (second phase of a two-phase commit)
-
 func (c *coordinator[T]) commitAll(ctx context.Context, replicas []string, op commitOp[T]) error {
 	var g errgroup.Group
 	c.responses = make([]T, len(replicas))

--- a/usecases/replica/transport.go
+++ b/usecases/replica/transport.go
@@ -44,9 +44,8 @@ type client interface {
 	DeleteObjects(ctx context.Context, host, index, shard, requestID string,
 		docIDs []uint64, dryRun bool) (SimpleResponse, error)
 
-	// TODO
-	// AddReferences(ctx context.Context, host, index, shard, requestID string,
-	// 	refs objects.BatchReferences) (SimpleResponse, error)
+	AddReferences(ctx context.Context, host, index, shard, requestID string,
+		refs objects.BatchReferences) (SimpleResponse, error)
 
 	Commit(ctx context.Context, host, index, shard, requestID string, resp interface{}) error
 


### PR DESCRIPTION


### What's being changed:
Add DeleteObject, MergeObject, AddReferences.
Change base path to replicas/{class}/shards/{shard} where class is the subject of replication.
Make command path consistent with object path.

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [x] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.
