### PR TITLE
Improve Startup Time by persisting more LSM Segment Information

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -29,3 +29,8 @@ tools/
 coverage-integration.txt
 coverage-unit.txt
 
+# wikipedia dataset when downloaded according to docs
+weaviate-wikipedia-*
+# the local path when extracting the wiki dataset
+var/weaviate/
+

--- a/adapters/repos/db/lsmkv/bucket_backup_test.go
+++ b/adapters/repos/db/lsmkv/bucket_backup_test.go
@@ -167,8 +167,15 @@ func TestBackup_ListFiles(t *testing.T) {
 	t.Run("assert expected bucket contents", func(t *testing.T) {
 		files, err := b.ListFiles(ctx)
 		assert.Nil(t, err)
-		assert.Len(t, files, 1)
-		assert.Equal(t, filepath.Ext(files[0]), ".db")
+		assert.Len(t, files, 3)
+
+		exts := make([]string, 3)
+		for i, file := range files {
+			exts[i] = filepath.Ext(file)
+		}
+		assert.Contains(t, exts, ".db")    // the segment itself
+		assert.Contains(t, exts, ".bloom") // the segment's bloom filter
+		assert.Contains(t, exts, ".cna")   // the segment's count net additions
 	})
 
 	err = b.Shutdown(context.Background())

--- a/adapters/repos/db/lsmkv/segment.go
+++ b/adapters/repos/db/lsmkv/segment.go
@@ -15,7 +15,6 @@ import (
 	"bytes"
 	"os"
 	"syscall"
-	"time"
 
 	"github.com/pkg/errors"
 	"github.com/semi-technologies/weaviate/adapters/repos/db/lsmkv/segmentindex"
@@ -190,47 +189,6 @@ func (ind *segment) initCountNetAdditions(exists existsOnLowerSegmentsFn) error 
 	ind.countNetAdditions = netCount
 
 	return lastErr
-}
-
-func (ind *segment) initBloomFilter() error {
-	before := time.Now()
-	keys, err := ind.index.AllKeys()
-	if err != nil {
-		return err
-	}
-
-	ind.bloomFilter = bloom.NewWithEstimates(uint(len(keys)), 0.001)
-	for _, key := range keys {
-		ind.bloomFilter.Add(key)
-	}
-
-	took := time.Since(before)
-	ind.logger.WithField("action", "lsm_init_disk_segment_build_bloom_filter_primary").
-		WithField("path", ind.path).
-		WithField("took", took).
-		Debugf("building bloom filter took %s\n", took)
-	return nil
-}
-
-func (ind *segment) initSecondaryBloomFilter(pos int) error {
-	before := time.Now()
-	keys, err := ind.secondaryIndices[pos].AllKeys()
-	if err != nil {
-		return err
-	}
-
-	ind.secondaryBloomFilters[pos] = bloom.NewWithEstimates(uint(len(keys)), 0.001)
-	for _, key := range keys {
-		ind.secondaryBloomFilters[pos].Add(key)
-	}
-	took := time.Since(before)
-
-	ind.logger.WithField("action", "lsm_init_disk_segment_build_bloom_filter_secondary").
-		WithField("secondary_index_position", pos).
-		WithField("path", ind.path).
-		WithField("took", took).
-		Debugf("building bloom filter took %s\n", took)
-	return nil
 }
 
 func (ind *segment) close() error {

--- a/adapters/repos/db/lsmkv/segment_bloom_filters.go
+++ b/adapters/repos/db/lsmkv/segment_bloom_filters.go
@@ -1,3 +1,14 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2022 SeMI Technologies B.V. All rights reserved.
+//
+//  CONTACT: hello@semi.technology
+//
+
 package lsmkv
 
 import (

--- a/adapters/repos/db/lsmkv/segment_bloom_filters.go
+++ b/adapters/repos/db/lsmkv/segment_bloom_filters.go
@@ -1,0 +1,107 @@
+package lsmkv
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/willf/bloom"
+)
+
+func (ind *segment) bloomFilterPath() string {
+	extless := strings.TrimSuffix(ind.path, filepath.Ext(ind.path))
+	return fmt.Sprintf("%s.bloom", extless)
+}
+
+func (ind *segment) initBloomFilter() error {
+	ok, err := fileExists(ind.bloomFilterPath())
+	if err != nil {
+		return err
+	}
+
+	if ok {
+		return ind.loadBloomFilterFromDisk()
+	}
+
+	before := time.Now()
+	keys, err := ind.index.AllKeys()
+	if err != nil {
+		return err
+	}
+
+	ind.bloomFilter = bloom.NewWithEstimates(uint(len(keys)), 0.001)
+	for _, key := range keys {
+		ind.bloomFilter.Add(key)
+	}
+
+	if err := ind.storeBloomFilterOnDisk(); err != nil {
+		return err
+	}
+
+	took := time.Since(before)
+	ind.logger.WithField("action", "lsm_init_disk_segment_build_bloom_filter_primary").
+		WithField("path", ind.path).
+		WithField("took", took).
+		Debugf("building bloom filter took %s\n", took)
+	return nil
+}
+
+func (ind *segment) storeBloomFilterOnDisk() error {
+	f, err := os.Create(ind.bloomFilterPath())
+	if err != nil {
+		return fmt.Errorf("open file for writing: %w", err)
+	}
+
+	_, err = ind.bloomFilter.WriteTo(f)
+	if err != nil {
+		return fmt.Errorf("write bloom filter to disk: %w", err)
+	}
+
+	if err := f.Close(); err != nil {
+		return fmt.Errorf("close bloom filter file: %w", err)
+	}
+
+	return nil
+}
+
+func (ind *segment) loadBloomFilterFromDisk() error {
+	f, err := os.Open(ind.bloomFilterPath())
+	if err != nil {
+		return fmt.Errorf("open file for reading: %w", err)
+	}
+
+	ind.bloomFilter = new(bloom.BloomFilter)
+	_, err = ind.bloomFilter.ReadFrom(f)
+	if err != nil {
+		return fmt.Errorf("read bloom filter from disk: %w", err)
+	}
+
+	if err := f.Close(); err != nil {
+		return fmt.Errorf("close bloom filter file: %w", err)
+	}
+
+	return nil
+}
+
+func (ind *segment) initSecondaryBloomFilter(pos int) error {
+	before := time.Now()
+	keys, err := ind.secondaryIndices[pos].AllKeys()
+	if err != nil {
+		return err
+	}
+
+	ind.secondaryBloomFilters[pos] = bloom.NewWithEstimates(uint(len(keys)), 0.001)
+	for _, key := range keys {
+		ind.secondaryBloomFilters[pos].Add(key)
+	}
+	took := time.Since(before)
+
+	ind.logger.WithField("action", "lsm_init_disk_segment_build_bloom_filter_secondary").
+		WithField("secondary_index_position", pos).
+		WithField("path", ind.path).
+		WithField("took", took).
+		Debugf("building bloom filter took %s\n", took)
+	return nil
+}

--- a/adapters/repos/db/lsmkv/segment_bloom_filters.go
+++ b/adapters/repos/db/lsmkv/segment_bloom_filters.go
@@ -99,43 +99,15 @@ func (ind *segment) storeBloomFilterSecondaryOnDisk(pos int) error {
 }
 
 func (ind *segment) loadBloomFilterFromDisk() error {
-	f, err := os.Open(ind.bloomFilterPath())
+	data, err := loadWithChecksum(ind.bloomFilterPath(), -1)
 	if err != nil {
-		return fmt.Errorf("open file for reading: %w", err)
-	}
-
-	buf := new(bytes.Buffer)
-	if _, err := buf.ReadFrom(f); err != nil {
-		// ignoring f.Close() error here, as we don't care about whether the file
-		// was flushed, the call is mainly intended to prevent a file descriptor
-		// leak.  We still want to return the original error below.
-		f.Close()
-		return fmt.Errorf("read bloom filter data from file: %w", err)
-	}
-	data := buf.Bytes()
-
-	chcksm := binary.LittleEndian.Uint32(data[:4])
-	actual := crc32.ChecksumIEEE(data[4:])
-	if chcksm != actual {
-		// ignoring f.Close() error here, as we don't care about whether the file
-		// was flushed, the call is mainly intended to prevent a file descriptor
-		// leak.  We still want to return the original error below.
-		f.Close()
-		return ErrInvalidChecksum
+		return err
 	}
 
 	ind.bloomFilter = new(bloom.BloomFilter)
-	_, err = ind.bloomFilter.ReadFrom(bytes.NewReader(data[4:]))
+	_, err = ind.bloomFilter.ReadFrom(bytes.NewReader(data))
 	if err != nil {
-		// ignoring f.Close() error here, as we don't care about whether the file
-		// was flushed, the call is mainly intended to prevent a file descriptor
-		// leak.  We still want to return the original error below.
-		f.Close()
 		return fmt.Errorf("read bloom filter from disk: %w", err)
-	}
-
-	if err := f.Close(); err != nil {
-		return fmt.Errorf("close bloom filter file: %w", err)
 	}
 
 	return nil
@@ -187,42 +159,15 @@ func (ind *segment) initSecondaryBloomFilter(pos int) error {
 }
 
 func (ind *segment) loadBloomFilterSecondaryFromDisk(pos int) error {
-	f, err := os.Open(ind.bloomFilterSecondaryPath(pos))
+	data, err := loadWithChecksum(ind.bloomFilterSecondaryPath(pos), -1)
 	if err != nil {
-		return fmt.Errorf("open file for reading: %w", err)
-	}
-
-	buf := new(bytes.Buffer)
-	if _, err := buf.ReadFrom(f); err != nil {
-		// ignoring f.Close() error here, as we don't care about whether the file
-		// was flushed, the call is mainly intended to prevent a file descriptor
-		// leak.  We still want to return the original error below.
-		f.Close()
-		return fmt.Errorf("read bloom filter data from file: %w", err)
-	}
-	data := buf.Bytes()
-	chcksm := binary.LittleEndian.Uint32(data[:4])
-	actual := crc32.ChecksumIEEE(data[4:])
-	if chcksm != actual {
-		// ignoring f.Close() error here, as we don't care about whether the file
-		// was flushed, the call is mainly intended to prevent a file descriptor
-		// leak.  We still want to return the original error below.
-		f.Close()
-		return ErrInvalidChecksum
+		return err
 	}
 
 	ind.secondaryBloomFilters[pos] = new(bloom.BloomFilter)
-	_, err = ind.secondaryBloomFilters[pos].ReadFrom(bytes.NewReader(data[4:]))
+	_, err = ind.secondaryBloomFilters[pos].ReadFrom(bytes.NewReader(data))
 	if err != nil {
-		// ignoring f.Close() error here, as we don't care about whether the file
-		// was flushed, the call is mainly intended to prevent a file descriptor
-		// leak.  We still want to return the original error below.
-		f.Close()
 		return fmt.Errorf("read bloom filter from disk: %w", err)
-	}
-
-	if err := f.Close(); err != nil {
-		return fmt.Errorf("close bloom filter file: %w", err)
 	}
 
 	return nil
@@ -257,4 +202,37 @@ func writeWithChecksum(data []byte, path string) error {
 	}
 
 	return nil
+}
+
+// use negative length check to indicate that no length check should be
+// performed
+func loadWithChecksum(path string, lengthCheck int) ([]byte, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return nil, fmt.Errorf("open file for reading: %w", err)
+	}
+
+	buf := new(bytes.Buffer)
+	if _, err := buf.ReadFrom(f); err != nil {
+		// ignoring f.Close() error here, as we don't care about whether the file
+		// was flushed, the call is mainly intended to prevent a file descriptor
+		// leak.  We still want to return the original error below.
+		f.Close()
+		return nil, fmt.Errorf("read bloom filter data from file: %w", err)
+	}
+	if err := f.Close(); err != nil {
+		return nil, fmt.Errorf("close bloom filter file: %w", err)
+	}
+
+	data := buf.Bytes()
+	if lengthCheck > 0 && len(data) != lengthCheck {
+		return nil, ErrInvalidChecksum
+	}
+	chcksm := binary.LittleEndian.Uint32(data[:4])
+	actual := crc32.ChecksumIEEE(data[4:])
+	if chcksm != actual {
+		return nil, ErrInvalidChecksum
+	}
+
+	return data[4:], nil
 }

--- a/adapters/repos/db/lsmkv/segment_bloom_filters.go
+++ b/adapters/repos/db/lsmkv/segment_bloom_filters.go
@@ -94,10 +94,18 @@ func (ind *segment) storeBloomFilterOnDisk() error {
 	}
 
 	if err := binary.Write(f, binary.LittleEndian, chksm); err != nil {
+		// ignoring f.Close() error here, as we don't care about whether the file
+		// was flushed, the call is mainly intended to prevent a file descriptor
+		// leak.  We still want to return the original error below.
+		f.Close()
 		return fmt.Errorf("write checkusm to file: %w", err)
 	}
 
 	if _, err := f.Write(data); err != nil {
+		// ignoring f.Close() error here, as we don't care about whether the file
+		// was flushed, the call is mainly intended to prevent a file descriptor
+		// leak.  We still want to return the original error below.
+		f.Close()
 		return fmt.Errorf("write bloom filter to disk: %w", err)
 	}
 
@@ -116,6 +124,10 @@ func (ind *segment) loadBloomFilterFromDisk() error {
 
 	buf := new(bytes.Buffer)
 	if _, err := buf.ReadFrom(f); err != nil {
+		// ignoring f.Close() error here, as we don't care about whether the file
+		// was flushed, the call is mainly intended to prevent a file descriptor
+		// leak.  We still want to return the original error below.
+		f.Close()
 		return fmt.Errorf("read bloom filter data from file: %w", err)
 	}
 	data := buf.Bytes()
@@ -123,12 +135,20 @@ func (ind *segment) loadBloomFilterFromDisk() error {
 	chcksm := binary.LittleEndian.Uint32(data[:4])
 	actual := crc32.ChecksumIEEE(data[4:])
 	if chcksm != actual {
+		// ignoring f.Close() error here, as we don't care about whether the file
+		// was flushed, the call is mainly intended to prevent a file descriptor
+		// leak.  We still want to return the original error below.
+		f.Close()
 		return ErrInvalidChecksum
 	}
 
 	ind.bloomFilter = new(bloom.BloomFilter)
 	_, err = ind.bloomFilter.ReadFrom(bytes.NewReader(data[4:]))
 	if err != nil {
+		// ignoring f.Close() error here, as we don't care about whether the file
+		// was flushed, the call is mainly intended to prevent a file descriptor
+		// leak.  We still want to return the original error below.
+		f.Close()
 		return fmt.Errorf("read bloom filter from disk: %w", err)
 	}
 
@@ -200,10 +220,18 @@ func (ind *segment) storeBloomFilterSecondaryOnDisk(pos int) error {
 	}
 
 	if err := binary.Write(f, binary.LittleEndian, chksm); err != nil {
+		// ignoring f.Close() error here, as we don't care about whether the file
+		// was flushed, the call is mainly intended to prevent a file descriptor
+		// leak.  We still want to return the original error below.
+		f.Close()
 		return fmt.Errorf("write checkusm to file: %w", err)
 	}
 
 	if _, err := f.Write(data); err != nil {
+		// ignoring f.Close() error here, as we don't care about whether the file
+		// was flushed, the call is mainly intended to prevent a file descriptor
+		// leak.  We still want to return the original error below.
+		f.Close()
 		return fmt.Errorf("write bloom filter to disk: %w", err)
 	}
 
@@ -222,18 +250,30 @@ func (ind *segment) loadBloomFilterSecondaryFromDisk(pos int) error {
 
 	buf := new(bytes.Buffer)
 	if _, err := buf.ReadFrom(f); err != nil {
+		// ignoring f.Close() error here, as we don't care about whether the file
+		// was flushed, the call is mainly intended to prevent a file descriptor
+		// leak.  We still want to return the original error below.
+		f.Close()
 		return fmt.Errorf("read bloom filter data from file: %w", err)
 	}
 	data := buf.Bytes()
 	chcksm := binary.LittleEndian.Uint32(data[:4])
 	actual := crc32.ChecksumIEEE(data[4:])
 	if chcksm != actual {
+		// ignoring f.Close() error here, as we don't care about whether the file
+		// was flushed, the call is mainly intended to prevent a file descriptor
+		// leak.  We still want to return the original error below.
+		f.Close()
 		return ErrInvalidChecksum
 	}
 
 	ind.secondaryBloomFilters[pos] = new(bloom.BloomFilter)
 	_, err = ind.secondaryBloomFilters[pos].ReadFrom(bytes.NewReader(data[4:]))
 	if err != nil {
+		// ignoring f.Close() error here, as we don't care about whether the file
+		// was flushed, the call is mainly intended to prevent a file descriptor
+		// leak.  We still want to return the original error below.
+		f.Close()
 		return fmt.Errorf("read bloom filter from disk: %w", err)
 	}
 

--- a/adapters/repos/db/lsmkv/segment_bloom_filters_test.go
+++ b/adapters/repos/db/lsmkv/segment_bloom_filters_test.go
@@ -25,8 +25,7 @@ import (
 
 func TestCreateBloomOnFlush(t *testing.T) {
 	ctx := context.Background()
-	dirName := makeTestDir(t)
-	defer removeTestDir(t, dirName)
+	dirName := t.TempDir()
 
 	logger, _ := test.NewNullLogger()
 
@@ -53,8 +52,7 @@ func TestCreateBloomInit(t *testing.T) {
 	// this test deletes the initial bloom and makes sure it gets recreated after
 	// the bucket is initialized
 	ctx := context.Background()
-	dirName := makeTestDir(t)
-	defer removeTestDir(t, dirName)
+	dirName := t.TempDir()
 
 	logger, _ := test.NewNullLogger()
 
@@ -98,8 +96,7 @@ func TestCreateBloomInit(t *testing.T) {
 
 func TestRepairCorruptedBloomOnInit(t *testing.T) {
 	ctx := context.Background()
-	dirName := makeTestDir(t)
-	defer removeTestDir(t, dirName)
+	dirName := t.TempDir()
 
 	logger, _ := test.NewNullLogger()
 
@@ -129,8 +126,7 @@ func TestRepairCorruptedBloomOnInit(t *testing.T) {
 
 func TestRepairCorruptedBloomSecondaryOnInit(t *testing.T) {
 	ctx := context.Background()
-	dirName := makeTestDir(t)
-	defer removeTestDir(t, dirName)
+	dirName := t.TempDir()
 
 	logger, _ := test.NewNullLogger()
 

--- a/adapters/repos/db/lsmkv/segment_bloom_filters_test.go
+++ b/adapters/repos/db/lsmkv/segment_bloom_filters_test.go
@@ -1,0 +1,152 @@
+package lsmkv
+
+import (
+	"context"
+	"io"
+	"os"
+	"path"
+	"testing"
+
+	"github.com/sirupsen/logrus/hooks/test"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCreateBloomOnFlush(t *testing.T) {
+	ctx := context.Background()
+	dirName := makeTestDir(t)
+	defer removeTestDir(t, dirName)
+
+	logger, _ := test.NewNullLogger()
+
+	b, err := NewBucket(ctx, dirName, "", logger, nil,
+		WithStrategy(StrategyReplace),
+		WithSecondaryIndices(1))
+	require.Nil(t, err)
+
+	require.Nil(t, b.Put([]byte("hello"), []byte("world"),
+		WithSecondaryKey(0, []byte("bonjour"))))
+	require.Nil(t, b.FlushMemtable(ctx))
+
+	files, err := os.ReadDir(dirName)
+	require.Nil(t, err)
+
+	_, ok := findFileWithExt(files, ".bloom")
+	assert.True(t, ok)
+
+	_, ok = findFileWithExt(files, "secondary.0.bloom")
+	assert.True(t, ok)
+}
+
+func TestCreateBloomInit(t *testing.T) {
+	// this test deletes the initial bloom and makes sure it gets recreated after
+	// the bucket is initialized
+	ctx := context.Background()
+	dirName := makeTestDir(t)
+	defer removeTestDir(t, dirName)
+
+	logger, _ := test.NewNullLogger()
+
+	b, err := NewBucket(ctx, dirName, "", logger, nil,
+		WithStrategy(StrategyReplace),
+		WithSecondaryIndices(1))
+	require.Nil(t, err)
+
+	require.Nil(t, b.Put([]byte("hello"), []byte("world"),
+		WithSecondaryKey(0, []byte("bonjour"))))
+	require.Nil(t, b.FlushMemtable(ctx))
+
+	for _, ext := range []string{".secondary.0.bloom", ".bloom"} {
+		files, err := os.ReadDir(dirName)
+		require.Nil(t, err)
+		fname, ok := findFileWithExt(files, ext)
+		require.True(t, ok)
+
+		err = os.RemoveAll(path.Join(dirName, fname))
+		require.Nil(t, err)
+
+		files, err = os.ReadDir(dirName)
+		require.Nil(t, err)
+		_, ok = findFileWithExt(files, ext)
+		require.False(t, ok, "verify the file is really gone")
+	}
+
+	require.Nil(t, b.Shutdown(ctx))
+
+	// now create a new bucket and assert that the file is re-created on init
+	_, err = NewBucket(ctx, dirName, "", logger, nil, WithStrategy(StrategyReplace))
+	require.Nil(t, err)
+
+	files, err := os.ReadDir(dirName)
+	require.Nil(t, err)
+	_, ok := findFileWithExt(files, ".bloom")
+	require.True(t, ok)
+	_, ok = findFileWithExt(files, ".secondary.0.bloom")
+	require.True(t, ok)
+}
+
+func TestRepairCorruptedBloomOnInit(t *testing.T) {
+	// this test deletes the initial bloom and makes sure it gets recreated after
+	// the bucket is initialized
+	ctx := context.Background()
+	dirName := makeTestDir(t)
+	defer removeTestDir(t, dirName)
+
+	logger, _ := test.NewNullLogger()
+
+	b, err := NewBucket(ctx, dirName, "", logger, nil, WithStrategy(StrategyReplace))
+	require.Nil(t, err)
+
+	require.Nil(t, b.Put([]byte("hello"), []byte("world")))
+	require.Nil(t, b.FlushMemtable(ctx))
+
+	files, err := os.ReadDir(dirName)
+	require.Nil(t, err)
+	fname, ok := findFileWithExt(files, ".bloom")
+	require.True(t, ok)
+
+	// now corrupt the file by replacing the count value without adapting the checksum
+	require.Nil(t, corruptBloomFile(path.Join(dirName, fname)))
+
+	// now create a new bucket and assert that the file is ignored, re-created on
+	// init, and the count matches
+	b2, err := NewBucket(ctx, dirName, "", logger, nil, WithStrategy(StrategyReplace))
+	require.Nil(t, err)
+
+	value, err := b2.Get([]byte("hello"))
+	assert.Nil(t, err)
+	assert.Equal(t, []byte("world"), value)
+}
+
+func corruptBloomFile(fname string) error {
+	f, err := os.Open(fname)
+	if err != nil {
+		return err
+	}
+
+	data, err := io.ReadAll(f)
+	if err != nil {
+		return err
+	}
+
+	if err := f.Close(); err != nil {
+		return err
+	}
+
+	// corrupt it by setting all data bytes to 0x01
+	for i := 5; i < len(data); i++ {
+		data[i] = 0x01
+	}
+
+	f, err = os.Create(fname)
+	if err != nil {
+		return err
+	}
+
+	_, err = f.Write(data)
+	if err != nil {
+		return err
+	}
+
+	return f.Close()
+}

--- a/adapters/repos/db/lsmkv/segment_group_compaction.go
+++ b/adapters/repos/db/lsmkv/segment_group_compaction.go
@@ -195,6 +195,9 @@ func (sg *SegmentGroup) replaceCompactedSegments(old1, old2 int,
 	sg.maintenanceLock.Lock()
 	defer sg.maintenanceLock.Unlock()
 
+	updatedCountNetAdditions := sg.segments[old1].countNetAdditions +
+		sg.segments[old2].countNetAdditions
+
 	if err := sg.segments[old1].close(); err != nil {
 		return errors.Wrap(err, "close disk segment")
 	}
@@ -220,6 +223,10 @@ func (sg *SegmentGroup) replaceCompactedSegments(old1, old2 int,
 	newPath, err := sg.stripTmpExtension(newPathTmp)
 	if err != nil {
 		return errors.Wrap(err, "strip .tmp extension of new segment")
+	}
+
+	if err := prefillCountNetAdditions(newPath, updatedCountNetAdditions); err != nil {
+		return fmt.Errorf("prefill count net additions: %w", err)
 	}
 
 	exists := sg.makeExistsOnLower(old1)

--- a/adapters/repos/db/lsmkv/segment_net_count_additions.go
+++ b/adapters/repos/db/lsmkv/segment_net_count_additions.go
@@ -1,3 +1,14 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2022 SeMI Technologies B.V. All rights reserved.
+//
+//  CONTACT: hello@semi.technology
+//
+
 package lsmkv
 
 import (

--- a/adapters/repos/db/lsmkv/segment_net_count_additions.go
+++ b/adapters/repos/db/lsmkv/segment_net_count_additions.go
@@ -126,35 +126,7 @@ func storeCountNetOnDisk(path string, value int) error {
 		return fmt.Errorf("write cna to buf: %w", err)
 	}
 
-	data := buf.Bytes()
-	chksm := crc32.ChecksumIEEE(data)
-
-	f, err := os.Create(path)
-	if err != nil {
-		return fmt.Errorf("open file for writing: %w", err)
-	}
-
-	if err := binary.Write(f, binary.LittleEndian, chksm); err != nil {
-		// ignoring f.Close() error here, as we don't care about whether the file
-		// was flushed, the call is mainly intended to prevent a file descriptor
-		// leak.  We still want to return the original error below.
-		f.Close()
-		return fmt.Errorf("write checkusm to file: %w", err)
-	}
-
-	if _, err := f.Write(data); err != nil {
-		// ignoring f.Close() error here, as we don't care about whether the file
-		// was flushed, the call is mainly intended to prevent a file descriptor
-		// leak.  We still want to return the original error below.
-		f.Close()
-		return fmt.Errorf("write cna data to file: %w", err)
-	}
-
-	if err := f.Close(); err != nil {
-		return fmt.Errorf("close cna file: %w", err)
-	}
-
-	return nil
+	return writeWithChecksum(buf.Bytes(), path)
 }
 
 func (ind *segment) loadCountNetFromDisk() error {

--- a/adapters/repos/db/lsmkv/segment_net_count_additions.go
+++ b/adapters/repos/db/lsmkv/segment_net_count_additions.go
@@ -1,0 +1,111 @@
+package lsmkv
+
+import (
+	"encoding/binary"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// existOnLowerSegments is a simple function that can be passed at segment
+// initialization time to check if any of the keys are truly new or previously
+// seen. This can in turn be used to build up the net count additions. The
+// reason this is abstrate:
+type existsOnLowerSegmentsFn func(key []byte) (bool, error)
+
+func (ind *segment) countNetPath() string {
+	extless := strings.TrimSuffix(ind.path, filepath.Ext(ind.path))
+	return fmt.Sprintf("%s.cna", extless)
+}
+
+func (ind *segment) initCountNetAdditions(exists existsOnLowerSegmentsFn) error {
+	if ind.strategy != SegmentStrategyReplace {
+		// replace is the only strategy that supports counting
+		return nil
+	}
+
+	ok, err := fileExists(ind.countNetPath())
+	if err != nil {
+		return err
+	}
+
+	if ok {
+		return ind.loadCountNetFromDisk()
+	}
+
+	// before := time.Now()
+	// defer func() {
+	// 	fmt.Printf("init count net additions took %s\n", time.Since(before))
+	// }()
+
+	var lastErr error
+	countNet := 0
+	cb := func(key []byte, tombstone bool) {
+		existedOnPrior, err := exists(key)
+		if err != nil {
+			lastErr = err
+		}
+
+		if tombstone && existedOnPrior {
+			countNet--
+		}
+
+		if !tombstone && !existedOnPrior {
+			countNet++
+		}
+	}
+
+	extr := newBufferedKeyAndTombstoneExtractor(ind.contents, ind.dataStartPos,
+		ind.dataEndPos, 10e6, ind.secondaryIndexCount, cb)
+
+	extr.do()
+
+	ind.countNetAdditions = countNet
+
+	if lastErr != nil {
+		return lastErr
+	}
+
+	if err := ind.storeCountNetOnDisk(); err != nil {
+		return fmt.Errorf("store count net additions on disk: %w", err)
+	}
+
+	return nil
+}
+
+func (ind *segment) storeCountNetOnDisk() error {
+	f, err := os.Create(ind.countNetPath())
+	if err != nil {
+		return fmt.Errorf("open file for writing: %w", err)
+	}
+
+	if err := binary.Write(f, binary.LittleEndian, int64(ind.countNetAdditions)); err != nil {
+		return fmt.Errorf("write cna to file: %w", err)
+	}
+
+	if err := f.Close(); err != nil {
+		return fmt.Errorf("close cna file: %w", err)
+	}
+
+	return nil
+}
+
+func (ind *segment) loadCountNetFromDisk() error {
+	f, err := os.Open(ind.countNetPath())
+	if err != nil {
+		return fmt.Errorf("open file for reading: %w", err)
+	}
+
+	var cna int64
+	if err := binary.Read(f, binary.LittleEndian, &cna); err != nil {
+		return fmt.Errorf("read cna from file: %w", err)
+	}
+	ind.countNetAdditions = int(cna)
+
+	if err := f.Close(); err != nil {
+		return fmt.Errorf("close cna file: %w", err)
+	}
+
+	return nil
+}

--- a/adapters/repos/db/lsmkv/segment_net_count_additions.go
+++ b/adapters/repos/db/lsmkv/segment_net_count_additions.go
@@ -135,10 +135,18 @@ func storeCountNetOnDisk(path string, value int) error {
 	}
 
 	if err := binary.Write(f, binary.LittleEndian, chksm); err != nil {
+		// ignoring f.Close() error here, as we don't care about whether the file
+		// was flushed, the call is mainly intended to prevent a file descriptor
+		// leak.  We still want to return the original error below.
+		f.Close()
 		return fmt.Errorf("write checkusm to file: %w", err)
 	}
 
 	if _, err := f.Write(data); err != nil {
+		// ignoring f.Close() error here, as we don't care about whether the file
+		// was flushed, the call is mainly intended to prevent a file descriptor
+		// leak.  We still want to return the original error below.
+		f.Close()
 		return fmt.Errorf("write cna data to file: %w", err)
 	}
 
@@ -157,16 +165,28 @@ func (ind *segment) loadCountNetFromDisk() error {
 
 	buf := new(bytes.Buffer)
 	if _, err := buf.ReadFrom(f); err != nil {
+		// ignoring f.Close() error here, as we don't care about whether the file
+		// was flushed, the call is mainly intended to prevent a file descriptor
+		// leak.  We still want to return the original error below.
+		f.Close()
 		return fmt.Errorf("read cna data from file: %w", err)
 	}
 	data := buf.Bytes()
 	if len(data) != 12 {
+		// ignoring f.Close() error here, as we don't care about whether the file
+		// was flushed, the call is mainly intended to prevent a file descriptor
+		// leak.  We still want to return the original error below.
+		f.Close()
 		return ErrInvalidChecksum
 	}
 
 	chcksm := binary.LittleEndian.Uint32(data[:4])
 	actual := crc32.ChecksumIEEE(data[4:])
 	if chcksm != actual {
+		// ignoring f.Close() error here, as we don't care about whether the file
+		// was flushed, the call is mainly intended to prevent a file descriptor
+		// leak.  We still want to return the original error below.
+		f.Close()
 		return ErrInvalidChecksum
 	}
 

--- a/adapters/repos/db/lsmkv/segment_net_count_additions.go
+++ b/adapters/repos/db/lsmkv/segment_net_count_additions.go
@@ -64,12 +64,6 @@ func (ind *segment) initCountNetAdditions(exists existsOnLowerSegmentsFn) error 
 			return err
 		}
 
-		// ErrInvalidChecksum is recoverable, we just need to delete the file
-		err = ind.deleteCountNetFromDisk()
-		if err != nil {
-			return nil
-		}
-
 		// now continue re-calculating
 	}
 
@@ -172,7 +166,6 @@ func (ind *segment) loadCountNetFromDisk() error {
 
 	chcksm := binary.LittleEndian.Uint32(data[:4])
 	actual := crc32.ChecksumIEEE(data[4:])
-
 	if chcksm != actual {
 		return ErrInvalidChecksum
 	}
@@ -181,15 +174,6 @@ func (ind *segment) loadCountNetFromDisk() error {
 
 	if err := f.Close(); err != nil {
 		return fmt.Errorf("close cna file: %w", err)
-	}
-
-	return nil
-}
-
-func (ind *segment) deleteCountNetFromDisk() error {
-	err := os.Remove(ind.countNetPath())
-	if err != nil {
-		return fmt.Errorf("delete count net file: %w", err)
 	}
 
 	return nil

--- a/adapters/repos/db/lsmkv/segment_net_count_additions_test.go
+++ b/adapters/repos/db/lsmkv/segment_net_count_additions_test.go
@@ -1,0 +1,147 @@
+package lsmkv
+
+import (
+	"context"
+	"encoding/binary"
+	"io"
+	"os"
+	"path"
+	"strings"
+	"testing"
+
+	"github.com/sirupsen/logrus/hooks/test"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCreateCNAOnFlush(t *testing.T) {
+	ctx := context.Background()
+	dirName := makeTestDir(t)
+	defer removeTestDir(t, dirName)
+
+	logger, _ := test.NewNullLogger()
+
+	b, err := NewBucket(ctx, dirName, "", logger, nil, WithStrategy(StrategyReplace))
+	require.Nil(t, err)
+
+	require.Nil(t, b.Put([]byte("hello"), []byte("world")))
+	require.Nil(t, b.FlushMemtable(ctx))
+
+	files, err := os.ReadDir(dirName)
+	require.Nil(t, err)
+
+	_, ok := findFileWithExt(files, ".cna")
+	assert.True(t, ok)
+}
+
+func TestCreateCNAInit(t *testing.T) {
+	// this test deletes the initial cna and makes sure it gets recreated after
+	// the bucket is initialized
+	ctx := context.Background()
+	dirName := makeTestDir(t)
+	defer removeTestDir(t, dirName)
+
+	logger, _ := test.NewNullLogger()
+
+	b, err := NewBucket(ctx, dirName, "", logger, nil, WithStrategy(StrategyReplace))
+	require.Nil(t, err)
+
+	require.Nil(t, b.Put([]byte("hello"), []byte("world")))
+	require.Nil(t, b.FlushMemtable(ctx))
+
+	files, err := os.ReadDir(dirName)
+	require.Nil(t, err)
+	fname, ok := findFileWithExt(files, ".cna")
+	require.True(t, ok)
+
+	err = os.RemoveAll(path.Join(dirName, fname))
+	require.Nil(t, err)
+
+	files, err = os.ReadDir(dirName)
+	require.Nil(t, err)
+	_, ok = findFileWithExt(files, ".cna")
+	require.False(t, ok, "verify the file is really gone")
+
+	require.Nil(t, b.Shutdown(ctx))
+
+	// now create a new bucket and assert that the file is re-created on init
+	_, err = NewBucket(ctx, dirName, "", logger, nil, WithStrategy(StrategyReplace))
+	require.Nil(t, err)
+
+	files, err = os.ReadDir(dirName)
+	require.Nil(t, err)
+	fname, ok = findFileWithExt(files, ".cna")
+	require.True(t, ok)
+}
+
+func TestRepairCorruptedCNAOnInit(t *testing.T) {
+	// this test deletes the initial cna and makes sure it gets recreated after
+	// the bucket is initialized
+	ctx := context.Background()
+	dirName := makeTestDir(t)
+	defer removeTestDir(t, dirName)
+
+	logger, _ := test.NewNullLogger()
+
+	b, err := NewBucket(ctx, dirName, "", logger, nil, WithStrategy(StrategyReplace))
+	require.Nil(t, err)
+
+	require.Nil(t, b.Put([]byte("hello"), []byte("world")))
+	require.Nil(t, b.FlushMemtable(ctx))
+
+	files, err := os.ReadDir(dirName)
+	require.Nil(t, err)
+	fname, ok := findFileWithExt(files, ".cna")
+	require.True(t, ok)
+
+	// now corrupt the file by replacing the count value without adapting the checksum
+	require.Nil(t, corruptCNAFile(path.Join(dirName, fname), 12345))
+
+	// now create a new bucket and assert that the file is ignored, re-created on
+	// init, and the count matches
+	b2, err := NewBucket(ctx, dirName, "", logger, nil, WithStrategy(StrategyReplace))
+	require.Nil(t, err)
+
+	assert.Equal(t, 1, b2.Count())
+}
+
+func findFileWithExt(files []os.DirEntry, ext string) (string, bool) {
+	for _, file := range files {
+		fname := file.Name()
+		if strings.HasSuffix(fname, ext) {
+			return fname, true
+		}
+
+	}
+	return "", false
+}
+
+func corruptCNAFile(fname string, corruptValue uint64) error {
+	f, err := os.Open(fname)
+	if err != nil {
+		return err
+	}
+
+	data, err := io.ReadAll(f)
+	if err != nil {
+		return err
+	}
+
+	if err := f.Close(); err != nil {
+		return err
+	}
+
+	binary.LittleEndian.PutUint64(data[4:12], corruptValue)
+
+	f, err = os.Create(fname)
+	if err != nil {
+		return err
+	}
+
+	_, err = f.Write(data)
+	if err != nil {
+		return err
+	}
+
+	return f.Close()
+}

--- a/adapters/repos/db/lsmkv/segment_net_count_additions_test.go
+++ b/adapters/repos/db/lsmkv/segment_net_count_additions_test.go
@@ -1,3 +1,14 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2022 SeMI Technologies B.V. All rights reserved.
+//
+//  CONTACT: hello@semi.technology
+//
+
 package lsmkv
 
 import (

--- a/adapters/repos/db/lsmkv/segment_net_count_additions_test.go
+++ b/adapters/repos/db/lsmkv/segment_net_count_additions_test.go
@@ -122,6 +122,7 @@ func TestPrefillCountNetAdditions(t *testing.T) {
 	require.Nil(t, err)
 
 	data, err := loadWithChecksum(expectedFileName, 12)
+	require.Nil(t, err)
 	count := binary.LittleEndian.Uint64(data)
 	assert.Equal(t, 20, int(count))
 }

--- a/adapters/repos/db/lsmkv/segment_net_count_additions_test.go
+++ b/adapters/repos/db/lsmkv/segment_net_count_additions_test.go
@@ -27,8 +27,7 @@ import (
 
 func TestCreateCNAOnFlush(t *testing.T) {
 	ctx := context.Background()
-	dirName := makeTestDir(t)
-	defer removeTestDir(t, dirName)
+	dirName := t.TempDir()
 
 	logger, _ := test.NewNullLogger()
 
@@ -49,8 +48,7 @@ func TestCreateCNAInit(t *testing.T) {
 	// this test deletes the initial cna and makes sure it gets recreated after
 	// the bucket is initialized
 	ctx := context.Background()
-	dirName := makeTestDir(t)
-	defer removeTestDir(t, dirName)
+	dirName := t.TempDir()
 
 	logger, _ := test.NewNullLogger()
 
@@ -89,8 +87,7 @@ func TestRepairCorruptedCNAOnInit(t *testing.T) {
 	// this test deletes the initial cna and makes sure it gets recreated after
 	// the bucket is initialized
 	ctx := context.Background()
-	dirName := makeTestDir(t)
-	defer removeTestDir(t, dirName)
+	dirName := t.TempDir()
 
 	logger, _ := test.NewNullLogger()
 

--- a/adapters/repos/db/lsmkv/segment_net_count_additions_test.go
+++ b/adapters/repos/db/lsmkv/segment_net_count_additions_test.go
@@ -113,6 +113,19 @@ func TestRepairCorruptedCNAOnInit(t *testing.T) {
 	assert.Equal(t, 1, b2.Count())
 }
 
+func TestPrefillCountNetAdditions(t *testing.T) {
+	dirName := t.TempDir()
+	segmentName := path.Join(dirName, "foo.db")
+	expectedFileName := path.Join(dirName, "foo.cna")
+
+	err := prefillCountNetAdditions(segmentName, 20)
+	require.Nil(t, err)
+
+	data, err := loadWithChecksum(expectedFileName, 12)
+	count := binary.LittleEndian.Uint64(data)
+	assert.Equal(t, 20, int(count))
+}
+
 func findFileWithExt(files []os.DirEntry, ext string) (string, bool) {
 	for _, file := range files {
 		fname := file.Name()

--- a/adapters/repos/db/lsmkv/segment_net_count_additions_test.go
+++ b/adapters/repos/db/lsmkv/segment_net_count_additions_test.go
@@ -81,7 +81,7 @@ func TestCreateCNAInit(t *testing.T) {
 
 	files, err = os.ReadDir(dirName)
 	require.Nil(t, err)
-	fname, ok = findFileWithExt(files, ".cna")
+	_, ok = findFileWithExt(files, ".cna")
 	require.True(t, ok)
 }
 

--- a/go.sum
+++ b/go.sum
@@ -211,6 +211,7 @@ github.com/containerd/continuity v0.0.0-20191127005431-f65d91d395eb/go.mod h1:GL
 github.com/containerd/continuity v0.0.0-20200710164510-efbc4488d8fe/go.mod h1:cECdGN1O8G9bgKTlLhuPJimka6Xb/Gg7vYzCTNVxhvo=
 github.com/containerd/continuity v0.0.0-20201208142359-180525291bb7/go.mod h1:kR3BEg7bDFaEddKm54WSmrol1fKWDU1nKYkgrcgZT7Y=
 github.com/containerd/continuity v0.0.0-20210208174643-50096c924a4e/go.mod h1:EXlVlkqNba9rJe3j7w3Xa924itAMLgZH4UD/Q4PExuQ=
+github.com/containerd/continuity v0.1.0 h1:UFRRY5JemiAhPZrr/uE0n8fMTLcZsUvySPr1+D7pgr8=
 github.com/containerd/continuity v0.1.0/go.mod h1:ICJu0PwR54nI0yPEnJ6jcS+J7CZAUXrLh8lPo2knzsM=
 github.com/containerd/fifo v0.0.0-20180307165137-3d5202aec260/go.mod h1:ODA38xgv3Kuk8dQz2ZQXpnv/UZZUHUCL7pnLehbXgQI=
 github.com/containerd/fifo v0.0.0-20190226154929-a9fb20d87448/go.mod h1:ODA38xgv3Kuk8dQz2ZQXpnv/UZZUHUCL7pnLehbXgQI=
@@ -276,6 +277,7 @@ github.com/cpuguy83/go-md2man/v2 v2.0.0-20190314233015-f79a8a8ca69d/go.mod h1:ma
 github.com/cpuguy83/go-md2man/v2 v2.0.0/go.mod h1:maD7wRr/U5Z6m/iR4s+kqSMx2CaBsrgA7czyZG/E6dU=
 github.com/creack/pty v1.1.7/go.mod h1:lj5s0c3V2DBrqTV7llrYr5NG6My20zk30Fl46Y7DoTY=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
+github.com/creack/pty v1.1.11 h1:07n33Z8lZxZ2qwegKbObQohDhXDQxiMMz1NOUGYlesw=
 github.com/creack/pty v1.1.11/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/cyphar/filepath-securejoin v0.2.2/go.mod h1:FpkQEhXnPnOthhzymB7CGsFk2G9VLXONKD9G7QGMM+4=
 github.com/d2g/dhcp4 v0.0.0-20170904100407-a1d1b6c41b1c/go.mod h1:Ct2BUK8SB0YC1SMSibvLzxjeJLnrYEVLULFNiHY9YfQ=
@@ -393,7 +395,9 @@ github.com/go-openapi/swag v0.22.3 h1:yMBqmnQ0gyZvEb/+KzuWZOXgllrXT4SADYbvDaXHv/
 github.com/go-openapi/swag v0.22.3/go.mod h1:UzaqsxGiab7freDnrUUra0MwWfN/q7tE4j+VcZ0yl14=
 github.com/go-openapi/validate v0.21.0 h1:+Wqk39yKOhfpLqNLEC0/eViCkzM5FVXVqrvt526+wcI=
 github.com/go-openapi/validate v0.21.0/go.mod h1:rjnrwK57VJ7A8xqfpAOEKRH8yQSGUriMu5/zuPSQ1hg=
+github.com/go-redis/redis v6.15.9+incompatible h1:K0pv1D7EQUjfyoMql+r/jZqCLizCGKFlFgcHWWmHQjg=
 github.com/go-redis/redis v6.15.9+incompatible/go.mod h1:NAIEuMOZ/fxfXJIrKDQDz8wamY7mA7PouImQ2Jvg6kA=
+github.com/go-sql-driver/mysql v1.6.0 h1:BCTh4TKNUYmOmMUcQ3IipzF5prigylS7XXjEkfCHuOE=
 github.com/go-sql-driver/mysql v1.6.0/go.mod h1:DCzpHaOWr8IXmIStZouvnhqoel9Qv2LBy8hT2VhHyBg=
 github.com/go-stack/stack v1.8.0/go.mod h1:v0f6uXyyMGvRgIKkXu+yp6POWl0qKG85gN/melR3HDY=
 github.com/go-stack/stack v1.8.1/go.mod h1:dcoOX6HbPZSZptuspn9bctJ+N/CnF5gGygcUP3XYfe4=
@@ -494,9 +498,11 @@ github.com/google/go-cmp v0.5.8 h1:e6P7q2lk1O+qJJb4BtCQXlK8vWEO8V1ZeuEdJNOqZyg=
 github.com/google/go-cmp v0.5.8/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
 github.com/google/gofuzz v1.0.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
 github.com/google/gofuzz v1.1.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
+github.com/google/martian v2.1.0+incompatible h1:/CP5g8u/VJHijgedC/Legn3BAbAaWPgecwXBIDzw5no=
 github.com/google/martian v2.1.0+incompatible/go.mod h1:9I4somxYTbIHy5NJKHRl3wXiIaQGbYVAs8BPL6v8lEs=
 github.com/google/martian/v3 v3.0.0/go.mod h1:y5Zk1BBys9G+gd6Jrk0W3cC1+ELVxBWuIGO+w/tUAp0=
 github.com/google/martian/v3 v3.1.0/go.mod h1:y5Zk1BBys9G+gd6Jrk0W3cC1+ELVxBWuIGO+w/tUAp0=
+github.com/google/martian/v3 v3.2.1 h1:d8MncMlErDFTwQGBK1xhv026j9kqhvw1Qv9IbWT1VLQ=
 github.com/google/martian/v3 v3.2.1/go.mod h1:oBOf6HBosgwRXnUGWUB05QECsc6uvmMiJ3+6W4l/CUk=
 github.com/google/pprof v0.0.0-20181206194817-3ea8567a2e57/go.mod h1:zfwlbNMJ+OItoe0UupaVj+oy1omPYYDuagoSzA8v9mc=
 github.com/google/pprof v0.0.0-20190515194954-54271f7e092f/go.mod h1:zfwlbNMJ+OItoe0UupaVj+oy1omPYYDuagoSzA8v9mc=
@@ -533,8 +539,10 @@ github.com/googleapis/gax-go/v2 v2.4.0 h1:dS9eYAjhrE2RjmzYw2XAPvcXfmcQLtFEQWn0CR
 github.com/googleapis/gax-go/v2 v2.4.0/go.mod h1:XOTVJ59hdnfJLIP/dh8n5CGryZR2LxK9wbMD5+iXC6c=
 github.com/googleapis/gnostic v0.4.1/go.mod h1:LRhVm6pbyptWbWbuZ38d1eyptfvIytN3ir6b65WBswg=
 github.com/googleapis/go-type-adapters v1.0.0/go.mod h1:zHW75FOG2aur7gAO2B+MLby+cLsWGBF62rFAi7WjWO4=
+github.com/gopherjs/gopherjs v0.0.0-20181017120253-0766667cb4d1 h1:EGx4pi6eqNxGaHF6qqu48+N2wcFQ5qg5FXgOdqsJ5d8=
 github.com/gopherjs/gopherjs v0.0.0-20181017120253-0766667cb4d1/go.mod h1:wJfORRmW1u3UXTncJ5qlYoELFm8eSnnEO6hX4iZ3EWY=
 github.com/gorilla/handlers v0.0.0-20150720190736-60c7bfde3e33/go.mod h1:Qkdc/uu4tH4g6mTK6auzZ766c4CA0Ng8+o/OAirnOIQ=
+github.com/gorilla/mux v1.7.2 h1:zoNxOV7WjqXptQOVngLmcSQgXmgk4NMz1HibBchjl/I=
 github.com/gorilla/mux v1.7.2/go.mod h1:1lud6UwP+6orDFRuTfBEV8e9/aOM/c4fVVCaMa2zaAs=
 github.com/gorilla/websocket v0.0.0-20170926233335-4201258b820c/go.mod h1:E7qHFY5m1UJ88s3WnNqhKjPHQ0heANvMoAMk2YaljkQ=
 github.com/gorilla/websocket v1.4.0/go.mod h1:E7qHFY5m1UJ88s3WnNqhKjPHQ0heANvMoAMk2YaljkQ=
@@ -558,6 +566,7 @@ github.com/hashicorp/go-multierror v1.0.0 h1:iVjPR7a6H0tWELX5NxNe7bYopibicUzc7uP
 github.com/hashicorp/go-multierror v1.0.0/go.mod h1:dHtQlpGsu+cZNNAkkCN/P3hoUDHhCYQXV3UM06sGGrk=
 github.com/hashicorp/go-sockaddr v1.0.0 h1:GeH6tui99pF4NJgfnhp+L6+FfobzVW3Ah46sLo0ICXs=
 github.com/hashicorp/go-sockaddr v1.0.0/go.mod h1:7Xibr9yA9JjQq1JpNB2Vw7kxv8xerXegt+ozgdvDeDU=
+github.com/hashicorp/go-uuid v1.0.0 h1:RS8zrF7PhGwyNPOtxSClXXj9HA8feRnJzgnI1RJCSnM=
 github.com/hashicorp/go-uuid v1.0.0/go.mod h1:6SBZvOh/SIDV7/2o3Jml5SYk/TvGqwFJ/bN7x4byOro=
 github.com/hashicorp/golang-lru v0.5.0/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
 github.com/hashicorp/golang-lru v0.5.1 h1:0hERBMJE1eitiLkihrMvRVBYAkpHzc/J3QdDN+dAcgU=
@@ -593,6 +602,7 @@ github.com/json-iterator/go v1.1.12 h1:PV8peI4a0ysnczrg+LtxykD8LfKY9ML6u2jnxaEnr
 github.com/json-iterator/go v1.1.12/go.mod h1:e30LSqwooZae/UwlEbR2852Gd8hjQvJoHmT4TnhNGBo=
 github.com/jstemmer/go-junit-report v0.0.0-20190106144839-af01ea7f8024/go.mod h1:6v2b51hI/fHJwM22ozAgKL4VKDeJcHhJFhtBdhmNjmU=
 github.com/jstemmer/go-junit-report v0.9.1/go.mod h1:Brl9GWCQeLvo8nXZwPNNblvFj/XSXhF0NWZEnDohbsk=
+github.com/jtolds/gls v4.20.0+incompatible h1:xdiiI2gbIgH/gLH7ADydsJ1uDOEzR8yvV7C0MuV77Wo=
 github.com/jtolds/gls v4.20.0+incompatible/go.mod h1:QJZ7F/aHp+rZTRtaJ1ow/lLfFfVYBRgL+9YlvaHOwJU=
 github.com/julienschmidt/httprouter v1.2.0/go.mod h1:SYymIcj16QtmaHHD7aYtjjsJG7VTCxuUUipMqKk8s4w=
 github.com/julienschmidt/httprouter v1.3.0/go.mod h1:JR6WtHb+2LUe8TCKY3cZOxFyyO8IZAc4RVcycCCAKdM=
@@ -617,10 +627,12 @@ github.com/konsorten/go-windows-terminal-sequences v1.0.3/go.mod h1:T0+1ngSBFLxv
 github.com/kr/logfmt v0.0.0-20140226030751-b84e30acd515/go.mod h1:+0opPa2QZZtGFBFZlji/RkVcI2GknAs/DXo4wKdlNEc=
 github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=
 github.com/kr/pretty v0.2.0/go.mod h1:ipq/a2n7PKx3OHsz4KJII5eveXtPO4qwEXGdVfWzfnI=
+github.com/kr/pretty v0.2.1 h1:Fmg33tUaq4/8ym9TJN1x7sLJnHVwhP33CNkpYV/7rwI=
 github.com/kr/pretty v0.2.1/go.mod h1:ipq/a2n7PKx3OHsz4KJII5eveXtPO4qwEXGdVfWzfnI=
 github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
 github.com/kr/pty v1.1.5/go.mod h1:9r2w37qlBe7rQ6e1fg1S/9xpWHSnaqNdHD3WcMdbPDA=
 github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
+github.com/kr/text v0.2.0 h1:5Nx0Ya0ZqY2ygV366QzturHI13Jq95ApcVaJBhpS+AY=
 github.com/kr/text v0.2.0/go.mod h1:eLer722TekiGuMkidMxC/pM04lWEeraHUUmBw8l2grE=
 github.com/magiconair/properties v1.8.0/go.mod h1:PppfXfuXeibc/6YijjN8zIbojt8czPbwD3XqdrwzmxQ=
 github.com/magiconair/properties v1.8.5 h1:b6kJs+EmPFMYGkow9GiUyCyOvIwYetYJ3fSaWak/Gls=
@@ -741,6 +753,7 @@ github.com/opencontainers/selinux v1.8.0/go.mod h1:RScLhm78qiWa2gbVCcGkC7tCGdgk3
 github.com/opencontainers/selinux v1.8.2/go.mod h1:MUIHuUEvKB1wtJjQdOyYRgOnLD2xAPP8dBsCoU0KuF8=
 github.com/opentracing/opentracing-go v1.2.0 h1:uEJPy/1a5RIPAJ0Ov+OIO8OxWu77jEv+1B0VhjKrZUs=
 github.com/opentracing/opentracing-go v1.2.0/go.mod h1:GxEUsuufX4nBwe+T+Wl9TAgYrxe9dPLANfrWvHYVTgc=
+github.com/pascaldekloe/goe v0.0.0-20180627143212-57f6aae5913c h1:Lgl0gzECD8GnQ5QCWA8o6BtfL6mDH5rQgM4/fX3avOs=
 github.com/pascaldekloe/goe v0.0.0-20180627143212-57f6aae5913c/go.mod h1:lzWF7FIEvWOWxwDKqyGYQf6ZUaNfKdP144TG7ZOy1lc=
 github.com/pelletier/go-toml v1.2.0/go.mod h1:5z9KED0ma1S8pY6P1sdut58dfprrGBbd/94hg7ilaic=
 github.com/pelletier/go-toml v1.7.0/go.mod h1:vwGMzjaWMwyfHwgIBhI2YUM4fB6nL6lVAvS1LBMMhTE=
@@ -820,8 +833,10 @@ github.com/sirupsen/logrus v1.6.0/go.mod h1:7uNnSEd1DgxDLC74fIahvMZmmYsHGZGEOFrf
 github.com/sirupsen/logrus v1.7.0/go.mod h1:yWOB1SBYBC5VeMP7gHvWumXLIWorT60ONWic61uBYv0=
 github.com/sirupsen/logrus v1.8.1 h1:dJKuHgqk1NNQlqoA6BTlM1Wf9DOH3NBjQyu0h9+AZZE=
 github.com/sirupsen/logrus v1.8.1/go.mod h1:yWOB1SBYBC5VeMP7gHvWumXLIWorT60ONWic61uBYv0=
+github.com/smartystreets/assertions v0.0.0-20180927180507-b2de0cb4f26d h1:zE9ykElWQ6/NYmHa3jpm/yHnI4xSofP+UP6SpjHcSeM=
 github.com/smartystreets/assertions v0.0.0-20180927180507-b2de0cb4f26d/go.mod h1:OnSkiWE9lh6wB0YB77sQom3nweQdgAjqCqsofrRNTgc=
 github.com/smartystreets/goconvey v0.0.0-20190330032615-68dc04aab96a/go.mod h1:syvi0/a8iFYH4r/RixwvyeAJjdLS9QV7WQ/tjFTllLA=
+github.com/smartystreets/goconvey v1.6.4 h1:fv0U8FUIMPNf1L9lnHLvLhgicrIVChEkdzIKYqbNC9s=
 github.com/soheilhy/cmux v0.1.4/go.mod h1:IM3LyeVVIOuxMH7sFAkER9+bJ4dT7Ms6E4xg4kGIyLM=
 github.com/spaolacci/murmur3 v0.0.0-20180118202830-f09979ecbc72/go.mod h1:JwIasOWyU6f++ZhiEuf87xNszmSA2myDM2Kzu9HwQUA=
 github.com/spaolacci/murmur3 v1.1.0 h1:7c1g84S4BPRrfL5Xrdp6fOJ206sU9y293DDHaoy0bLI=
@@ -867,6 +882,7 @@ github.com/tailor-inc/graphql v0.1.0/go.mod h1:Rl0/u8OoidpQkaoKFph1ElyMc3EI6GYdC
 github.com/tchap/go-patricia v2.2.6+incompatible/go.mod h1:bmLyhP68RS6kStMGxByiQ23RP/odRBOTVjwp2cDyi6I=
 github.com/testcontainers/testcontainers-go v0.13.0 h1:OUujSlEGsXVo/ykPVZk3KanBNGN0TYb/7oKIPVn15JA=
 github.com/testcontainers/testcontainers-go v0.13.0/go.mod h1:z1abufU633Eb/FmSBTzV6ntZAC1eZBYPtaFsn4nPuDk=
+github.com/tidwall/pretty v1.0.0 h1:HsD+QiTn7sK6flMKIvNmpqz1qrpP3Ps6jOKIKMooyg4=
 github.com/tidwall/pretty v1.0.0/go.mod h1:XNkn88O1ChpSDQmQeStsy+sBenx6DDtFZJxhVysOjyk=
 github.com/tmc/grpc-websocket-proxy v0.0.0-20170815181823-89b8d40f7ca8/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=
 github.com/tmc/grpc-websocket-proxy v0.0.0-20190109142713-0ad062ec5ee5/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=
@@ -962,6 +978,7 @@ golang.org/x/exp v0.0.0-20191129062945-2f5052295587/go.mod h1:2RIsYlXP63K8oxa1u0
 golang.org/x/exp v0.0.0-20191227195350-da58074b4299/go.mod h1:2RIsYlXP63K8oxa1u096TMicItID8zy7Y6sNkU49FU4=
 golang.org/x/exp v0.0.0-20200119233911-0405dc783f0a/go.mod h1:2RIsYlXP63K8oxa1u096TMicItID8zy7Y6sNkU49FU4=
 golang.org/x/exp v0.0.0-20200207192155-f17229e696bd/go.mod h1:J/WKrq2StrnmMY6+EHIKF9dgMWnmCNThgcyBT1FY9mM=
+golang.org/x/exp v0.0.0-20200224162631-6cc2880d07d6 h1:QE6XYQK6naiK1EPAe1g/ILLxN5RBoH5xkJk3CqlMI/Y=
 golang.org/x/exp v0.0.0-20200224162631-6cc2880d07d6/go.mod h1:3jZMyOhIsHpP37uCMkUooju7aAi5cS1Q23tOzKc+0MU=
 golang.org/x/image v0.0.0-20180708004352-c73c2afc3b81/go.mod h1:ux5Hcp/YLpHSI86hEcLt0YII63i6oz57MZXIpbrjZUs=
 golang.org/x/image v0.0.0-20190227222117-0694c2d4d067/go.mod h1:kZ7UVZpmo3dzQBMxlp+ypCbDeSB+sBbTgSJuh5dn5js=
@@ -1225,6 +1242,7 @@ golang.org/x/time v0.0.0-20180412165947-fbb02b2291d2/go.mod h1:tRJNPiyCQ0inRvYxb
 golang.org/x/time v0.0.0-20181108054448-85acf8d2951c/go.mod h1:tRJNPiyCQ0inRvYxbN9jk5I+vvW/OXSQhTDSoE431IQ=
 golang.org/x/time v0.0.0-20190308202827-9d24e82272b4/go.mod h1:tRJNPiyCQ0inRvYxbN9jk5I+vvW/OXSQhTDSoE431IQ=
 golang.org/x/time v0.0.0-20191024005414-555d28b269f0/go.mod h1:tRJNPiyCQ0inRvYxbN9jk5I+vvW/OXSQhTDSoE431IQ=
+golang.org/x/time v0.0.0-20200630173020-3af7569d3a1e h1:EHBhcS0mlXEAVwNyO2dLfjToGsyY4j24pTs2ScHnX7s=
 golang.org/x/time v0.0.0-20200630173020-3af7569d3a1e/go.mod h1:tRJNPiyCQ0inRvYxbN9jk5I+vvW/OXSQhTDSoE431IQ=
 golang.org/x/tools v0.0.0-20180221164845-07fd8470d635/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=
 golang.org/x/tools v0.0.0-20180525024113-a5b4c53f6e8b/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=
@@ -1305,6 +1323,7 @@ gonum.org/v1/gonum v0.0.0-20180816165407-929014505bf4/go.mod h1:Y+Yx5eoAFn32cQvJ
 gonum.org/v1/gonum v0.8.2/go.mod h1:oe/vMfY3deqTw+1EZJhuvEW2iwGF1bW9wwu7XCu0+v0=
 gonum.org/v1/gonum v0.9.1 h1:HCWmqqNoELL0RAQeKBXWtkp04mGk8koafcB4He6+uhc=
 gonum.org/v1/gonum v0.9.1/go.mod h1:TZumC3NeyVQskjXqmyWt4S3bINhy7B4eYwW69EbyX+0=
+gonum.org/v1/netlib v0.0.0-20190313105609-8cb42192e0e0 h1:OE9mWmgKkjJyEmDAAtGMPjXu+YNeGvK9VTSHY6+Qihc=
 gonum.org/v1/netlib v0.0.0-20190313105609-8cb42192e0e0/go.mod h1:wa6Ws7BG/ESfp6dHfk7C6KdzKA7wR7u/rKwOGE66zvw=
 gonum.org/v1/plot v0.0.0-20190515093506-e2840ee46a6b/go.mod h1:Wt8AAjI+ypCyYX3nZBvf6cAIx93T+c/OS2HFAYskSZc=
 gonum.org/v1/plot v0.9.0/go.mod h1:3Pcqqmp6RHvJI72kgb8fThyUnav364FOsdDo2aGW5lY=
@@ -1501,6 +1520,7 @@ gopkg.in/check.v1 v1.0.0-20141024133853-64131543e789/go.mod h1:Co6ibVJAznAaIkqp8
 gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20200227125254-8fa46927fb4f/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c h1:Hei/4ADfdWqJk1ZMxUNpqntNwaWcugrBjAiHlqqRiVk=
 gopkg.in/cheggaaa/pb.v1 v1.0.25/go.mod h1:V/YB90LKu/1FcN3WVnfiiE5oMCibMjukxqG/qStrOgw=
 gopkg.in/errgo.v2 v2.1.0/go.mod h1:hNsd1EY+bozCKY1Ytp96fpM3vjJbqLJn88ws8XvfDNI=
 gopkg.in/fsnotify.v1 v1.4.7/go.mod h1:Tz8NjZHkW78fSQdbUxIjBTcgA1z1m8ZHf0WmKUhAMys=
@@ -1532,9 +1552,11 @@ gopkg.in/yaml.v3 v3.0.0-20200615113413-eeeca48fe776/go.mod h1:K4uyk7z7BCEPqu6E+C
 gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
+gotest.tools v2.2.0+incompatible h1:VsBPFP1AI068pPrMxtb/S8Zkgf9xEmTLJjfM+P5UIEo=
 gotest.tools v2.2.0+incompatible/go.mod h1:DsYFclhRJ6vuDpmuTbkuFWG+y2sxOXAzmJt81HFBacw=
 gotest.tools/gotestsum v1.7.0/go.mod h1:V1m4Jw3eBerhI/A6qCxUE07RnCg7ACkKj9BYcAm09V8=
 gotest.tools/v3 v3.0.2/go.mod h1:3SzNCllyD9/Y+b5r9JIKQ474KzkZyqLqEfYqMsX94Bk=
+gotest.tools/v3 v3.0.3 h1:4AuOwCGf4lLR9u3YOe2awrHygurzhO/HeQ6laiA6Sx0=
 gotest.tools/v3 v3.0.3/go.mod h1:Z7Lb0S5l+klDB31fvDQX8ss/FlKDxtlFlw3Oa8Ymbl8=
 honnef.co/go/tools v0.0.0-20190102054323-c2f93a96b099/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=
 honnef.co/go/tools v0.0.0-20190106161140-3f1c8253044a/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=

--- a/go.sum
+++ b/go.sum
@@ -211,7 +211,6 @@ github.com/containerd/continuity v0.0.0-20191127005431-f65d91d395eb/go.mod h1:GL
 github.com/containerd/continuity v0.0.0-20200710164510-efbc4488d8fe/go.mod h1:cECdGN1O8G9bgKTlLhuPJimka6Xb/Gg7vYzCTNVxhvo=
 github.com/containerd/continuity v0.0.0-20201208142359-180525291bb7/go.mod h1:kR3BEg7bDFaEddKm54WSmrol1fKWDU1nKYkgrcgZT7Y=
 github.com/containerd/continuity v0.0.0-20210208174643-50096c924a4e/go.mod h1:EXlVlkqNba9rJe3j7w3Xa924itAMLgZH4UD/Q4PExuQ=
-github.com/containerd/continuity v0.1.0 h1:UFRRY5JemiAhPZrr/uE0n8fMTLcZsUvySPr1+D7pgr8=
 github.com/containerd/continuity v0.1.0/go.mod h1:ICJu0PwR54nI0yPEnJ6jcS+J7CZAUXrLh8lPo2knzsM=
 github.com/containerd/fifo v0.0.0-20180307165137-3d5202aec260/go.mod h1:ODA38xgv3Kuk8dQz2ZQXpnv/UZZUHUCL7pnLehbXgQI=
 github.com/containerd/fifo v0.0.0-20190226154929-a9fb20d87448/go.mod h1:ODA38xgv3Kuk8dQz2ZQXpnv/UZZUHUCL7pnLehbXgQI=
@@ -277,7 +276,6 @@ github.com/cpuguy83/go-md2man/v2 v2.0.0-20190314233015-f79a8a8ca69d/go.mod h1:ma
 github.com/cpuguy83/go-md2man/v2 v2.0.0/go.mod h1:maD7wRr/U5Z6m/iR4s+kqSMx2CaBsrgA7czyZG/E6dU=
 github.com/creack/pty v1.1.7/go.mod h1:lj5s0c3V2DBrqTV7llrYr5NG6My20zk30Fl46Y7DoTY=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
-github.com/creack/pty v1.1.11 h1:07n33Z8lZxZ2qwegKbObQohDhXDQxiMMz1NOUGYlesw=
 github.com/creack/pty v1.1.11/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/cyphar/filepath-securejoin v0.2.2/go.mod h1:FpkQEhXnPnOthhzymB7CGsFk2G9VLXONKD9G7QGMM+4=
 github.com/d2g/dhcp4 v0.0.0-20170904100407-a1d1b6c41b1c/go.mod h1:Ct2BUK8SB0YC1SMSibvLzxjeJLnrYEVLULFNiHY9YfQ=
@@ -395,9 +393,7 @@ github.com/go-openapi/swag v0.22.3 h1:yMBqmnQ0gyZvEb/+KzuWZOXgllrXT4SADYbvDaXHv/
 github.com/go-openapi/swag v0.22.3/go.mod h1:UzaqsxGiab7freDnrUUra0MwWfN/q7tE4j+VcZ0yl14=
 github.com/go-openapi/validate v0.21.0 h1:+Wqk39yKOhfpLqNLEC0/eViCkzM5FVXVqrvt526+wcI=
 github.com/go-openapi/validate v0.21.0/go.mod h1:rjnrwK57VJ7A8xqfpAOEKRH8yQSGUriMu5/zuPSQ1hg=
-github.com/go-redis/redis v6.15.9+incompatible h1:K0pv1D7EQUjfyoMql+r/jZqCLizCGKFlFgcHWWmHQjg=
 github.com/go-redis/redis v6.15.9+incompatible/go.mod h1:NAIEuMOZ/fxfXJIrKDQDz8wamY7mA7PouImQ2Jvg6kA=
-github.com/go-sql-driver/mysql v1.6.0 h1:BCTh4TKNUYmOmMUcQ3IipzF5prigylS7XXjEkfCHuOE=
 github.com/go-sql-driver/mysql v1.6.0/go.mod h1:DCzpHaOWr8IXmIStZouvnhqoel9Qv2LBy8hT2VhHyBg=
 github.com/go-stack/stack v1.8.0/go.mod h1:v0f6uXyyMGvRgIKkXu+yp6POWl0qKG85gN/melR3HDY=
 github.com/go-stack/stack v1.8.1/go.mod h1:dcoOX6HbPZSZptuspn9bctJ+N/CnF5gGygcUP3XYfe4=
@@ -498,11 +494,9 @@ github.com/google/go-cmp v0.5.8 h1:e6P7q2lk1O+qJJb4BtCQXlK8vWEO8V1ZeuEdJNOqZyg=
 github.com/google/go-cmp v0.5.8/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
 github.com/google/gofuzz v1.0.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
 github.com/google/gofuzz v1.1.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
-github.com/google/martian v2.1.0+incompatible h1:/CP5g8u/VJHijgedC/Legn3BAbAaWPgecwXBIDzw5no=
 github.com/google/martian v2.1.0+incompatible/go.mod h1:9I4somxYTbIHy5NJKHRl3wXiIaQGbYVAs8BPL6v8lEs=
 github.com/google/martian/v3 v3.0.0/go.mod h1:y5Zk1BBys9G+gd6Jrk0W3cC1+ELVxBWuIGO+w/tUAp0=
 github.com/google/martian/v3 v3.1.0/go.mod h1:y5Zk1BBys9G+gd6Jrk0W3cC1+ELVxBWuIGO+w/tUAp0=
-github.com/google/martian/v3 v3.2.1 h1:d8MncMlErDFTwQGBK1xhv026j9kqhvw1Qv9IbWT1VLQ=
 github.com/google/martian/v3 v3.2.1/go.mod h1:oBOf6HBosgwRXnUGWUB05QECsc6uvmMiJ3+6W4l/CUk=
 github.com/google/pprof v0.0.0-20181206194817-3ea8567a2e57/go.mod h1:zfwlbNMJ+OItoe0UupaVj+oy1omPYYDuagoSzA8v9mc=
 github.com/google/pprof v0.0.0-20190515194954-54271f7e092f/go.mod h1:zfwlbNMJ+OItoe0UupaVj+oy1omPYYDuagoSzA8v9mc=
@@ -539,10 +533,8 @@ github.com/googleapis/gax-go/v2 v2.4.0 h1:dS9eYAjhrE2RjmzYw2XAPvcXfmcQLtFEQWn0CR
 github.com/googleapis/gax-go/v2 v2.4.0/go.mod h1:XOTVJ59hdnfJLIP/dh8n5CGryZR2LxK9wbMD5+iXC6c=
 github.com/googleapis/gnostic v0.4.1/go.mod h1:LRhVm6pbyptWbWbuZ38d1eyptfvIytN3ir6b65WBswg=
 github.com/googleapis/go-type-adapters v1.0.0/go.mod h1:zHW75FOG2aur7gAO2B+MLby+cLsWGBF62rFAi7WjWO4=
-github.com/gopherjs/gopherjs v0.0.0-20181017120253-0766667cb4d1 h1:EGx4pi6eqNxGaHF6qqu48+N2wcFQ5qg5FXgOdqsJ5d8=
 github.com/gopherjs/gopherjs v0.0.0-20181017120253-0766667cb4d1/go.mod h1:wJfORRmW1u3UXTncJ5qlYoELFm8eSnnEO6hX4iZ3EWY=
 github.com/gorilla/handlers v0.0.0-20150720190736-60c7bfde3e33/go.mod h1:Qkdc/uu4tH4g6mTK6auzZ766c4CA0Ng8+o/OAirnOIQ=
-github.com/gorilla/mux v1.7.2 h1:zoNxOV7WjqXptQOVngLmcSQgXmgk4NMz1HibBchjl/I=
 github.com/gorilla/mux v1.7.2/go.mod h1:1lud6UwP+6orDFRuTfBEV8e9/aOM/c4fVVCaMa2zaAs=
 github.com/gorilla/websocket v0.0.0-20170926233335-4201258b820c/go.mod h1:E7qHFY5m1UJ88s3WnNqhKjPHQ0heANvMoAMk2YaljkQ=
 github.com/gorilla/websocket v1.4.0/go.mod h1:E7qHFY5m1UJ88s3WnNqhKjPHQ0heANvMoAMk2YaljkQ=
@@ -566,7 +558,6 @@ github.com/hashicorp/go-multierror v1.0.0 h1:iVjPR7a6H0tWELX5NxNe7bYopibicUzc7uP
 github.com/hashicorp/go-multierror v1.0.0/go.mod h1:dHtQlpGsu+cZNNAkkCN/P3hoUDHhCYQXV3UM06sGGrk=
 github.com/hashicorp/go-sockaddr v1.0.0 h1:GeH6tui99pF4NJgfnhp+L6+FfobzVW3Ah46sLo0ICXs=
 github.com/hashicorp/go-sockaddr v1.0.0/go.mod h1:7Xibr9yA9JjQq1JpNB2Vw7kxv8xerXegt+ozgdvDeDU=
-github.com/hashicorp/go-uuid v1.0.0 h1:RS8zrF7PhGwyNPOtxSClXXj9HA8feRnJzgnI1RJCSnM=
 github.com/hashicorp/go-uuid v1.0.0/go.mod h1:6SBZvOh/SIDV7/2o3Jml5SYk/TvGqwFJ/bN7x4byOro=
 github.com/hashicorp/golang-lru v0.5.0/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
 github.com/hashicorp/golang-lru v0.5.1 h1:0hERBMJE1eitiLkihrMvRVBYAkpHzc/J3QdDN+dAcgU=
@@ -602,7 +593,6 @@ github.com/json-iterator/go v1.1.12 h1:PV8peI4a0ysnczrg+LtxykD8LfKY9ML6u2jnxaEnr
 github.com/json-iterator/go v1.1.12/go.mod h1:e30LSqwooZae/UwlEbR2852Gd8hjQvJoHmT4TnhNGBo=
 github.com/jstemmer/go-junit-report v0.0.0-20190106144839-af01ea7f8024/go.mod h1:6v2b51hI/fHJwM22ozAgKL4VKDeJcHhJFhtBdhmNjmU=
 github.com/jstemmer/go-junit-report v0.9.1/go.mod h1:Brl9GWCQeLvo8nXZwPNNblvFj/XSXhF0NWZEnDohbsk=
-github.com/jtolds/gls v4.20.0+incompatible h1:xdiiI2gbIgH/gLH7ADydsJ1uDOEzR8yvV7C0MuV77Wo=
 github.com/jtolds/gls v4.20.0+incompatible/go.mod h1:QJZ7F/aHp+rZTRtaJ1ow/lLfFfVYBRgL+9YlvaHOwJU=
 github.com/julienschmidt/httprouter v1.2.0/go.mod h1:SYymIcj16QtmaHHD7aYtjjsJG7VTCxuUUipMqKk8s4w=
 github.com/julienschmidt/httprouter v1.3.0/go.mod h1:JR6WtHb+2LUe8TCKY3cZOxFyyO8IZAc4RVcycCCAKdM=
@@ -627,12 +617,10 @@ github.com/konsorten/go-windows-terminal-sequences v1.0.3/go.mod h1:T0+1ngSBFLxv
 github.com/kr/logfmt v0.0.0-20140226030751-b84e30acd515/go.mod h1:+0opPa2QZZtGFBFZlji/RkVcI2GknAs/DXo4wKdlNEc=
 github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=
 github.com/kr/pretty v0.2.0/go.mod h1:ipq/a2n7PKx3OHsz4KJII5eveXtPO4qwEXGdVfWzfnI=
-github.com/kr/pretty v0.2.1 h1:Fmg33tUaq4/8ym9TJN1x7sLJnHVwhP33CNkpYV/7rwI=
 github.com/kr/pretty v0.2.1/go.mod h1:ipq/a2n7PKx3OHsz4KJII5eveXtPO4qwEXGdVfWzfnI=
 github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
 github.com/kr/pty v1.1.5/go.mod h1:9r2w37qlBe7rQ6e1fg1S/9xpWHSnaqNdHD3WcMdbPDA=
 github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
-github.com/kr/text v0.2.0 h1:5Nx0Ya0ZqY2ygV366QzturHI13Jq95ApcVaJBhpS+AY=
 github.com/kr/text v0.2.0/go.mod h1:eLer722TekiGuMkidMxC/pM04lWEeraHUUmBw8l2grE=
 github.com/magiconair/properties v1.8.0/go.mod h1:PppfXfuXeibc/6YijjN8zIbojt8czPbwD3XqdrwzmxQ=
 github.com/magiconair/properties v1.8.5 h1:b6kJs+EmPFMYGkow9GiUyCyOvIwYetYJ3fSaWak/Gls=
@@ -753,7 +741,6 @@ github.com/opencontainers/selinux v1.8.0/go.mod h1:RScLhm78qiWa2gbVCcGkC7tCGdgk3
 github.com/opencontainers/selinux v1.8.2/go.mod h1:MUIHuUEvKB1wtJjQdOyYRgOnLD2xAPP8dBsCoU0KuF8=
 github.com/opentracing/opentracing-go v1.2.0 h1:uEJPy/1a5RIPAJ0Ov+OIO8OxWu77jEv+1B0VhjKrZUs=
 github.com/opentracing/opentracing-go v1.2.0/go.mod h1:GxEUsuufX4nBwe+T+Wl9TAgYrxe9dPLANfrWvHYVTgc=
-github.com/pascaldekloe/goe v0.0.0-20180627143212-57f6aae5913c h1:Lgl0gzECD8GnQ5QCWA8o6BtfL6mDH5rQgM4/fX3avOs=
 github.com/pascaldekloe/goe v0.0.0-20180627143212-57f6aae5913c/go.mod h1:lzWF7FIEvWOWxwDKqyGYQf6ZUaNfKdP144TG7ZOy1lc=
 github.com/pelletier/go-toml v1.2.0/go.mod h1:5z9KED0ma1S8pY6P1sdut58dfprrGBbd/94hg7ilaic=
 github.com/pelletier/go-toml v1.7.0/go.mod h1:vwGMzjaWMwyfHwgIBhI2YUM4fB6nL6lVAvS1LBMMhTE=
@@ -833,10 +820,8 @@ github.com/sirupsen/logrus v1.6.0/go.mod h1:7uNnSEd1DgxDLC74fIahvMZmmYsHGZGEOFrf
 github.com/sirupsen/logrus v1.7.0/go.mod h1:yWOB1SBYBC5VeMP7gHvWumXLIWorT60ONWic61uBYv0=
 github.com/sirupsen/logrus v1.8.1 h1:dJKuHgqk1NNQlqoA6BTlM1Wf9DOH3NBjQyu0h9+AZZE=
 github.com/sirupsen/logrus v1.8.1/go.mod h1:yWOB1SBYBC5VeMP7gHvWumXLIWorT60ONWic61uBYv0=
-github.com/smartystreets/assertions v0.0.0-20180927180507-b2de0cb4f26d h1:zE9ykElWQ6/NYmHa3jpm/yHnI4xSofP+UP6SpjHcSeM=
 github.com/smartystreets/assertions v0.0.0-20180927180507-b2de0cb4f26d/go.mod h1:OnSkiWE9lh6wB0YB77sQom3nweQdgAjqCqsofrRNTgc=
 github.com/smartystreets/goconvey v0.0.0-20190330032615-68dc04aab96a/go.mod h1:syvi0/a8iFYH4r/RixwvyeAJjdLS9QV7WQ/tjFTllLA=
-github.com/smartystreets/goconvey v1.6.4 h1:fv0U8FUIMPNf1L9lnHLvLhgicrIVChEkdzIKYqbNC9s=
 github.com/soheilhy/cmux v0.1.4/go.mod h1:IM3LyeVVIOuxMH7sFAkER9+bJ4dT7Ms6E4xg4kGIyLM=
 github.com/spaolacci/murmur3 v0.0.0-20180118202830-f09979ecbc72/go.mod h1:JwIasOWyU6f++ZhiEuf87xNszmSA2myDM2Kzu9HwQUA=
 github.com/spaolacci/murmur3 v1.1.0 h1:7c1g84S4BPRrfL5Xrdp6fOJ206sU9y293DDHaoy0bLI=
@@ -882,7 +867,6 @@ github.com/tailor-inc/graphql v0.1.0/go.mod h1:Rl0/u8OoidpQkaoKFph1ElyMc3EI6GYdC
 github.com/tchap/go-patricia v2.2.6+incompatible/go.mod h1:bmLyhP68RS6kStMGxByiQ23RP/odRBOTVjwp2cDyi6I=
 github.com/testcontainers/testcontainers-go v0.13.0 h1:OUujSlEGsXVo/ykPVZk3KanBNGN0TYb/7oKIPVn15JA=
 github.com/testcontainers/testcontainers-go v0.13.0/go.mod h1:z1abufU633Eb/FmSBTzV6ntZAC1eZBYPtaFsn4nPuDk=
-github.com/tidwall/pretty v1.0.0 h1:HsD+QiTn7sK6flMKIvNmpqz1qrpP3Ps6jOKIKMooyg4=
 github.com/tidwall/pretty v1.0.0/go.mod h1:XNkn88O1ChpSDQmQeStsy+sBenx6DDtFZJxhVysOjyk=
 github.com/tmc/grpc-websocket-proxy v0.0.0-20170815181823-89b8d40f7ca8/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=
 github.com/tmc/grpc-websocket-proxy v0.0.0-20190109142713-0ad062ec5ee5/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=
@@ -978,7 +962,6 @@ golang.org/x/exp v0.0.0-20191129062945-2f5052295587/go.mod h1:2RIsYlXP63K8oxa1u0
 golang.org/x/exp v0.0.0-20191227195350-da58074b4299/go.mod h1:2RIsYlXP63K8oxa1u096TMicItID8zy7Y6sNkU49FU4=
 golang.org/x/exp v0.0.0-20200119233911-0405dc783f0a/go.mod h1:2RIsYlXP63K8oxa1u096TMicItID8zy7Y6sNkU49FU4=
 golang.org/x/exp v0.0.0-20200207192155-f17229e696bd/go.mod h1:J/WKrq2StrnmMY6+EHIKF9dgMWnmCNThgcyBT1FY9mM=
-golang.org/x/exp v0.0.0-20200224162631-6cc2880d07d6 h1:QE6XYQK6naiK1EPAe1g/ILLxN5RBoH5xkJk3CqlMI/Y=
 golang.org/x/exp v0.0.0-20200224162631-6cc2880d07d6/go.mod h1:3jZMyOhIsHpP37uCMkUooju7aAi5cS1Q23tOzKc+0MU=
 golang.org/x/image v0.0.0-20180708004352-c73c2afc3b81/go.mod h1:ux5Hcp/YLpHSI86hEcLt0YII63i6oz57MZXIpbrjZUs=
 golang.org/x/image v0.0.0-20190227222117-0694c2d4d067/go.mod h1:kZ7UVZpmo3dzQBMxlp+ypCbDeSB+sBbTgSJuh5dn5js=
@@ -1242,7 +1225,6 @@ golang.org/x/time v0.0.0-20180412165947-fbb02b2291d2/go.mod h1:tRJNPiyCQ0inRvYxb
 golang.org/x/time v0.0.0-20181108054448-85acf8d2951c/go.mod h1:tRJNPiyCQ0inRvYxbN9jk5I+vvW/OXSQhTDSoE431IQ=
 golang.org/x/time v0.0.0-20190308202827-9d24e82272b4/go.mod h1:tRJNPiyCQ0inRvYxbN9jk5I+vvW/OXSQhTDSoE431IQ=
 golang.org/x/time v0.0.0-20191024005414-555d28b269f0/go.mod h1:tRJNPiyCQ0inRvYxbN9jk5I+vvW/OXSQhTDSoE431IQ=
-golang.org/x/time v0.0.0-20200630173020-3af7569d3a1e h1:EHBhcS0mlXEAVwNyO2dLfjToGsyY4j24pTs2ScHnX7s=
 golang.org/x/time v0.0.0-20200630173020-3af7569d3a1e/go.mod h1:tRJNPiyCQ0inRvYxbN9jk5I+vvW/OXSQhTDSoE431IQ=
 golang.org/x/tools v0.0.0-20180221164845-07fd8470d635/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=
 golang.org/x/tools v0.0.0-20180525024113-a5b4c53f6e8b/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=
@@ -1323,7 +1305,6 @@ gonum.org/v1/gonum v0.0.0-20180816165407-929014505bf4/go.mod h1:Y+Yx5eoAFn32cQvJ
 gonum.org/v1/gonum v0.8.2/go.mod h1:oe/vMfY3deqTw+1EZJhuvEW2iwGF1bW9wwu7XCu0+v0=
 gonum.org/v1/gonum v0.9.1 h1:HCWmqqNoELL0RAQeKBXWtkp04mGk8koafcB4He6+uhc=
 gonum.org/v1/gonum v0.9.1/go.mod h1:TZumC3NeyVQskjXqmyWt4S3bINhy7B4eYwW69EbyX+0=
-gonum.org/v1/netlib v0.0.0-20190313105609-8cb42192e0e0 h1:OE9mWmgKkjJyEmDAAtGMPjXu+YNeGvK9VTSHY6+Qihc=
 gonum.org/v1/netlib v0.0.0-20190313105609-8cb42192e0e0/go.mod h1:wa6Ws7BG/ESfp6dHfk7C6KdzKA7wR7u/rKwOGE66zvw=
 gonum.org/v1/plot v0.0.0-20190515093506-e2840ee46a6b/go.mod h1:Wt8AAjI+ypCyYX3nZBvf6cAIx93T+c/OS2HFAYskSZc=
 gonum.org/v1/plot v0.9.0/go.mod h1:3Pcqqmp6RHvJI72kgb8fThyUnav364FOsdDo2aGW5lY=
@@ -1520,7 +1501,6 @@ gopkg.in/check.v1 v1.0.0-20141024133853-64131543e789/go.mod h1:Co6ibVJAznAaIkqp8
 gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20200227125254-8fa46927fb4f/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
-gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c h1:Hei/4ADfdWqJk1ZMxUNpqntNwaWcugrBjAiHlqqRiVk=
 gopkg.in/cheggaaa/pb.v1 v1.0.25/go.mod h1:V/YB90LKu/1FcN3WVnfiiE5oMCibMjukxqG/qStrOgw=
 gopkg.in/errgo.v2 v2.1.0/go.mod h1:hNsd1EY+bozCKY1Ytp96fpM3vjJbqLJn88ws8XvfDNI=
 gopkg.in/fsnotify.v1 v1.4.7/go.mod h1:Tz8NjZHkW78fSQdbUxIjBTcgA1z1m8ZHf0WmKUhAMys=
@@ -1552,11 +1532,9 @@ gopkg.in/yaml.v3 v3.0.0-20200615113413-eeeca48fe776/go.mod h1:K4uyk7z7BCEPqu6E+C
 gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
-gotest.tools v2.2.0+incompatible h1:VsBPFP1AI068pPrMxtb/S8Zkgf9xEmTLJjfM+P5UIEo=
 gotest.tools v2.2.0+incompatible/go.mod h1:DsYFclhRJ6vuDpmuTbkuFWG+y2sxOXAzmJt81HFBacw=
 gotest.tools/gotestsum v1.7.0/go.mod h1:V1m4Jw3eBerhI/A6qCxUE07RnCg7ACkKj9BYcAm09V8=
 gotest.tools/v3 v3.0.2/go.mod h1:3SzNCllyD9/Y+b5r9JIKQ474KzkZyqLqEfYqMsX94Bk=
-gotest.tools/v3 v3.0.3 h1:4AuOwCGf4lLR9u3YOe2awrHygurzhO/HeQ6laiA6Sx0=
 gotest.tools/v3 v3.0.3/go.mod h1:Z7Lb0S5l+klDB31fvDQX8ss/FlKDxtlFlw3Oa8Ymbl8=
 honnef.co/go/tools v0.0.0-20190102054323-c2f93a96b099/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=
 honnef.co/go/tools v0.0.0-20190106161140-3f1c8253044a/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=

--- a/tools/dev/run_dev_server.sh
+++ b/tools/dev/run_dev_server.sh
@@ -17,6 +17,7 @@ export ORIGIN=${ORIGIN:-"http://localhost:8080"}
 export QUERY_DEFAULTS_LIMIT=${QUERY_DEFAULTS_LIMIT:-"20"}
 export QUERY_MAXIMUM_RESULTS=${QUERY_MAXIMUM_RESULTS:-"10000"}
 export TRACK_VECTOR_DIMENSIONS=true
+export CLUSTER_HOSTNAME=${CLUSTER_HOSTNAME:-"node1"}
 
 function go_run() {
   GIT_HASH=$(git rev-parse --short HEAD)
@@ -29,7 +30,6 @@ case $CONFIG in
       AUTHENTICATION_ANONYMOUS_ACCESS_ENABLED=true \
       DEFAULT_VECTORIZER_MODULE=text2vec-contextionary \
       ENABLE_MODULES="text2vec-contextionary" \
-      CLUSTER_HOSTNAME="node1" \
       dlv debug ./cmd/weaviate-server -- \
         --scheme http \
         --host "127.0.0.1" \
@@ -44,7 +44,6 @@ case $CONFIG in
       DEFAULT_VECTORIZER_MODULE=text2vec-contextionary \
       BACKUP_FILESYSTEM_PATH="${PWD}/backups" \
       ENABLE_MODULES="text2vec-contextionary,backup-filesystem" \
-      CLUSTER_HOSTNAME="$CLUSTER_HOSTNAME" \
       CLUSTER_GOSSIP_BIND_PORT="7100" \
       CLUSTER_DATA_BIND_PORT="7101" \
       go_run ./cmd/weaviate-server \
@@ -117,7 +116,6 @@ case $CONFIG in
       AUTHENTICATION_ANONYMOUS_ACCESS_ENABLED=true \
       DEFAULT_VECTORIZER_MODULE=text2vec-transformers \
       TRANSFORMERS_INFERENCE_API="http://localhost:8000" \
-      CLUSTER_HOSTNAME="node1" \
       ENABLE_MODULES="text2vec-transformers" \
       go_run ./cmd/weaviate-server \
         --scheme http \
@@ -132,7 +130,6 @@ case $CONFIG in
       DEFAULT_VECTORIZER_MODULE=text2vec-transformers \
       TRANSFORMERS_PASSAGE_INFERENCE_API="http://localhost:8006" \
       TRANSFORMERS_QUERY_INFERENCE_API="http://localhost:8007" \
-      CLUSTER_HOSTNAME="node1" \
       ENABLE_MODULES="text2vec-transformers" \
       go_run ./cmd/weaviate-server \
         --scheme http \
@@ -146,7 +143,6 @@ case $CONFIG in
       AUTHENTICATION_ANONYMOUS_ACCESS_ENABLED=true \
       DEFAULT_VECTORIZER_MODULE=text2vec-contextionary \
       QNA_INFERENCE_API="http://localhost:8001" \
-      CLUSTER_HOSTNAME="node1" \
       ENABLE_MODULES="text2vec-contextionary,qna-transformers" \
       go_run ./cmd/weaviate-server \
         --scheme http \
@@ -160,7 +156,6 @@ case $CONFIG in
       AUTHENTICATION_ANONYMOUS_ACCESS_ENABLED=true \
       DEFAULT_VECTORIZER_MODULE=text2vec-contextionary \
       SUM_INFERENCE_API="http://localhost:8008" \
-      CLUSTER_HOSTNAME="node1" \
       ENABLE_MODULES="text2vec-contextionary,sum-transformers" \
       go_run ./cmd/weaviate-server \
         --scheme http \
@@ -174,7 +169,6 @@ case $CONFIG in
       AUTHENTICATION_ANONYMOUS_ACCESS_ENABLED=true \
       DEFAULT_VECTORIZER_MODULE=text2vec-contextionary \
       IMAGE_INFERENCE_API="http://localhost:8002" \
-      CLUSTER_HOSTNAME="node1" \
       ENABLE_MODULES="text2vec-contextionary,img2vec-neural" \
       go_run ./cmd/weaviate-server \
         --scheme http \
@@ -189,7 +183,6 @@ case $CONFIG in
       DEFAULT_VECTORIZER_MODULE=text2vec-contextionary \
       NER_INFERENCE_API="http://localhost:8003" \
       ENABLE_MODULES="text2vec-contextionary,ner-transformers" \
-      CLUSTER_HOSTNAME="node1" \
       go_run ./cmd/weaviate-server \
         --scheme http \
         --host "127.0.0.1" \
@@ -203,7 +196,6 @@ case $CONFIG in
       DEFAULT_VECTORIZER_MODULE=text2vec-contextionary \
       SPELLCHECK_INFERENCE_API="http://localhost:8004" \
       ENABLE_MODULES="text2vec-contextionary,text-spellcheck" \
-      CLUSTER_HOSTNAME="node1" \
       go_run ./cmd/weaviate-server \
         --scheme http \
         --host "127.0.0.1" \
@@ -217,7 +209,6 @@ case $CONFIG in
       DEFAULT_VECTORIZER_MODULE=multi2vec-clip \
       CLIP_INFERENCE_API="http://localhost:8005" \
       ENABLE_MODULES="multi2vec-clip" \
-      CLUSTER_HOSTNAME="node1" \
       go_run ./cmd/weaviate-server \
         --scheme http \
         --host "127.0.0.1" \
@@ -236,7 +227,6 @@ case $CONFIG in
       AUTHORIZATION_ADMINLIST_ENABLED=true \
       AUTHORIZATION_ADMINLIST_USERS=john@doe.com \
       DEFAULT_VECTORIZER_MODULE=text2vec-contextionary \
-      CLUSTER_HOSTNAME="node1" \
       go_run ./cmd/weaviate-server \
         --scheme http \
         --host "127.0.0.1" \
@@ -250,7 +240,6 @@ case $CONFIG in
       TRANSFORMERS_INFERENCE_API=http://localhost:8000 \
       CLIP_INFERENCE_API=http://localhost:8005 \
       ENABLE_MODULES=text2vec-contextionary,text2vec-transformers,multi2vec-clip \
-      CLUSTER_HOSTNAME="node1" \
       go_run ./cmd/weaviate-server \
         --scheme http \
         --host "127.0.0.1" \
@@ -261,7 +250,6 @@ case $CONFIG in
       AUTHENTICATION_ANONYMOUS_ACCESS_ENABLED=true \
       DEFAULT_VECTORIZER_MODULE=text2vec-openai \
       ENABLE_MODULES="text2vec-openai" \
-      CLUSTER_HOSTNAME="node1" \
       go_run ./cmd/weaviate-server \
         --scheme http \
         --host "127.0.0.1" \
@@ -274,7 +262,6 @@ case $CONFIG in
       AUTHENTICATION_ANONYMOUS_ACCESS_ENABLED=true \
       DEFAULT_VECTORIZER_MODULE=text2vec-huggingface \
       ENABLE_MODULES="text2vec-huggingface" \
-      CLUSTER_HOSTNAME="node1" \
       go_run ./cmd/weaviate-server \
         --scheme http \
         --host "127.0.0.1" \
@@ -284,7 +271,6 @@ case $CONFIG in
     ;;
 
   local-no-modules)
-      CLUSTER_HOSTNAME="node1" \
       CLUSTER_GOSSIP_BIND_PORT="7100" \
       CLUSTER_DATA_BIND_PORT="7101" \
       AUTHENTICATION_ANONYMOUS_ACCESS_ENABLED=true \
@@ -298,7 +284,6 @@ case $CONFIG in
     ;;
 
   local-centroid)
-      CLUSTER_HOSTNAME="node1" \
       AUTHENTICATION_ANONYMOUS_ACCESS_ENABLED=true \
       ENABLE_MODULES="ref2vec-centroid" \
       go_run ./cmd/weaviate-server \
@@ -318,7 +303,6 @@ case $CONFIG in
       AWS_ACCESS_KEY_ID="aws_access_key" \
       AWS_SECRET_KEY="aws_secret_key" \
       ENABLE_MODULES="text2vec-contextionary,backup-s3" \
-      CLUSTER_HOSTNAME="node1" \
       CLUSTER_GOSSIP_BIND_PORT="7100" \
       CLUSTER_DATA_BIND_PORT="7101" \
       go_run ./cmd/weaviate-server \
@@ -338,7 +322,6 @@ case $CONFIG in
       BACKUP_GCS_ENDPOINT=localhost:9090 \
       BACKUP_GCS_BUCKET=weaviate-backups \
       ENABLE_MODULES="text2vec-contextionary,backup-gcs" \
-      CLUSTER_HOSTNAME="node1" \
       CLUSTER_GOSSIP_BIND_PORT="7100" \
       CLUSTER_DATA_BIND_PORT="7101" \
       go_run ./cmd/weaviate-server \
@@ -353,7 +336,6 @@ case $CONFIG in
       AUTHENTICATION_ANONYMOUS_ACCESS_ENABLED=true \
       DEFAULT_VECTORIZER_MODULE=text2vec-cohere \
       ENABLE_MODULES="text2vec-cohere" \
-      CLUSTER_HOSTNAME="node1" \
       go_run ./cmd/weaviate-server \
         --scheme http \
         --host "127.0.0.1" \

--- a/tools/dev/run_dev_server.sh
+++ b/tools/dev/run_dev_server.sh
@@ -44,7 +44,7 @@ case $CONFIG in
       DEFAULT_VECTORIZER_MODULE=text2vec-contextionary \
       BACKUP_FILESYSTEM_PATH="${PWD}/backups" \
       ENABLE_MODULES="text2vec-contextionary,backup-filesystem" \
-      CLUSTER_HOSTNAME="node1" \
+      CLUSTER_HOSTNAME="$CLUSTER_HOSTNAME" \
       CLUSTER_GOSSIP_BIND_PORT="7100" \
       CLUSTER_DATA_BIND_PORT="7101" \
       go_run ./cmd/weaviate-server \


### PR DESCRIPTION
### What's being changed:

*tl;dr: This improves startup time with the Wikiepdia dataset from ~5min to ~1min. It does so by persisting things that we are currently unnecessarily computing at startup time.*

**Before**

<img width="994" alt="image" src="https://user-images.githubusercontent.com/8974479/204230560-8556a421-c924-4a73-b3c5-9650f6390650.png">

**After**

<img width="958" alt="image" src="https://user-images.githubusercontent.com/8974479/204230860-359852a2-7c50-4844-8b5d-2323c2181f02.png">

## Long Form

Before this PR, whenever we would initiate an LSM store segment, we would have to do two operations: 

1. Build a bloom filter for the segment. This required parsing all the keys in the segment's index structure. It was thus a function of the segments size.
2. Calculate the "count net additions" (CNAs). CNAs are a way to identify how many objects are in a bucket quickly. Because LSM stores are append-only, an update and a delete are also "just a write" – so simply counting keys isn't enough. We need to know if a key is a new insertion (count + 1), an updated (count unchanged) or a delete of an existing key (count -1). 

Both of these operations can easily be persisted on disk as well. This eliminates the need to recalculate them. The Bloom filter depends purely on the segment's contents. Since segments are immutable, the bloom filter is also immutable. The CNA depends on the contents of the segments and the contents of all previous segments. Since new segments can only be appended at the end (i.e., after an existing segment), the CNA is unaffected. Segments before or can only be changed by merging two together ("compaction"); however, the merged segment must have the same contents as its two inputs, thus not affecting the CNA.

This statement is verified extensively through [a brand new stress-test pipeline](https://github.com/semi-technologies/weaviate-chaos-engineering/pull/23) that produces a lot of compactions on a dataset, including plenty of deletions. It validates the object count at many points, including before, during, and after compactions.

## Backward Compatibility

This change is fully backward-compatible. When upgrading to this version, the files cannot yet be read from the disk because they don't exist. Therefore in the init phase, they are created (in-mem) as they would have been before. However, once created, they are persisted on disk. On subsequent starts, the files are read from disk, thus speeding up startup considerably.

## Checksums

This PR introduces new files next to the `segment-[0-9]+.db` files with extensions `.bloom` for bloom filters, and `.cna` for count net additions. Both new files make use of checksums. If a checksum is invalid - for example because Weaviate crashed while partially writing a file or hardware data corruption - the files are discarded and rebuilt on the fly. 

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [x] Chaos pipeline run or not necessary. [Link to pipeline](https://app.travis-ci.com/github/semi-technologies/weaviate-chaos-engineering)
- [x] All new code is covered by tests where it is reasonable: Yes, the remaining uncovered lines are all `if err != nil` branches on mostly os/file level operations
- [ ] Performance tests have been run or not necessary.
