### PR TITLE
Improve p9999 Batch Import Latency by precomputing segment metadata for newly compacted segments

### DIFF
--- a/adapters/repos/db/lsmkv/segment_bloom_filters.go
+++ b/adapters/repos/db/lsmkv/segment_bloom_filters.go
@@ -161,7 +161,7 @@ func (ind *segment) initSecondaryBloomFilter(pos int) error {
 		// now continue re-calculating
 	}
 
-	if err := ind.computeAndStoreSeondaryBloomFilter(path, pos); err != nil {
+	if err := ind.computeAndStoreSecondaryBloomFilter(path, pos); err != nil {
 		return err
 	}
 
@@ -175,7 +175,7 @@ func (ind *segment) initSecondaryBloomFilter(pos int) error {
 	return nil
 }
 
-func (ind *segment) computeAndStoreSeondaryBloomFilter(path string, pos int) error {
+func (ind *segment) computeAndStoreSecondaryBloomFilter(path string, pos int) error {
 	keys, err := ind.secondaryIndices[pos].AllKeys()
 	if err != nil {
 		return err
@@ -206,7 +206,7 @@ func (ind *segment) precomputeSecondaryBloomFilter(pos int) error {
 		return fmt.Errorf("a secondary bloom filter already exists with path %s", path)
 	}
 
-	if err := ind.computeAndStoreSeondaryBloomFilter(path, pos); err != nil {
+	if err := ind.computeAndStoreSecondaryBloomFilter(path, pos); err != nil {
 		return err
 	}
 

--- a/adapters/repos/db/lsmkv/segment_bloom_filters_test.go
+++ b/adapters/repos/db/lsmkv/segment_bloom_filters_test.go
@@ -33,6 +33,7 @@ func TestCreateBloomOnFlush(t *testing.T) {
 		WithStrategy(StrategyReplace),
 		WithSecondaryIndices(1))
 	require.Nil(t, err)
+	defer b.Shutdown(ctx)
 
 	require.Nil(t, b.Put([]byte("hello"), []byte("world"),
 		WithSecondaryKey(0, []byte("bonjour"))))
@@ -51,6 +52,7 @@ func TestCreateBloomOnFlush(t *testing.T) {
 		WithStrategy(StrategyReplace),
 		WithSecondaryIndices(1))
 	require.Nil(t, err)
+	defer b2.Shutdown(ctx)
 
 	valuePrimary, err := b2.Get([]byte("hello"))
 	require.Nil(t, err)
@@ -73,6 +75,7 @@ func TestCreateBloomInit(t *testing.T) {
 		WithStrategy(StrategyReplace),
 		WithSecondaryIndices(1))
 	require.Nil(t, err)
+	defer b.Shutdown(ctx)
 
 	require.Nil(t, b.Put([]byte("hello"), []byte("world"),
 		WithSecondaryKey(0, []byte("bonjour"))))
@@ -96,8 +99,9 @@ func TestCreateBloomInit(t *testing.T) {
 	require.Nil(t, b.Shutdown(ctx))
 
 	// now create a new bucket and assert that the file is re-created on init
-	_, err = NewBucket(ctx, dirName, "", logger, nil, WithStrategy(StrategyReplace))
+	b2, err := NewBucket(ctx, dirName, "", logger, nil, WithStrategy(StrategyReplace))
 	require.Nil(t, err)
+	defer b2.Shutdown(ctx)
 
 	files, err := os.ReadDir(dirName)
 	require.Nil(t, err)
@@ -115,6 +119,7 @@ func TestRepairCorruptedBloomOnInit(t *testing.T) {
 
 	b, err := NewBucket(ctx, dirName, "", logger, nil, WithStrategy(StrategyReplace))
 	require.Nil(t, err)
+	defer b.Shutdown(ctx)
 
 	require.Nil(t, b.Put([]byte("hello"), []byte("world")))
 	require.Nil(t, b.FlushMemtable(ctx))
@@ -131,6 +136,7 @@ func TestRepairCorruptedBloomOnInit(t *testing.T) {
 	// init, and the count matches
 	b2, err := NewBucket(ctx, dirName, "", logger, nil, WithStrategy(StrategyReplace))
 	require.Nil(t, err)
+	defer b2.Shutdown(ctx)
 
 	value, err := b2.Get([]byte("hello"))
 	assert.Nil(t, err)
@@ -147,6 +153,7 @@ func TestRepairCorruptedBloomSecondaryOnInit(t *testing.T) {
 		WithStrategy(StrategyReplace),
 		WithSecondaryIndices(1))
 	require.Nil(t, err)
+	defer b.Shutdown(ctx)
 
 	require.Nil(t, b.Put([]byte("hello"), []byte("world"),
 		WithSecondaryKey(0, []byte("bonjour"))))
@@ -165,6 +172,7 @@ func TestRepairCorruptedBloomSecondaryOnInit(t *testing.T) {
 	b2, err := NewBucket(ctx, dirName, "", logger, nil,
 		WithStrategy(StrategyReplace), WithSecondaryIndices(1))
 	require.Nil(t, err)
+	defer b2.Shutdown(ctx)
 
 	value, err := b2.GetBySecondary(0, []byte("bonjour"))
 	assert.Nil(t, err)

--- a/adapters/repos/db/lsmkv/segment_group_compaction.go
+++ b/adapters/repos/db/lsmkv/segment_group_compaction.go
@@ -197,7 +197,8 @@ func (sg *SegmentGroup) replaceCompactedSegments(old1, old2 int,
 		sg.segments[old2].countNetAdditions
 	sg.maintenanceLock.RUnlock()
 
-	precomputedFiles, err := preComputeSegmentMeta(newPathTmp, updatedCountNetAdditions)
+	precomputedFiles, err := preComputeSegmentMeta(newPathTmp,
+		updatedCountNetAdditions, sg.logger)
 	if err != nil {
 		return fmt.Errorf("precompute segment meta: %w", err)
 	}

--- a/adapters/repos/db/lsmkv/segment_group_compaction.go
+++ b/adapters/repos/db/lsmkv/segment_group_compaction.go
@@ -192,11 +192,18 @@ func (sg *SegmentGroup) compactOnce() error {
 func (sg *SegmentGroup) replaceCompactedSegments(old1, old2 int,
 	newPathTmp string,
 ) error {
-	sg.maintenanceLock.Lock()
-	defer sg.maintenanceLock.Unlock()
-
+	sg.maintenanceLock.RLock()
 	updatedCountNetAdditions := sg.segments[old1].countNetAdditions +
 		sg.segments[old2].countNetAdditions
+	sg.maintenanceLock.RUnlock()
+
+	precomputedFiles, err := preComputeSegmentMeta(newPathTmp, updatedCountNetAdditions)
+	if err != nil {
+		return fmt.Errorf("precompute segment meta: %w", err)
+	}
+
+	sg.maintenanceLock.Lock()
+	defer sg.maintenanceLock.Unlock()
 
 	if err := sg.segments[old1].close(); err != nil {
 		return errors.Wrap(err, "close disk segment")
@@ -217,20 +224,23 @@ func (sg *SegmentGroup) replaceCompactedSegments(old1, old2 int,
 	sg.segments[old1] = nil
 	sg.segments[old2] = nil
 
+	var newPath string
 	// the old segments have been deleted, we can now safely remove the .tmp
-	// extension from the new segment which carried the name of the second old
-	// segment
-	newPath, err := sg.stripTmpExtension(newPathTmp)
-	if err != nil {
-		return errors.Wrap(err, "strip .tmp extension of new segment")
+	// extension from the new segment itself and the pre-computed files which
+	// carried the name of the second old segment
+	for i, path := range precomputedFiles {
+		updated, err := sg.stripTmpExtension(path)
+		if err != nil {
+			return errors.Wrap(err, "strip .tmp extension of new segment")
+		}
+
+		if i == 0 {
+			// the first element in the list is the segment itself
+			newPath = updated
+		}
 	}
 
-	if err := prefillCountNetAdditions(newPath, updatedCountNetAdditions); err != nil {
-		return fmt.Errorf("prefill count net additions: %w", err)
-	}
-
-	exists := sg.makeExistsOnLower(old1)
-	seg, err := newSegment(newPath, sg.logger, sg.metrics, exists)
+	seg, err := newSegment(newPath, sg.logger, sg.metrics, nil)
 	if err != nil {
 		return errors.Wrap(err, "create new segment")
 	}

--- a/adapters/repos/db/lsmkv/segment_net_count_additions_test.go
+++ b/adapters/repos/db/lsmkv/segment_net_count_additions_test.go
@@ -33,6 +33,7 @@ func TestCreateCNAOnFlush(t *testing.T) {
 
 	b, err := NewBucket(ctx, dirName, "", logger, nil, WithStrategy(StrategyReplace))
 	require.Nil(t, err)
+	defer b.Shutdown(ctx)
 
 	require.Nil(t, b.Put([]byte("hello"), []byte("world")))
 	require.Nil(t, b.FlushMemtable(ctx))
@@ -54,6 +55,7 @@ func TestCreateCNAInit(t *testing.T) {
 
 	b, err := NewBucket(ctx, dirName, "", logger, nil, WithStrategy(StrategyReplace))
 	require.Nil(t, err)
+	defer b.Shutdown(ctx)
 
 	require.Nil(t, b.Put([]byte("hello"), []byte("world")))
 	require.Nil(t, b.FlushMemtable(ctx))
@@ -74,8 +76,9 @@ func TestCreateCNAInit(t *testing.T) {
 	require.Nil(t, b.Shutdown(ctx))
 
 	// now create a new bucket and assert that the file is re-created on init
-	_, err = NewBucket(ctx, dirName, "", logger, nil, WithStrategy(StrategyReplace))
+	b2, err := NewBucket(ctx, dirName, "", logger, nil, WithStrategy(StrategyReplace))
 	require.Nil(t, err)
+	defer b2.Shutdown(ctx)
 
 	files, err = os.ReadDir(dirName)
 	require.Nil(t, err)
@@ -93,6 +96,7 @@ func TestRepairCorruptedCNAOnInit(t *testing.T) {
 
 	b, err := NewBucket(ctx, dirName, "", logger, nil, WithStrategy(StrategyReplace))
 	require.Nil(t, err)
+	defer b.Shutdown(ctx)
 
 	require.Nil(t, b.Put([]byte("hello"), []byte("world")))
 	require.Nil(t, b.FlushMemtable(ctx))
@@ -109,6 +113,7 @@ func TestRepairCorruptedCNAOnInit(t *testing.T) {
 	// init, and the count matches
 	b2, err := NewBucket(ctx, dirName, "", logger, nil, WithStrategy(StrategyReplace))
 	require.Nil(t, err)
+	defer b2.Shutdown(ctx)
 
 	assert.Equal(t, 1, b2.Count())
 }

--- a/adapters/repos/db/lsmkv/segment_precompute_for_compaction.go
+++ b/adapters/repos/db/lsmkv/segment_precompute_for_compaction.go
@@ -1,0 +1,126 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2022 SeMI Technologies B.V. All rights reserved.
+//
+//  CONTACT: hello@semi.technology
+//
+
+package lsmkv
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+	"strings"
+	"syscall"
+
+	"github.com/pkg/errors"
+	"github.com/semi-technologies/weaviate/adapters/repos/db/lsmkv/segmentindex"
+	"github.com/willf/bloom"
+)
+
+// preComputeSegmentMeta has no side-effects for an already running store. As a
+// result this can be run without the need to obtain any locks. All files
+// created will have a .tmp suffix so they don't interfere with existing
+// segments that might have a similar name.
+func preComputeSegmentMeta(path string, updatedCountNetAdditions int) ([]string, error) {
+	out := []string{path}
+
+	if !strings.HasSuffix(path, ".tmp") {
+		return nil, fmt.Errorf("pre computing a segment expects a .tmp segment path")
+	}
+
+	file, err := os.Open(path)
+	if err != nil {
+		return nil, fmt.Errorf("open file: %w", err)
+	}
+
+	fileInfo, err := file.Stat()
+	if err != nil {
+		return nil, fmt.Errorf("stat file: %w", err)
+	}
+
+	content, err := syscall.Mmap(int(file.Fd()), 0, int(fileInfo.Size()), syscall.PROT_READ, syscall.MAP_SHARED)
+	if err != nil {
+		return nil, fmt.Errorf("mmap file: %w", err)
+	}
+
+	header, err := parseSegmentHeader(bytes.NewReader(content[:SegmentHeaderSize]))
+	if err != nil {
+		return nil, fmt.Errorf("parse header: %w", err)
+	}
+
+	switch header.strategy {
+	case SegmentStrategyReplace, SegmentStrategySetCollection,
+		SegmentStrategyMapCollection:
+	default:
+		return nil, fmt.Errorf("unsupported strategy in segment")
+	}
+
+	primaryIndex, err := header.PrimaryIndex(content)
+	if err != nil {
+		return nil, fmt.Errorf("extract primary index position: %w", err)
+	}
+
+	primaryDiskIndex := segmentindex.NewDiskTree(primaryIndex)
+
+	ind := &segment{
+		level: header.level,
+		// trim the .tmp suffix to make sure the naming rules for the files we
+		// pre-compute later on still apply they will in turn be suffixed with
+		// .tmp, but that is supposed to be the end of the file. if we didn't trim
+		// the path here, we would end up with filenames like
+		// segment.tmp.bloom.tmp, whereas we want to end up with segment.bloom.tmp
+		path:                strings.TrimSuffix(path, ".tmp"),
+		contents:            content,
+		version:             header.version,
+		secondaryIndexCount: header.secondaryIndices,
+		segmentStartPos:     header.indexStart,
+		segmentEndPos:       uint64(len(content)),
+		strategy:            header.strategy,
+		dataStartPos:        SegmentHeaderSize, // fixed value that's the same for all strategies
+		dataEndPos:          header.indexStart,
+		index:               primaryDiskIndex,
+	}
+
+	if ind.secondaryIndexCount > 0 {
+		ind.secondaryIndices = make([]diskIndex, ind.secondaryIndexCount)
+		ind.secondaryBloomFilters = make([]*bloom.BloomFilter, ind.secondaryIndexCount)
+		for i := range ind.secondaryIndices {
+			secondary, err := header.SecondaryIndex(content, uint16(i))
+			if err != nil {
+				return nil, errors.Wrapf(err, "get position for secondary index at %d", i)
+			}
+
+			ind.secondaryIndices[i] = segmentindex.NewDiskTree(secondary)
+			if err := ind.precomputeSecondaryBloomFilter(i); err != nil {
+				return nil, errors.Wrapf(err, "init bloom filter for secondary index at %d", i)
+			}
+
+			out = append(out, fmt.Sprintf("%s.tmp", ind.bloomFilterSecondaryPath(i)))
+		}
+	}
+
+	if err := ind.precomputeBloomFilter(); err != nil {
+		return nil, err
+	}
+
+	out = append(out, fmt.Sprintf("%s.tmp", ind.bloomFilterPath()))
+
+	if ind.strategy != SegmentStrategyReplace {
+		// only "replace" has count net additions, so we are done
+		return out, nil
+	}
+
+	cnaPath := fmt.Sprintf("%s.tmp", ind.countNetPath())
+	if err := storeCountNetOnDisk(cnaPath, updatedCountNetAdditions); err != nil {
+		return nil, err
+	}
+
+	out = append(out, cnaPath)
+	return out, nil
+}

--- a/adapters/repos/db/lsmkv/segment_precompute_for_compaction.go
+++ b/adapters/repos/db/lsmkv/segment_precompute_for_compaction.go
@@ -20,6 +20,7 @@ import (
 
 	"github.com/pkg/errors"
 	"github.com/semi-technologies/weaviate/adapters/repos/db/lsmkv/segmentindex"
+	"github.com/sirupsen/logrus"
 	"github.com/willf/bloom"
 )
 
@@ -27,7 +28,9 @@ import (
 // result this can be run without the need to obtain any locks. All files
 // created will have a .tmp suffix so they don't interfere with existing
 // segments that might have a similar name.
-func preComputeSegmentMeta(path string, updatedCountNetAdditions int) ([]string, error) {
+func preComputeSegmentMeta(path string, updatedCountNetAdditions int,
+	logger logrus.FieldLogger,
+) ([]string, error) {
 	out := []string{path}
 
 	if !strings.HasSuffix(path, ".tmp") {
@@ -85,6 +88,7 @@ func preComputeSegmentMeta(path string, updatedCountNetAdditions int) ([]string,
 		dataStartPos:        SegmentHeaderSize, // fixed value that's the same for all strategies
 		dataEndPos:          header.indexStart,
 		index:               primaryDiskIndex,
+		logger:              logger,
 	}
 
 	if ind.secondaryIndexCount > 0 {

--- a/adapters/repos/db/lsmkv/segment_precompute_for_compaction.go
+++ b/adapters/repos/db/lsmkv/segment_precompute_for_compaction.go
@@ -33,6 +33,9 @@ func preComputeSegmentMeta(path string, updatedCountNetAdditions int,
 ) ([]string, error) {
 	out := []string{path}
 
+	// as a guardrail validate that the segment is considered a .tmp segment.
+	// This way we can be sure that we're not accidentally operating on a live
+	// segment as the segment group completely ignores .tmp segment files
 	if !strings.HasSuffix(path, ".tmp") {
 		return nil, fmt.Errorf("pre computing a segment expects a .tmp segment path")
 	}

--- a/adapters/repos/db/lsmkv/segment_precompute_for_compation_test.go
+++ b/adapters/repos/db/lsmkv/segment_precompute_for_compation_test.go
@@ -1,0 +1,205 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2022 SeMI Technologies B.V. All rights reserved.
+//
+//  CONTACT: hello@semi.technology
+//
+
+package lsmkv
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path"
+	"strings"
+	"testing"
+
+	"github.com/sirupsen/logrus/hooks/test"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestPrecomputeSegmentMeta_Replace(t *testing.T) {
+	// first build a complete reference segment of which we can then strip its
+	// meta
+
+	ctx := context.Background()
+	dirName := t.TempDir()
+
+	logger, _ := test.NewNullLogger()
+
+	b, err := NewBucket(ctx, dirName, "", logger, nil,
+		WithStrategy(StrategyReplace),
+		WithSecondaryIndices(1))
+	require.Nil(t, err)
+	defer b.Shutdown(ctx)
+
+	require.Nil(t, b.Put([]byte("hello"), []byte("world"),
+		WithSecondaryKey(0, []byte("bonjour"))))
+	require.Nil(t, b.FlushMemtable(ctx))
+
+	for _, ext := range []string{".secondary.0.bloom", ".bloom", ".cna"} {
+		files, err := os.ReadDir(dirName)
+		require.Nil(t, err)
+		fname, ok := findFileWithExt(files, ext)
+		require.True(t, ok)
+
+		err = os.RemoveAll(path.Join(dirName, fname))
+		require.Nil(t, err)
+
+		files, err = os.ReadDir(dirName)
+		require.Nil(t, err)
+		_, ok = findFileWithExt(files, ext)
+		require.False(t, ok, "verify the file is really gone")
+	}
+
+	require.Nil(t, b.Shutdown(ctx))
+
+	// now identify the segment file and rename it to be a tmp file
+	files, err := os.ReadDir(dirName)
+	require.Nil(t, err)
+	fname, ok := findFileWithExt(files, ".db")
+	require.True(t, ok)
+
+	segmentTmp := path.Join(dirName, fmt.Sprintf("%s.tmp", fname))
+	err = os.Rename(path.Join(dirName, fname), segmentTmp)
+	require.Nil(t, err)
+
+	fileNames, err := preComputeSegmentMeta(segmentTmp, 1, logger)
+	require.Nil(t, err)
+
+	// there should be 4 files and they should all have a .tmp suffix:
+	// segment.db.tmp
+	// segment.cna.tmp
+	// segment.bloom.tmp
+	// segment.secondary.0.bloom.tmp
+	assert.Len(t, fileNames, 4)
+	for _, fName := range fileNames {
+		assert.True(t, strings.HasSuffix(fName, ".tmp"))
+	}
+}
+
+// Precomputing of segment is almost identical across segment types, however,
+// only Replace supports CNA, so we should test at least one other segment type
+// which does not support CNA, represented here by using the "Set" type
+func TestPrecomputeSegmentMeta_Set(t *testing.T) {
+	// first build a complete reference segment of which we can then strip its
+	// meta
+
+	ctx := context.Background()
+	dirName := t.TempDir()
+
+	logger, _ := test.NewNullLogger()
+
+	b, err := NewBucket(ctx, dirName, "", logger, nil,
+		WithStrategy(StrategySetCollection))
+	require.Nil(t, err)
+	defer b.Shutdown(ctx)
+
+	err = b.SetAdd([]byte("greetings"), [][]byte{[]byte("hello"), []byte("hola")})
+	require.Nil(t, err)
+	require.Nil(t, b.FlushMemtable(ctx))
+
+	files, err := os.ReadDir(dirName)
+	require.Nil(t, err)
+	fname, ok := findFileWithExt(files, ".bloom")
+	require.True(t, ok)
+
+	err = os.RemoveAll(path.Join(dirName, fname))
+	require.Nil(t, err)
+
+	// verify it's actually gone
+	files, err = os.ReadDir(dirName)
+	require.Nil(t, err)
+	_, ok = findFileWithExt(files, ".bloom")
+	require.False(t, ok)
+
+	require.Nil(t, b.Shutdown(ctx))
+
+	// now identify the segment file and rename it to be a tmp file
+	fname, ok = findFileWithExt(files, ".db")
+	require.True(t, ok)
+
+	segmentTmp := path.Join(dirName, fmt.Sprintf("%s.tmp", fname))
+	err = os.Rename(path.Join(dirName, fname), segmentTmp)
+	require.Nil(t, err)
+
+	fileNames, err := preComputeSegmentMeta(segmentTmp, 1, logger)
+	require.Nil(t, err)
+
+	// there should be 2 files and they should all have a .tmp suffix:
+	// segment.db.tmp
+	// segment.bloom.tmp
+	assert.Len(t, fileNames, 2)
+	for _, fName := range fileNames {
+		assert.True(t, strings.HasSuffix(fName, ".tmp"))
+	}
+}
+
+func TestPrecomputeSegmentMeta_UnhappyPaths(t *testing.T) {
+	t.Run("file without .tmp suffix", func(t *testing.T) {
+		logger, _ := test.NewNullLogger()
+		_, err := preComputeSegmentMeta("a-path-without-the-required-suffix", 7, logger)
+		require.NotNil(t, err)
+		assert.Contains(t, err.Error(), "expects a .tmp segment")
+	})
+
+	t.Run("file does not exist", func(t *testing.T) {
+		logger, _ := test.NewNullLogger()
+		_, err := preComputeSegmentMeta("i-dont-exist.tmp", 7, logger)
+		require.NotNil(t, err)
+		assert.Contains(t, err.Error(), "no such file or directory")
+	})
+
+	t.Run("segment header can't be parsed", func(t *testing.T) {
+		logger, _ := test.NewNullLogger()
+		dirName := t.TempDir()
+		segmentName := path.Join(dirName, "my-segment.tmp")
+
+		header := &segmentHeader{
+			version: 100, // only supported version as of writing this test is 0
+		}
+
+		f, err := os.Create(segmentName)
+		require.Nil(t, err)
+
+		_, err = header.WriteTo(f)
+		require.Nil(t, err)
+
+		err = f.Close()
+		require.Nil(t, err)
+
+		_, err = preComputeSegmentMeta(segmentName, 7, logger)
+		require.NotNil(t, err)
+		assert.Contains(t, err.Error(), "parse header")
+	})
+
+	t.Run("unsupported strategy", func(t *testing.T) {
+		logger, _ := test.NewNullLogger()
+		dirName := t.TempDir()
+		segmentName := path.Join(dirName, "my-segment.tmp")
+
+		header := &segmentHeader{
+			version:  0,
+			strategy: SegmentStrategy(100), // this strategy doesn't exist
+		}
+
+		f, err := os.Create(segmentName)
+		require.Nil(t, err)
+
+		_, err = header.WriteTo(f)
+		require.Nil(t, err)
+
+		err = f.Close()
+		require.Nil(t, err)
+
+		_, err = preComputeSegmentMeta(segmentName, 7, logger)
+		require.NotNil(t, err)
+		assert.Contains(t, err.Error(), "unsupported strategy")
+	})
+}

--- a/go.mod
+++ b/go.mod
@@ -32,10 +32,10 @@ require (
 	github.com/testcontainers/testcontainers-go v0.13.0
 	github.com/willf/bloom v2.0.3+incompatible
 	go.etcd.io/bbolt v1.3.5
-	golang.org/x/net v0.2.0
+	golang.org/x/net v0.4.0
 	golang.org/x/oauth2 v0.0.0-20220822191816-0ebed06d0094
 	golang.org/x/sync v0.0.0-20220601150217-0de741cfad7f
-	golang.org/x/sys v0.2.0
+	golang.org/x/sys v0.3.0
 	gonum.org/v1/gonum v0.9.1
 	google.golang.org/api v0.85.0
 	google.golang.org/grpc v1.47.0
@@ -45,7 +45,7 @@ require (
 require (
 	github.com/coreos/go-oidc/v3 v3.4.0
 	github.com/tailor-inc/graphql v0.1.0
-	golang.org/x/text v0.4.0
+	golang.org/x/text v0.5.0
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -1089,6 +1089,8 @@ golang.org/x/net v0.0.0-20220624214902-1bab6f366d9e/go.mod h1:XRhObCWvk6IyKnWLug
 golang.org/x/net v0.0.0-20220826154423-83b083e8dc8b/go.mod h1:YDH+HFinaLZZlnHAfSS6ZXJJ9M9t4Dl22yv3iI2vPwk=
 golang.org/x/net v0.2.0 h1:sZfSu1wtKLGlWI4ZZayP0ck9Y73K1ynO6gqzTdBVdPU=
 golang.org/x/net v0.2.0/go.mod h1:KqCZLdyyvdV855qA2rE3GC2aiw5xGR5TEjj8smXukLY=
+golang.org/x/net v0.4.0 h1:Q5QPcMlvfxFTAPV0+07Xz/MpK9NTXu2VDUuy0FeMfaU=
+golang.org/x/net v0.4.0/go.mod h1:MBQ8lrhLObU/6UmLb4fmbmk5OcyYmqtbGd/9yIeKjEE=
 golang.org/x/oauth2 v0.0.0-20180821212333-d2e6202438be/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=
 golang.org/x/oauth2 v0.0.0-20190226205417-e64efc72b421/go.mod h1:gOpvHmFTYa4IltrdGE7lF6nIHvwfUNPOp7c8zoXwtLw=
 golang.org/x/oauth2 v0.0.0-20190604053449-0f29369cfe45/go.mod h1:gOpvHmFTYa4IltrdGE7lF6nIHvwfUNPOp7c8zoXwtLw=
@@ -1237,6 +1239,8 @@ golang.org/x/sys v0.0.0-20220615213510-4f61da869c0c/go.mod h1:oPkhp1MJrh7nUepCBc
 golang.org/x/sys v0.0.0-20220728004956-3c1f35247d10/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.2.0 h1:ljd4t30dBnAvMZaQCevtY0xLLD0A+bRZXbgLMLU1F/A=
 golang.org/x/sys v0.2.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.3.0 h1:w8ZOecv6NaNa/zC8944JTU3vz4u6Lagfk4RPQxv92NQ=
+golang.org/x/sys v0.3.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/term v0.0.0-20201117132131-f5c789dd3221/go.mod h1:Nr5EML6q2oocZ2LXRh80K7BxOlk5/8JxuGnuhpl+muw=
 golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
 golang.org/x/term v0.0.0-20210927222741-03fcf44c2211/go.mod h1:jbD1KX2456YbFQfuXm/mYQcufACuNUgVhRMnK/tPxf8=
@@ -1251,6 +1255,8 @@ golang.org/x/text v0.3.6/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
 golang.org/x/text v0.3.7/go.mod h1:u+2+/6zg+i71rQMx5EYifcz6MCKuco9NR6JIITiCfzQ=
 golang.org/x/text v0.4.0 h1:BrVqGRd7+k1DiOgtnFvAkoQEWQvBc25ouMJM6429SFg=
 golang.org/x/text v0.4.0/go.mod h1:mrYo+phRRbMaCq/xk9113O4dZlRixOauAjOtrjsXDZ8=
+golang.org/x/text v0.5.0 h1:OLmvp0KP+FVG99Ct/qFiL/Fhk4zp4QQnZ7b2U+5piUM=
+golang.org/x/text v0.5.0/go.mod h1:mrYo+phRRbMaCq/xk9113O4dZlRixOauAjOtrjsXDZ8=
 golang.org/x/time v0.0.0-20180412165947-fbb02b2291d2/go.mod h1:tRJNPiyCQ0inRvYxbN9jk5I+vvW/OXSQhTDSoE431IQ=
 golang.org/x/time v0.0.0-20181108054448-85acf8d2951c/go.mod h1:tRJNPiyCQ0inRvYxbN9jk5I+vvW/OXSQhTDSoE431IQ=
 golang.org/x/time v0.0.0-20190308202827-9d24e82272b4/go.mod h1:tRJNPiyCQ0inRvYxbN9jk5I+vvW/OXSQhTDSoE431IQ=


### PR DESCRIPTION
### What's being changed:
* After segment compaction, the new segment requires a new bloom filter
* Previously, we were computing the bloom filter as part of the init
* However, during the init, we are already holding the `maintenanceLock` which blocks all operations
* Instead of doing the above, this is now split into two parts: First (without the need for a lock) all metadata including bloom filters is created for the new segment, then (while holding the lock) the segment is initialized with the precomputed metadata

#### Control (v1.16.6):
You can see a large spike of over 20s when importing >30M items
![image](https://user-images.githubusercontent.com/8974479/206698247-164ee3bd-ac9e-4ab1-a475-8353d73afccd.png)

#### This PR
The largest spike is now about 3s. Note that not all improvements between v1.16.6 are caused solely by this PR. Multiple other PRs were already merged, this is the final one. The improvement really shows the changes of all PRs, not just this one:
![image](https://user-images.githubusercontent.com/8974479/206698440-476d2975-f54a-45f5-be24-d25ad12adfc8.png)


### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [x] Chaos pipeline run or not necessary. Link to pipeline: https://github.com/semi-technologies/weaviate-chaos-engineering/actions/runs/3675768221/jobs/6215593363
- [x] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.
