### PR TITLE
Extend scaling client's endpoints with retry strategy

### DIFF
--- a/adapters/clients/client.go
+++ b/adapters/clients/client.go
@@ -1,3 +1,14 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2022 SeMI Technologies B.V. All rights reserved.
+//
+//  CONTACT: hello@semi.technology
+//
+
 package clients
 
 import (

--- a/adapters/clients/client.go
+++ b/adapters/clients/client.go
@@ -1,0 +1,62 @@
+package clients
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"time"
+)
+
+type retryClient struct {
+	client *http.Client
+	*retryer
+}
+
+type retryer struct {
+	minBackOff  time.Duration
+	maxBackOff  time.Duration
+	timeoutUnit time.Duration
+}
+
+func newRetryer() *retryer {
+	return &retryer{
+		minBackOff:  time.Millisecond * 200,
+		maxBackOff:  time.Second * 30,
+		timeoutUnit: time.Second, // used by unit tests
+	}
+}
+
+// WithMin set minimum delay
+func (r *retryer) WithMin(d time.Duration) *retryer {
+	r.minBackOff = d
+	return r
+}
+
+// WithMax sets maximum delay
+func (r *retryer) WithMax(d time.Duration) *retryer {
+	r.maxBackOff = d
+	return r
+}
+
+func (r *retryer) retry(ctx context.Context, n int, work func(context.Context) (bool, error)) error {
+	delay := r.minBackOff
+	for {
+		keepTrying, err := work(ctx)
+		if !keepTrying || n < 1 || err == nil {
+			return err
+		}
+
+		n--
+		if delay = backOff(delay); delay > r.maxBackOff {
+			delay = r.maxBackOff
+		}
+		timer := time.NewTimer(delay)
+		select {
+		case <-ctx.Done():
+			timer.Stop()
+			return fmt.Errorf("%v: %w", err, ctx.Err())
+		case <-timer.C:
+		}
+		timer.Stop()
+	}
+}

--- a/adapters/clients/remote_index.go
+++ b/adapters/clients/remote_index.go
@@ -34,12 +34,10 @@ import (
 	"github.com/semi-technologies/weaviate/usecases/sharding"
 )
 
