### PR TITLE
Fix autoschema when adding objects with varying properties

### DIFF
--- a/test/acceptance/objects/auto_schema_test.go
+++ b/test/acceptance/objects/auto_schema_test.go
@@ -17,10 +17,61 @@ import (
 	"encoding/json"
 	"testing"
 
+	"github.com/semi-technologies/weaviate/client/schema"
+	"github.com/stretchr/testify/assert"
+
 	"github.com/semi-technologies/weaviate/client/objects"
 	"github.com/semi-technologies/weaviate/entities/models"
 	"github.com/semi-technologies/weaviate/test/helper"
 )
+
+func TestAutoSchemaWithDifferentProperties(t *testing.T) {
+	// Add two objects with different properties to the same class. With autoschema enabled both should be added and
+	// the class should have properties form both classes at the end
+	className := "RandomName234234"
+
+	testCases := []struct {
+		name  string
+		names []string
+	}{
+		{name: "UpperCase", names: []string{"NonExistingProperty", "OtherNonExistingProperty"}},
+		{name: "LowerCase", names: []string{"nonExistingProperty", "otherNonExistingProperty"}},
+	}
+
+	for _, test := range testCases {
+		t.Run(test.name, func(t *testing.T) {
+			obj1 := &models.Object{
+				Class: className,
+				Properties: map[string]interface{}{
+					test.names[0]: "test",
+				},
+			}
+			params := objects.NewObjectsCreateParams().WithBody(obj1)
+			resp, err := helper.Client(t).Objects.ObjectsCreate(params, nil)
+			helper.AssertRequestOk(t, resp, err, nil)
+
+			obj2 := &models.Object{
+				Class: className,
+				Properties: map[string]interface{}{
+					test.names[1]: "test",
+				},
+			}
+			params2 := objects.NewObjectsCreateParams().WithBody(obj2)
+			resp2, err2 := helper.Client(t).Objects.ObjectsCreate(params2, nil)
+			helper.AssertRequestOk(t, resp2, err2, nil)
+
+			SchmeaParams := schema.NewSchemaDumpParams()
+			resp3, err3 := helper.Client(t).Schema.SchemaDump(SchmeaParams, nil)
+			helper.AssertRequestOk(t, resp3, err3, nil)
+			assert.Len(t, resp3.Payload.Classes, 1)
+			class := resp3.Payload.Classes[0]
+			assert.Len(t, class.Properties, 2)
+			props := class.Properties
+			assert.ElementsMatch(t, []string{props[0].Name, props[1].Name}, []string{"nonExistingProperty", "otherNonExistingProperty"})
+			deleteObjectClass(t, className)
+		})
+	}
+}
 
 // run from setup_test.go
 func autoSchemaObjects(t *testing.T) {

--- a/usecases/modules/module_config_init_and_validate.go
+++ b/usecases/modules/module_config_init_and_validate.go
@@ -96,7 +96,7 @@ func (p *Provider) setSinglePropertyConfigDefaults(class *models.Class,
 	prop *models.Property, cfg *ClassBasedModuleConfig,
 	cc modulecapabilities.ClassConfigurator,
 ) {
-	dt, _ := schema.GetPropertyDataType(class, prop.Name)
+	dt, _ := schema.GetValueDataTypeFromString(prop.DataType[0])
 	modDefaults := cc.PropertyConfigDefaults(dt)
 	userSpecified := cfg.Property(prop.Name)
 	mergedConfig := map[string]interface{}{}

--- a/usecases/objects/validation/properties_validation.go
+++ b/usecases/objects/validation/properties_validation.go
@@ -16,6 +16,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"regexp"
+	"strings"
 	"time"
 
 	"github.com/semi-technologies/weaviate/entities/models"
@@ -69,17 +70,23 @@ func (v *Validator) properties(ctx context.Context, object interface{}) error {
 		if propertyValue == nil {
 			continue // nil values are removed and filtered out
 		}
-		dataType, err := schema.GetPropertyDataType(class, propertyKey)
+
+		// properties in the class are saved with lower case first letter
+		propertyKeyLowerCase := strings.ToLower(propertyKey[:1])
+		if len(propertyKey) > 1 {
+			propertyKeyLowerCase += propertyKey[1:]
+		}
+		dataType, err := schema.GetPropertyDataType(class, propertyKeyLowerCase)
 		if err != nil {
 			return err
 		}
 
-		data, err := v.extractAndValidateProperty(ctx, propertyKey, propertyValue, className, dataType)
+		data, err := v.extractAndValidateProperty(ctx, propertyKeyLowerCase, propertyValue, className, dataType)
 		if err != nil {
 			return err
 		}
 
-		returnSchema[propertyKey] = data
+		returnSchema[propertyKeyLowerCase] = data
 	}
 
 	object.(*models.Object).Properties = returnSchema


### PR DESCRIPTION
### What's being changed:

With autoschema enabled adding objects with different properties was not possible.

Example:
```
obj1 := &models.Object{
  Class: className,
  Properties: map[string]interface{}{
	 "NonExistingProperty": "test",
  },
}

obj2 := &models.Object{
  Class: className,
  Properties: map[string]interface{}{
	  "OtherNonExistingProperty": "test",
  },
}
```


### Review checklist

- [x] Chaos pipeline run or not necessary. Link to pipeline: https://github.com/semi-technologies/weaviate-chaos-engineering/pull/32/checks
- [x] All new code is covered by tests where it is reasonable.
- [x] Performance tests have been run or not necessary.
