### PR TITLE
Run docker push step on larger machine

### DIFF
--- a/.github/workflows/pull_requests.yaml
+++ b/.github/workflows/pull_requests.yaml
@@ -83,7 +83,7 @@ jobs:
           verbose: true
   Modules-Acceptance-Tests:
     needs: [Run-Swagger]
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-latest-8-cores
     steps:
       - uses: actions/checkout@v3
       - name: Set up Go
@@ -107,7 +107,7 @@ jobs:
         run: ./test/run.sh --acceptance-only
   Push-Docker:
     needs: [Acceptance-Tests, Modules-Acceptance-Tests, Unit-Tests, Integration-Tests, Vulnerability-Scanning]
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-latest-8-cores
     if: ${{ !github.event.pull_request.head.repo.fork }}  # no PRs from fork
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
### What's being changed:

* Activate (paid) larger runner on module acceptance and docker push steps 
* This runs on any PR build so this could cost some money, but there's only one way to find out :-) 
* Uses up about 15 minutes of an 8 core per build, so at $0.032 p.m., this should cost us $0.48 per CI build
* An alternative would be to only run this on special builds, such as tagged builds

### With paid runners
<img width="981" alt="image" src="https://user-images.githubusercontent.com/8974479/207113410-27484a3f-9a5c-4029-be6b-366a0d0fdf28.png">

### Control
A randomly chosen PR that does not have this change
<img width="952" alt="image" src="https://user-images.githubusercontent.com/8974479/207113747-94191e86-83a2-4292-9748-2c67e72d677c.png">



### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.
