### PR TITLE
Fix broken logger in tx manager

### DIFF
--- a/usecases/cluster/transactions_write.go
+++ b/usecases/cluster/transactions_write.go
@@ -77,6 +77,7 @@ func NewTxManager(remote Remote, logger logrus.FieldLogger) *TxManager {
 		// nil-check on every call.
 		commitFn:   newDummyCommitResponseFn(),
 		responseFn: newDummyCommitResponseFn(),
+		logger:     logger,
 	}
 }
 


### PR DESCRIPTION
### What's being changed:
* fix broken logger in tx manager (was introduced with dynamically scaling nodes, i.e. is not released yet)

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [x] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.