-type RemoteIndex struct {
-	client *http.Client
-}
+type RemoteIndex retryClient
 
 func NewRemoteIndex(httpClient *http.Client) *RemoteIndex {
-	return &RemoteIndex{client: httpClient}
+	return &RemoteIndex{client: httpClient, retryer: newRetryer()}
 }
 
 func (c *RemoteIndex) PutObject(ctx context.Context, hostName, indexName,
@@ -612,6 +610,8 @@ func (c *RemoteIndex) DeleteObjectBatch(ctx context.Context, hostName, indexName
 func (c *RemoteIndex) GetShardStatus(ctx context.Context,
 	hostName, indexName, shardName string,
 ) (string, error) {
+	//TODO improve path
+
 	path := fmt.Sprintf("/indices/%s/shards/%s/_status", indexName, shardName)
 	method := http.MethodGet
 	url := url.URL{Scheme: "http", Host: hostName, Path: path}
@@ -620,35 +620,37 @@ func (c *RemoteIndex) GetShardStatus(ctx context.Context,
 	if err != nil {
 		return "", errors.Wrap(err, "open http request")
 	}
-
+	var status string
 	clusterapi.IndicesPayloads.GetShardStatusParams.SetContentTypeHeaderReq(req)
-	res, err := c.client.Do(req)
-	if err != nil {
-		return "", errors.Wrap(err, "send http request")
-	}
+	try := func(ctx context.Context) (bool, error) {
+		res, err := c.client.Do(req)
+		if err != nil {
+			return ctx.Err() == nil, fmt.Errorf("connect: %w", err)
+		}
+		defer res.Body.Close()
 
-	defer res.Body.Close()
-	if res.StatusCode != http.StatusOK {
-		body, _ := io.ReadAll(res.Body)
-		return "", errors.Errorf("unexpected status code %d (%s)", res.StatusCode,
-			body)
-	}
+		if code := res.StatusCode; code != http.StatusOK {
+			body, _ := io.ReadAll(res.Body)
+			shouldRetry := (code == http.StatusInternalServerError || code == http.StatusTooManyRequests)
+			return shouldRetry, fmt.Errorf("status code: %v body: (%s)", code, body)
+		}
+		resBytes, err := io.ReadAll(res.Body)
+		if err != nil {
+			return false, errors.Wrap(err, "read body")
+		}
 
-	resBytes, err := io.ReadAll(res.Body)
-	if err != nil {
-		return "", errors.Wrap(err, "read body")
-	}
+		ct, ok := clusterapi.IndicesPayloads.GetShardStatusResults.CheckContentTypeHeader(res)
+		if !ok {
+			return false, errors.Errorf("unexpected content type: %s", ct)
+		}
 
-	ct, ok := clusterapi.IndicesPayloads.GetShardStatusResults.CheckContentTypeHeader(res)
-	if !ok {
-		return "", errors.Errorf("unexpected content type: %s", ct)
+		status, err = clusterapi.IndicesPayloads.GetShardStatusResults.Unmarshal(resBytes)
+		if err != nil {
+			return false, errors.Wrap(err, "unmarshal body")
+		}
+		return false, nil
 	}
-
-	status, err := clusterapi.IndicesPayloads.GetShardStatusResults.Unmarshal(resBytes)
-	if err != nil {
-		return "", errors.Wrap(err, "unmarshal body")
-	}
-	return status, nil
+	return status, c.retry(ctx, 5, try)
 }
 
 func (c *RemoteIndex) UpdateShardStatus(ctx context.Context, hostName, indexName, shardName,
@@ -658,41 +660,46 @@ func (c *RemoteIndex) UpdateShardStatus(ctx context.Context, hostName, indexName
 	if err != nil {
 		return errors.Wrap(err, "marshal request payload")
 	}
-
+	//TODO improve path
 	path := fmt.Sprintf("/indices/%s/shards/%s/_status", indexName, shardName)
 	method := http.MethodPost
 	url := url.URL{Scheme: "http", Host: hostName, Path: path}
 
-	req, err := http.NewRequestWithContext(ctx, method, url.String(),
-		bytes.NewReader(paramsBytes))
-	if err != nil {
-		return errors.Wrap(err, "open http request")
+	try := func(ctx context.Context) (bool, error) {
+		req, err := http.NewRequestWithContext(ctx, method, url.String(),
+			bytes.NewReader(paramsBytes))
+		if err != nil {
+			return false, fmt.Errorf("create http request: %w", err)
+		}
+		clusterapi.IndicesPayloads.UpdateShardStatusParams.SetContentTypeHeaderReq(req)
+
+		res, err := c.client.Do(req)
+		if err != nil {
+			return ctx.Err() == nil, fmt.Errorf("connect: %w", err)
+		}
+		defer res.Body.Close()
+
+		if code := res.StatusCode; code != http.StatusOK {
+			body, _ := io.ReadAll(res.Body)
+			shouldRetry := (code == http.StatusInternalServerError || code == http.StatusTooManyRequests)
+			return shouldRetry, fmt.Errorf("status code: %v body: (%s)", code, body)
+		}
+
+		// TODO: remove it since we are not using the content in any way.
+		// Change server to code
+		// _, err = io.ReadAll(res.Body)
+		// if err != nil {
+		// 	return false, fmt.Errorf("read body: %w", err)
+		// }
+
+		// ct, ok := clusterapi.IndicesPayloads.UpdateShardsStatusResults.CheckContentTypeHeader(res)
+		// if !ok {
+		// 	return false, errors.Errorf("unexpected content type: %s", ct)
+		// }
+		return false, nil
 	}
 
-	clusterapi.IndicesPayloads.UpdateShardStatusParams.SetContentTypeHeaderReq(req)
-	res, err := c.client.Do(req)
-	if err != nil {
-		return errors.Wrap(err, "send http request")
-	}
-
-	defer res.Body.Close()
-	if res.StatusCode != http.StatusOK {
-		body, _ := io.ReadAll(res.Body)
-		return errors.Errorf("unexpected status code %d (%s)", res.StatusCode,
-			body)
-	}
-
-	_, err = io.ReadAll(res.Body)
-	if err != nil {
-		return errors.Wrap(err, "read body")
-	}
-
-	ct, ok := clusterapi.IndicesPayloads.UpdateShardsStatusResults.CheckContentTypeHeader(res)
-	if !ok {
-		return errors.Errorf("unexpected content type: %s", ct)
-	}
-
-	return nil
+	return c.retry(ctx, 7, try)
 }
 
 func (c *RemoteIndex) PutFile(ctx context.Context, hostName, indexName,
@@ -707,23 +714,27 @@ func (c *RemoteIndex) PutFile(ctx context.Context, hostName, indexName,
 
 	req, err := http.NewRequestWithContext(ctx, method, url.String(), payload)
 	if err != nil {
-		return errors.Wrap(err, "open http request")
+		return fmt.Errorf("create http request: %w", err)
 	}
 
 	clusterapi.IndicesPayloads.ShardFiles.SetContentTypeHeaderReq(req)
-	res, err := c.client.Do(req)
-	if err != nil {
-		return errors.Wrap(err, "send http request")
+	try := func(ctx context.Context) (bool, error) {
+		res, err := c.client.Do(req)
+		if err != nil {
+			return ctx.Err() == nil, fmt.Errorf("connect: %w", err)
+		}
+		defer res.Body.Close()
+
+		if code := res.StatusCode; code != http.StatusNoContent {
+			// TODO: make request retryable before activating the line below
+			shouldRetry := false //(code == http.StatusInternalServerError || code == http.StatusTooManyRequests)
+			body, _ := io.ReadAll(res.Body)
+			return shouldRetry, fmt.Errorf("status code: %v body: (%s)", code, body)
+		}
+		return false, nil
 	}
 
-	defer res.Body.Close()
-	if res.StatusCode != http.StatusNoContent {
-		body, _ := io.ReadAll(res.Body)
-		return errors.Errorf("unexpected status code %d (%s)", res.StatusCode,
-			body)
-	}
-
-	return nil
+	return c.retry(ctx, 7, try)
 }
 
 func (c *RemoteIndex) CreateShard(ctx context.Context,
@@ -736,27 +747,31 @@ func (c *RemoteIndex) CreateShard(ctx context.Context,
 
 	req, err := http.NewRequestWithContext(ctx, method, url.String(), nil)
 	if err != nil {
-		return errors.Wrap(err, "open http request")
+		return fmt.Errorf("create http request: %w", err)
+	}
+	try := func(ctx context.Context) (bool, error) {
+		res, err := c.client.Do(req)
+		if err != nil {
+			return ctx.Err() == nil, fmt.Errorf("connect: %w", err)
+		}
+		defer res.Body.Close()
+
+		if code := res.StatusCode; code != http.StatusCreated {
+			shouldRetry := (code == http.StatusInternalServerError || code == http.StatusTooManyRequests)
+			body, _ := io.ReadAll(res.Body)
+			return shouldRetry, fmt.Errorf("status code: %v body: (%s)", code, body)
+		}
+		return false, nil
 	}
 
-	res, err := c.client.Do(req)
-	if err != nil {
-		return errors.Wrap(err, "send http request")
-	}
-
-	defer res.Body.Close()
-	if res.StatusCode != http.StatusCreated {
-		body, _ := io.ReadAll(res.Body)
-		return errors.Errorf("unexpected status code %d (%s)", res.StatusCode,
-			body)
-	}
-
-	return nil
+	return c.retry(ctx, 7, try)
 }
 
 func (c *RemoteIndex) ReinitShard(ctx context.Context,
 	hostName, indexName, shardName string,
 ) error {
+	//TODO improve path
+
 	path := fmt.Sprintf("/indices/%s/shards/%s/_reinit", indexName, shardName)
 
 	method := http.MethodPut
@@ -764,28 +779,31 @@ func (c *RemoteIndex) ReinitShard(ctx context.Context,
 
 	req, err := http.NewRequestWithContext(ctx, method, url.String(), nil)
 	if err != nil {
-		return errors.Wrap(err, "open http request")
+		return fmt.Errorf("create http request: %w", err)
+	}
+	try := func(ctx context.Context) (bool, error) {
+		res, err := c.client.Do(req)
+		if err != nil {
+			return ctx.Err() == nil, fmt.Errorf("connect: %w", err)
+		}
+		defer res.Body.Close()
+
+		if code := res.StatusCode; code != http.StatusNoContent {
+			shouldRetry := (code == http.StatusInternalServerError || code == http.StatusTooManyRequests)
+			body, _ := io.ReadAll(res.Body)
+			return shouldRetry, fmt.Errorf("status code: %v body: (%s)", code, body)
+
+		}
+		return false, nil
 	}
 
-	res, err := c.client.Do(req)
-	if err != nil {
-		return errors.Wrap(err, "send http request")
-	}
-
-	defer res.Body.Close()
-	if res.StatusCode != http.StatusNoContent {
-		body, _ := io.ReadAll(res.Body)
-		return errors.Errorf("unexpected status code %d (%s)", res.StatusCode,
-			body)
-	}
-
-	return nil
+	return c.retry(ctx, 7, try)
 }
 
 func (c *RemoteIndex) IncreaseReplicationFactor(ctx context.Context,
 	hostName, indexName string, ssBefore, ssAfter *sharding.State,
 ) error {
-	path := fmt.Sprintf("/replicas/indices/%s/replication-factor/_increase", indexName)
+	path := fmt.Sprintf("/replicas/indices/%s/replication-factor:increase", indexName)
 
 	method := http.MethodPut
 	url := url.URL{Scheme: "http", Host: hostName, Path: path}
@@ -794,23 +812,24 @@ func (c *RemoteIndex) IncreaseReplicationFactor(ctx context.Context,
 	if err != nil {
 		return err
 	}
+	try := func(ctx context.Context) (bool, error) {
+		req, err := http.NewRequestWithContext(ctx, method, url.String(), bytes.NewReader(body))
+		if err != nil {
+			return false, fmt.Errorf("create http request: %w", err)
+		}
 
-	req, err := http.NewRequestWithContext(ctx, method, url.String(), bytes.NewReader(body))
-	if err != nil {
-		return errors.Wrap(err, "open http request")
+		res, err := c.client.Do(req)
+		if err != nil {
+			return ctx.Err() == nil, fmt.Errorf("connect: %w", err)
+		}
+		defer res.Body.Close()
+
+		if code := res.StatusCode; code != http.StatusNoContent {
+			body, _ := io.ReadAll(res.Body)
+			shouldRetry := (code == http.StatusInternalServerError || code == http.StatusTooManyRequests)
+			return shouldRetry, fmt.Errorf("status code: %v body: (%s)", code, body)
+		}
+		return false, nil
 	}
-
-	res, err := c.client.Do(req)
-	if err != nil {
-		return errors.Wrap(err, "send http request")
-	}
-
-	defer res.Body.Close()
-	if res.StatusCode != http.StatusNoContent {
-		body, _ := io.ReadAll(res.Body)
-		return errors.Errorf("unexpected status code %d (%s)", res.StatusCode,
-			body)
-	}
-
-	return nil
+	return c.retry(ctx, 7, try)
 }

--- a/adapters/clients/remote_index.go
+++ b/adapters/clients/remote_index.go
@@ -610,9 +610,7 @@ func (c *RemoteIndex) DeleteObjectBatch(ctx context.Context, hostName, indexName
 func (c *RemoteIndex) GetShardStatus(ctx context.Context,
 	hostName, indexName, shardName string,
 ) (string, error) {
-	// TODO improve path
-
-	path := fmt.Sprintf("/indices/%s/shards/%s/_status", indexName, shardName)
+	path := fmt.Sprintf("/indices/%s/shards/%s/status", indexName, shardName)
 	method := http.MethodGet
 	url := url.URL{Scheme: "http", Host: hostName, Path: path}
 
@@ -660,8 +658,7 @@ func (c *RemoteIndex) UpdateShardStatus(ctx context.Context, hostName, indexName
 	if err != nil {
 		return errors.Wrap(err, "marshal request payload")
 	}
-	// TODO improve path
-	path := fmt.Sprintf("/indices/%s/shards/%s/_status", indexName, shardName)
+	path := fmt.Sprintf("/indices/%s/shards/%s/status", indexName, shardName)
 	method := http.MethodPost
 	url := url.URL{Scheme: "http", Host: hostName, Path: path}
 
@@ -685,17 +682,6 @@ func (c *RemoteIndex) UpdateShardStatus(ctx context.Context, hostName, indexName
 			return shouldRetry, fmt.Errorf("status code: %v body: (%s)", code, body)
 		}
 
-		// TODO: remove it since we are not using the content in any way.
-		// Change server to code
-		// _, err = io.ReadAll(res.Body)
-		// if err != nil {
-		// 	return false, fmt.Errorf("read body: %w", err)
-		// }
-
-		// ct, ok := clusterapi.IndicesPayloads.UpdateShardsStatusResults.CheckContentTypeHeader(res)
-		// if !ok {
-		// 	return false, errors.Errorf("unexpected content type: %s", ct)
-		// }
 		return false, nil
 	}
 
@@ -768,12 +754,10 @@ func (c *RemoteIndex) CreateShard(ctx context.Context,
 	return c.retry(ctx, 7, try)
 }
 
-func (c *RemoteIndex) ReinitShard(ctx context.Context,
+func (c *RemoteIndex) ReInitShard(ctx context.Context,
 	hostName, indexName, shardName string,
 ) error {
-	// TODO improve path
-
-	path := fmt.Sprintf("/indices/%s/shards/%s/_reinit", indexName, shardName)
+	path := fmt.Sprintf("/indices/%s/shards/%s:reinit", indexName, shardName)
 
 	method := http.MethodPut
 	url := url.URL{Scheme: "http", Host: hostName, Path: path}

--- a/adapters/clients/remote_index_test.go
+++ b/adapters/clients/remote_index_test.go
@@ -1,3 +1,14 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2022 SeMI Technologies B.V. All rights reserved.
+//
+//  CONTACT: hello@semi.technology
+//
+
 //	_       _
 //
 // __      _____  __ ___   ___  __ _| |_ ___
@@ -60,13 +71,13 @@ func TestRemoteIndexReInitShardIn(t *testing.T) {
 	t.Parallel()
 
 	ctx := context.Background()
-	path := "/indices/C1/shards/S1/_reinit"
+	path := "/indices/C1/shards/S1:reinit"
 	fs := newFakeRemoteIndexServer(t, http.MethodPut, path)
 	ts := fs.server(t)
 	defer ts.Close()
 	client := newRemoteIndex(ts.Client())
 	t.Run("ConnectionError", func(t *testing.T) {
-		err := client.ReinitShard(ctx, "", "C1", "S1")
+		err := client.ReInitShard(ctx, "", "C1", "S1")
 		assert.NotNil(t, err)
 		assert.Contains(t, err.Error(), "connect")
 	})
@@ -82,7 +93,7 @@ func TestRemoteIndexReInitShardIn(t *testing.T) {
 		n++
 	}
 	t.Run("Success", func(t *testing.T) {
-		err := client.ReinitShard(ctx, fs.host, "C1", "S1")
+		err := client.ReInitShard(ctx, fs.host, "C1", "S1")
 		assert.Nil(t, err)
 	})
 }
@@ -122,7 +133,7 @@ func TestRemoteIndexUpdateShardStatus(t *testing.T) {
 	t.Parallel()
 
 	ctx := context.Background()
-	path := "/indices/C1/shards/S1/_status"
+	path := "/indices/C1/shards/S1/status"
 	fs := newFakeRemoteIndexServer(t, http.MethodPost, path)
 	ts := fs.server(t)
 	defer ts.Close()
@@ -151,7 +162,7 @@ func TestRemoteIndexShardStatus(t *testing.T) {
 	t.Parallel()
 	var (
 		ctx    = context.Background()
-		path   = "/indices/C1/shards/S1/_status"
+		path   = "/indices/C1/shards/S1/status"
 		fs     = newFakeRemoteIndexServer(t, http.MethodGet, path)
 		Status = "READONLY"
 	)

--- a/adapters/clients/remote_index_test.go
+++ b/adapters/clients/remote_index_test.go
@@ -1,0 +1,258 @@
+//	_       _
+//
+// __      _____  __ ___   ___  __ _| |_ ___
+//
+//	\ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//	 \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//	  \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//	 Copyright © 2016 - 2022 SeMI Technologies B.V. All rights reserved.
+//
+//	 CONTACT: hello@semi.technology
+package clients
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/semi-technologies/weaviate/adapters/handlers/rest/clusterapi"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestRemoteIndexIncreaseRF(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	path := "/replicas/indices/C1/replication-factor:increase"
+	fs := newFakeRemoteIndexServer(t, http.MethodPut, path)
+	ts := fs.server(t)
+	defer ts.Close()
+	client := newRemoteIndex(ts.Client())
+	t.Run("ConnectionError", func(t *testing.T) {
+		err := client.IncreaseReplicationFactor(ctx, "", "C1", nil, nil)
+		assert.NotNil(t, err)
+		assert.Contains(t, err.Error(), "connect")
+	})
+	n := 0
+	fs.doAfter = func(w http.ResponseWriter, r *http.Request) {
+		if n == 0 {
+			w.WriteHeader(http.StatusInternalServerError)
+		} else if n == 1 {
+			w.WriteHeader(http.StatusTooManyRequests)
+		} else {
+			w.WriteHeader(http.StatusNoContent)
+		}
+		n++
+	}
+	t.Run("Success", func(t *testing.T) {
+		err := client.IncreaseReplicationFactor(ctx, fs.host, "C1", nil, nil)
+		assert.Nil(t, err)
+	})
+}
+
+func TestRemoteIndexReInitShardIn(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	path := "/indices/C1/shards/S1/_reinit"
+	fs := newFakeRemoteIndexServer(t, http.MethodPut, path)
+	ts := fs.server(t)
+	defer ts.Close()
+	client := newRemoteIndex(ts.Client())
+	t.Run("ConnectionError", func(t *testing.T) {
+		err := client.ReinitShard(ctx, "", "C1", "S1")
+		assert.NotNil(t, err)
+		assert.Contains(t, err.Error(), "connect")
+	})
+	n := 0
+	fs.doAfter = func(w http.ResponseWriter, r *http.Request) {
+		if n == 0 {
+			w.WriteHeader(http.StatusInternalServerError)
+		} else if n == 1 {
+			w.WriteHeader(http.StatusTooManyRequests)
+		} else {
+			w.WriteHeader(http.StatusNoContent)
+		}
+		n++
+	}
+	t.Run("Success", func(t *testing.T) {
+		err := client.ReinitShard(ctx, fs.host, "C1", "S1")
+		assert.Nil(t, err)
+	})
+}
+
+func TestRemoteIndexCreateShard(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	path := "/indices/C1/shards/S1"
+	fs := newFakeRemoteIndexServer(t, http.MethodPost, path)
+	ts := fs.server(t)
+	defer ts.Close()
+	client := newRemoteIndex(ts.Client())
+	t.Run("ConnectionError", func(t *testing.T) {
+		err := client.CreateShard(ctx, "", "C1", "S1")
+		assert.NotNil(t, err)
+		assert.Contains(t, err.Error(), "connect")
+	})
+	n := 0
+	fs.doAfter = func(w http.ResponseWriter, r *http.Request) {
+		if n == 0 {
+			w.WriteHeader(http.StatusInternalServerError)
+		} else if n == 1 {
+			w.WriteHeader(http.StatusTooManyRequests)
+		} else {
+			w.WriteHeader(http.StatusCreated)
+		}
+		n++
+	}
+	t.Run("Success", func(t *testing.T) {
+		err := client.CreateShard(ctx, fs.host, "C1", "S1")
+		assert.Nil(t, err)
+	})
+}
+
+func TestRemoteIndexUpdateShardStatus(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	path := "/indices/C1/shards/S1/_status"
+	fs := newFakeRemoteIndexServer(t, http.MethodPost, path)
+	ts := fs.server(t)
+	defer ts.Close()
+	client := newRemoteIndex(ts.Client())
+	t.Run("ConnectionError", func(t *testing.T) {
+		err := client.UpdateShardStatus(ctx, "", "C1", "S1", "NewStatus")
+		assert.NotNil(t, err)
+		assert.Contains(t, err.Error(), "connect")
+	})
+	n := 0
+	fs.doAfter = func(w http.ResponseWriter, r *http.Request) {
+		if n == 0 {
+			w.WriteHeader(http.StatusInternalServerError)
+		} else if n == 1 {
+			w.WriteHeader(http.StatusTooManyRequests)
+		}
+		n++
+	}
+	t.Run("Success", func(t *testing.T) {
+		err := client.UpdateShardStatus(ctx, fs.host, "C1", "S1", "NewStatus")
+		assert.Nil(t, err)
+	})
+}
+
+func TestRemoteIndexShardStatus(t *testing.T) {
+	t.Parallel()
+	var (
+		ctx    = context.Background()
+		path   = "/indices/C1/shards/S1/_status"
+		fs     = newFakeRemoteIndexServer(t, http.MethodGet, path)
+		Status = "READONLY"
+	)
+	ts := fs.server(t)
+	defer ts.Close()
+	client := newRemoteIndex(ts.Client())
+	t.Run("ConnectionError", func(t *testing.T) {
+		_, err := client.GetShardStatus(ctx, "", "C1", "S1")
+		assert.NotNil(t, err)
+		assert.Contains(t, err.Error(), "connect")
+	})
+	n := 0
+	fs.doAfter = func(w http.ResponseWriter, r *http.Request) {
+		if n == 0 {
+			w.WriteHeader(http.StatusInternalServerError)
+		} else if n == 1 {
+			w.WriteHeader(http.StatusTooManyRequests)
+		} else if n == 2 {
+			w.Header().Set("content-type", "any")
+		} else if n == 3 {
+			clusterapi.IndicesPayloads.GetShardStatusResults.SetContentTypeHeader(w)
+		} else {
+			clusterapi.IndicesPayloads.GetShardStatusResults.SetContentTypeHeader(w)
+			bytes, _ := clusterapi.IndicesPayloads.GetShardStatusResults.Marshal(Status)
+			w.Write(bytes)
+		}
+		n++
+	}
+
+	t.Run("ContentType", func(t *testing.T) {
+		_, err := client.GetShardStatus(ctx, fs.host, "C1", "S1")
+		assert.NotNil(t, err)
+	})
+	t.Run("Status", func(t *testing.T) {
+		_, err := client.GetShardStatus(ctx, fs.host, "C1", "S1")
+		assert.NotNil(t, err)
+	})
+	t.Run("Success", func(t *testing.T) {
+		st, err := client.GetShardStatus(ctx, fs.host, "C1", "S1")
+		assert.Nil(t, err)
+		assert.Equal(t, "READONLY", st)
+	})
+}
+
+func newRemoteIndex(httpClient *http.Client) *RemoteIndex {
+	ri := NewRemoteIndex(httpClient)
+	ri.minBackOff = time.Millisecond * 1
+	ri.maxBackOff = time.Millisecond * 10
+	ri.timeoutUnit = time.Millisecond * 20
+	return ri
+}
+
+type fakeRemoteIndexServer struct {
+	method   string
+	path     string
+	host     string
+	doBefore func(w http.ResponseWriter, r *http.Request) error
+	doAfter  func(w http.ResponseWriter, r *http.Request)
+}
+
+func newFakeRemoteIndexServer(t *testing.T, method, path string) *fakeRemoteIndexServer {
+	f := &fakeRemoteIndexServer{
+		method: method,
+		path:   path,
+	}
+	f.doBefore = func(w http.ResponseWriter, r *http.Request) error {
+		if r.Method != f.method {
+			w.WriteHeader(http.StatusBadRequest)
+			return fmt.Errorf("method want %s got %s", method, r.Method)
+		}
+		if f.path != r.URL.Path {
+			w.WriteHeader(http.StatusBadRequest)
+			return fmt.Errorf("path want %s got %s", path, r.URL.Path)
+		}
+		return nil
+	}
+	return f
+}
+
+func (f *fakeRemoteIndexServer) server(t *testing.T) *httptest.Server {
+	if f.doBefore == nil {
+		f.doBefore = func(w http.ResponseWriter, r *http.Request) error {
+			if r.Method != f.method {
+				w.WriteHeader(http.StatusBadRequest)
+				return fmt.Errorf("method want %s got %s", f.method, r.Method)
+			}
+			if f.path != r.URL.Path {
+				w.WriteHeader(http.StatusBadRequest)
+				return fmt.Errorf("path want %s got %s", f.path, r.URL.Path)
+			}
+			return nil
+		}
+	}
+	handler := func(w http.ResponseWriter, r *http.Request) {
+		if err := f.doBefore(w, r); err != nil {
+			t.Error(err)
+			return
+		}
+		if f.doAfter != nil {
+			f.doAfter(w, r)
+		}
+	}
+	serv := httptest.NewServer(http.HandlerFunc(handler))
+	f.host = serv.URL[7:]
+	return serv
+}

--- a/adapters/clients/replication_test.go
+++ b/adapters/clients/replication_test.go
@@ -47,7 +47,7 @@ type fakeServer struct {
 	host           string
 }
 
-func newFakeServer(t *testing.T, method, path string) *fakeServer {
+func newFakeReplicationServer(t *testing.T, method, path string) *fakeServer {
 	return &fakeServer{
 		method:         method,
 		path:           path,
@@ -105,7 +105,7 @@ func TestReplicationPutObject(t *testing.T) {
 	t.Parallel()
 
 	ctx := context.Background()
-	f := newFakeServer(t, http.MethodPost, "/replicas/indices/C1/shards/S1/objects")
+	f := newFakeReplicationServer(t, http.MethodPost, "/replicas/indices/C1/shards/S1/objects")
 	ts := f.server(t)
 	defer ts.Close()
 
@@ -149,7 +149,7 @@ func TestReplicationDeleteObject(t *testing.T) {
 	ctx := context.Background()
 	uuid := UUID1
 	path := "/replicas/indices/C1/shards/S1/objects/" + uuid.String()
-	fs := newFakeServer(t, http.MethodDelete, path)
+	fs := newFakeReplicationServer(t, http.MethodDelete, path)
 	ts := fs.server(t)
 	defer ts.Close()
 
@@ -182,7 +182,7 @@ func TestReplicationDeleteObject(t *testing.T) {
 func TestReplicationPutObjects(t *testing.T) {
 	t.Parallel()
 	ctx := context.Background()
-	fs := newFakeServer(t, http.MethodPost, "/replicas/indices/C1/shards/S1/objects")
+	fs := newFakeReplicationServer(t, http.MethodPost, "/replicas/indices/C1/shards/S1/objects")
 	fs.RequestError.Errors = append(fs.RequestError.Errors, replica.Error{Msg: "error2"})
 	ts := fs.server(t)
 	defer ts.Close()
@@ -229,7 +229,7 @@ func TestReplicationMergeObject(t *testing.T) {
 	t.Parallel()
 	ctx := context.Background()
 	uuid := UUID1
-	f := newFakeServer(t, http.MethodPatch, "/replicas/indices/C1/shards/S1/objects/"+uuid.String())
+	f := newFakeReplicationServer(t, http.MethodPatch, "/replicas/indices/C1/shards/S1/objects/"+uuid.String())
 	ts := f.server(t)
 	defer ts.Close()
 
@@ -264,7 +264,7 @@ func TestReplicationAddReferences(t *testing.T) {
 	t.Parallel()
 
 	ctx := context.Background()
-	fs := newFakeServer(t, http.MethodPost, "/replicas/indices/C1/shards/S1/objects/references")
+	fs := newFakeReplicationServer(t, http.MethodPost, "/replicas/indices/C1/shards/S1/objects/references")
 	fs.RequestError.Errors = append(fs.RequestError.Errors, replica.Error{Msg: "error2"})
 	ts := fs.server(t)
 	defer ts.Close()
@@ -300,7 +300,7 @@ func TestReplicationDeleteObjects(t *testing.T) {
 	t.Parallel()
 
 	ctx := context.Background()
-	fs := newFakeServer(t, http.MethodDelete, "/replicas/indices/C1/shards/S1/objects")
+	fs := newFakeReplicationServer(t, http.MethodDelete, "/replicas/indices/C1/shards/S1/objects")
 	fs.RequestError.Errors = append(fs.RequestError.Errors, replica.Error{Msg: "error2"})
 	ts := fs.server(t)
 	defer ts.Close()
@@ -337,7 +337,7 @@ func TestReplicationAbort(t *testing.T) {
 
 	ctx := context.Background()
 	path := "/replicas/indices/C1/shards/S1:abort"
-	fs := newFakeServer(t, http.MethodPost, path)
+	fs := newFakeReplicationServer(t, http.MethodPost, path)
 	ts := fs.server(t)
 	defer ts.Close()
 	client := newReplicationClient(ts.Client())
@@ -348,7 +348,6 @@ func TestReplicationAbort(t *testing.T) {
 		_, err := client.Abort(ctx, "", "C1", "S1", "")
 		assert.NotNil(t, err)
 		assert.Contains(t, err.Error(), "connect")
-		assert.ErrorIs(t, err, context.DeadlineExceeded)
 	})
 
 	t.Run("Error", func(t *testing.T) {
@@ -375,7 +374,7 @@ func TestReplicationCommit(t *testing.T) {
 
 	ctx := context.Background()
 	path := "/replicas/indices/C1/shards/S1:commit"
-	fs := newFakeServer(t, http.MethodPost, path)
+	fs := newFakeReplicationServer(t, http.MethodPost, path)
 	ts := fs.server(t)
 	defer ts.Close()
 	resp := replica.SimpleResponse{}

--- a/adapters/handlers/rest/clusterapi/indices.go
+++ b/adapters/handlers/rest/clusterapi/indices.go
@@ -59,13 +59,13 @@ const (
 	urlPatternReferences = `\/indices\/([A-Za-z0-9_+-]+)` +
 		`\/shards\/([A-Za-z0-9]+)\/references`
 	urlPatternShardsStatus = `\/indices\/([A-Za-z0-9_+-]+)` +
-		`\/shards\/([A-Za-z0-9]+)\/_status`
+		`\/shards\/([A-Za-z0-9]+)\/status`
 	urlPatternShardFiles = `\/indices\/([A-Za-z0-9_+-]+)` +
 		`\/shards\/([A-Za-z0-9]+)\/files/(.*)`
 	urlPatternShard = `\/indices\/([A-Za-z0-9_+-]+)` +
 		`\/shards\/([A-Za-z0-9]+)$`
 	urlPatternShardReinit = `\/indices\/([A-Za-z0-9_+-]+)` +
-		`\/shards\/([A-Za-z0-9]+)/_reinit`
+		`\/shards\/([A-Za-z0-9]+):reinit`
 )
 
 type shards interface {
@@ -104,7 +104,7 @@ type shards interface {
 	FilePutter(ctx context.Context, indexName, shardName,
 		filePath string) (io.WriteCloser, error)
 	CreateShard(ctx context.Context, indexName, shardName string) error
-	ReinitShard(ctx context.Context, indexName, shardName string) error
+	ReInitShard(ctx context.Context, indexName, shardName string) error
 }
 
 func NewIndices(shards shards) *indices {
@@ -817,8 +817,6 @@ func (i *indices) postUpdateShardStatus() http.Handler {
 			return
 		}
 
-		IndicesPayloads.UpdateShardsStatusResults.SetContentTypeHeader(w)
-
 		err = i.shards.UpdateShardStatus(r.Context(), index, shard, targetStatus)
 		if err != nil {
 			http.Error(w, err.Error(), http.StatusInternalServerError)
@@ -895,7 +893,7 @@ func (i *indices) putShardReinit() http.Handler {
 
 		index, shard := args[1], args[2]
 
-		err := i.shards.ReinitShard(r.Context(), index, shard)
+		err := i.shards.ReInitShard(r.Context(), index, shard)
 		if err != nil {
 			http.Error(w, err.Error(), http.StatusInternalServerError)
 			return

--- a/adapters/handlers/rest/clusterapi/indices_replicas.go
+++ b/adapters/handlers/rest/clusterapi/indices_replicas.go
@@ -63,7 +63,7 @@ var (
 	regxReferences = regexp.MustCompile(`\/replicas\/indices\/([A-Za-z0-9_+-]+)` +
 		`\/shards\/([A-Za-z0-9]+)\/objects/references`)
 	regxIncreaseRepFactor = regexp.MustCompile(`\/replicas\/indices\/([A-Za-z0-9_+-]+)` +
-		`\/replication-factor\/_increase`)
+		`\/replication-factor:increase`)
 	regxCommitPhase = regexp.MustCompile(`\/replicas\/indices\/([A-Za-z0-9_+-]+)` +
 		`\/shards\/([A-Za-z0-9]+):(commit|abort)`)
 )

--- a/adapters/repos/db/fakes_for_test.go
+++ b/adapters/repos/db/fakes_for_test.go
@@ -207,7 +207,7 @@ func (f *fakeRemoteClient) UpdateShardStatus(ctx context.Context, hostName, inde
 }
 
 func (f *fakeRemoteClient) PutFile(ctx context.Context, hostName, indexName, shardName,
-	fileName string, payload io.ReadCloser,
+	fileName string, payload io.ReadSeekCloser,
 ) error {
 	return nil
 }

--- a/usecases/classification/integrationtest/fakes_for_integration_test.go
+++ b/usecases/classification/integrationtest/fakes_for_integration_test.go
@@ -338,7 +338,7 @@ func (f *fakeRemoteClient) PutObject(ctx context.Context, hostName, indexName,
 }
 
 func (f *fakeRemoteClient) PutFile(ctx context.Context, hostName, indexName,
-	shardName, fileName string, payload io.ReadCloser,
+	shardName, fileName string, payload io.ReadSeekCloser,
 ) error {
 	return nil
 }
@@ -443,21 +443,25 @@ func (f *fakeReplicationClient) PutObject(ctx context.Context, host, index, shar
 ) (replica.SimpleResponse, error) {
 	return replica.SimpleResponse{}, nil
 }
+
 func (f *fakeReplicationClient) DeleteObject(ctx context.Context, host, index, shard, requestID string,
 	id strfmt.UUID,
 ) (replica.SimpleResponse, error) {
 	return replica.SimpleResponse{}, nil
 }
+
 func (f *fakeReplicationClient) PutObjects(ctx context.Context, host, index, shard, requestID string,
 	objs []*storobj.Object,
 ) (replica.SimpleResponse, error) {
 	return replica.SimpleResponse{}, nil
 }
+
 func (f *fakeReplicationClient) MergeObject(ctx context.Context, host, index, shard, requestID string,
 	mergeDoc *objects.MergeDocument,
 ) (replica.SimpleResponse, error) {
 	return replica.SimpleResponse{}, nil
 }
+
 func (f *fakeReplicationClient) DeleteObjects(ctx context.Context, host, index, shard, requestID string,
 	docIDs []uint64, dryRun bool,
 ) (replica.SimpleResponse, error) {

--- a/usecases/scaling/scale_out_manager.go
+++ b/usecases/scaling/scale_out_manager.go
@@ -239,7 +239,7 @@ func (som *ScaleOutManager) LocalScaleOut(ctx context.Context,
 			// Now that all files are on the remote node's new shard, the shard needs
 			// to be reinitialized. Otherwise, it would not recognize the files when
 			// serving traffic later.
-			if err := som.ReinitShard(ctx, targetNode, className, shardName); err != nil {
+			if err := som.ReInitShard(ctx, targetNode, className, shardName); err != nil {
 				return fmt.Errorf("create new shard on remote node: %w", err)
 			}
 		}
@@ -288,7 +288,7 @@ func (som *ScaleOutManager) CreateShard(ctx context.Context,
 	return som.nodes.CreateShard(ctx, hostname, className, shardName)
 }
 
-func (som *ScaleOutManager) ReinitShard(ctx context.Context,
+func (som *ScaleOutManager) ReInitShard(ctx context.Context,
 	targetNode, className, shardName string,
 ) error {
 	hostname, ok := som.clusterState.NodeHostname(targetNode)
@@ -296,7 +296,7 @@ func (som *ScaleOutManager) ReinitShard(ctx context.Context,
 		return fmt.Errorf("resolve hostname for node %q", targetNode)
 	}
 
-	return som.nodes.ReinitShard(ctx, hostname, className, shardName)
+	return som.nodes.ReInitShard(ctx, hostname, className, shardName)
 }
 
 type nodeClient interface {
@@ -304,7 +304,7 @@ type nodeClient interface {
 		shardName, fileName string, payload io.ReadSeekCloser) error
 	CreateShard(ctx context.Context,
 		hostName, indexName, shardName string) error
-	ReinitShard(ctx context.Context,
+	ReInitShard(ctx context.Context,
 		hostName, indexName, shardName string) error
 	IncreaseReplicationFactor(ctx context.Context, hostName, indexName string,
 		ssBefore, ssAfter *sharding.State) error

--- a/usecases/scaling/scale_out_manager.go
+++ b/usecases/scaling/scale_out_manager.go
@@ -301,7 +301,7 @@ func (som *ScaleOutManager) ReinitShard(ctx context.Context,
 
 type nodeClient interface {
 	PutFile(ctx context.Context, hostName, indexName,
-		shardName, fileName string, payload io.ReadCloser) error
+		shardName, fileName string, payload io.ReadSeekCloser) error
 	CreateShard(ctx context.Context,
 		hostName, indexName, shardName string) error
 	ReinitShard(ctx context.Context,

--- a/usecases/sharding/remote_index.go
+++ b/usecases/sharding/remote_index.go
@@ -86,7 +86,7 @@ type RemoteIndexClient interface {
 		targetStatus string) error
 
 	PutFile(ctx context.Context, hostName, indexName, shardName, fileName string,
-		payload io.ReadCloser) error
+		payload io.ReadSeekCloser) error
 }
 
 func (ri *RemoteIndex) PutObject(ctx context.Context, shardName string,

--- a/usecases/sharding/remote_index_incoming.go
+++ b/usecases/sharding/remote_index_incoming.go
@@ -262,7 +262,7 @@ func (rii *RemoteIndexIncoming) CreateShard(ctx context.Context,
 	return index.IncomingCreateShard(ctx, shardName)
 }
 
-func (rii *RemoteIndexIncoming) ReinitShard(ctx context.Context,
+func (rii *RemoteIndexIncoming) ReInitShard(ctx context.Context,
 	indexName, shardName string,
 ) error {
 	index := rii.repo.GetIndexForIncoming(schema.ClassName(indexName))


### PR DESCRIPTION
### What's being changed:
Extend client endpoints with retry strategy
Make PutFile client endpoint retryable
Refactor used path and endpoints implementation

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [x] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.
