### PR TITLE
Retry replication operation if participant node is still initializing index

### DIFF
--- a/adapters/clients/replication.go
+++ b/adapters/clients/replication.go
@@ -210,8 +210,6 @@ func (c *replicationClient) do(timeout time.Duration, req *http.Request, resp in
 		defer res.Body.Close()
 
 		if res.StatusCode == http.StatusServiceUnavailable {
-			// give the node a chance to reinit the DB
-			time.Sleep(time.Second)
 			return true, fmt.Errorf("host %q is unavailable", req.Host)
 		}
 		if code := res.StatusCode; code != http.StatusOK {

--- a/adapters/clients/replication.go
+++ b/adapters/clients/replication.go
@@ -44,18 +44,18 @@ func (c *replicationClient) PutObject(ctx context.Context, host, index,
 	shard, requestID string, obj *storobj.Object,
 ) (replica.SimpleResponse, error) {
 	var resp replica.SimpleResponse
-	payload, err := clusterapi.IndicesPayloads.SingleObject.Marshal(obj)
+	body, err := clusterapi.IndicesPayloads.SingleObject.Marshal(obj)
 	if err != nil {
 		return resp, fmt.Errorf("encode request: %w", err)
 	}
 
-	req, err := newHttpReplicaRequest(ctx, http.MethodPost, host, index, shard, requestID, "", bytes.NewReader(payload))
+	req, err := newHttpReplicaRequest(ctx, http.MethodPost, host, index, shard, requestID, "", nil)
 	if err != nil {
 		return resp, fmt.Errorf("create http request: %w", err)
 	}
 
 	clusterapi.IndicesPayloads.SingleObject.SetContentTypeHeaderReq(req)
-	err = c.do(c.timeoutUnit*10, req, &resp)
+	err = c.do(c.timeoutUnit*10, req, body, &resp)
 	return resp, err
 }
 
@@ -68,7 +68,7 @@ func (c *replicationClient) DeleteObject(ctx context.Context, host, index,
 		return resp, fmt.Errorf("create http request: %w", err)
 	}
 
-	err = c.do(c.timeoutUnit*2, req, &resp)
+	err = c.do(c.timeoutUnit*2, req, nil, &resp)
 	return resp, err
 }
 
@@ -80,13 +80,13 @@ func (c *replicationClient) PutObjects(ctx context.Context, host, index,
 	if err != nil {
 		return resp, fmt.Errorf("encode request: %w", err)
 	}
-	req, err := newHttpReplicaRequest(ctx, http.MethodPost, host, index, shard, requestID, "", bytes.NewReader(body))
+	req, err := newHttpReplicaRequest(ctx, http.MethodPost, host, index, shard, requestID, "", nil)
 	if err != nil {
 		return resp, fmt.Errorf("create http request: %w", err)
 	}
 
 	clusterapi.IndicesPayloads.ObjectList.SetContentTypeHeaderReq(req)
-	err = c.do(c.timeoutUnit*10, req, &resp)
+	err = c.do(c.timeoutUnit*10, req, body, &resp)
 	return resp, err
 }
 
@@ -100,13 +100,13 @@ func (c *replicationClient) MergeObject(ctx context.Context, host, index, shard,
 	}
 
 	req, err := newHttpReplicaRequest(ctx, http.MethodPatch, host, index, shard,
-		requestID, doc.ID.String(), bytes.NewReader(body))
+		requestID, doc.ID.String(), nil)
 	if err != nil {
 		return resp, fmt.Errorf("create http request: %w", err)
 	}
 
 	clusterapi.IndicesPayloads.MergeDoc.SetContentTypeHeaderReq(req)
-	err = c.do(c.timeoutUnit*2, req, &resp)
+	err = c.do(c.timeoutUnit*2, req, body, &resp)
 	return resp, err
 }
 
@@ -119,14 +119,13 @@ func (c *replicationClient) AddReferences(ctx context.Context, host, index,
 		return resp, fmt.Errorf("encode request: %w", err)
 	}
 	req, err := newHttpReplicaRequest(ctx, http.MethodPost, host, index, shard,
-		requestID, "references",
-		bytes.NewReader(body))
+		requestID, "references", nil)
 	if err != nil {
 		return resp, fmt.Errorf("create http request: %w", err)
 	}
 
 	clusterapi.IndicesPayloads.ReferenceList.SetContentTypeHeaderReq(req)
-	err = c.do(c.timeoutUnit*10, req, &resp)
+	err = c.do(c.timeoutUnit*10, req, body, &resp)
 	return resp, err
 }
 
@@ -137,13 +136,13 @@ func (c *replicationClient) DeleteObjects(ctx context.Context, host, index, shar
 	if err != nil {
 		return resp, fmt.Errorf("encode request: %w", err)
 	}
-	req, err := newHttpReplicaRequest(ctx, http.MethodDelete, host, index, shard, requestID, "", bytes.NewReader(body))
+	req, err := newHttpReplicaRequest(ctx, http.MethodDelete, host, index, shard, requestID, "", nil)
 	if err != nil {
 		return resp, fmt.Errorf("create http request: %w", err)
 	}
 
 	clusterapi.IndicesPayloads.BatchDeleteParams.SetContentTypeHeaderReq(req)
-	err = c.do(c.timeoutUnit*10, req, &resp)
+	err = c.do(c.timeoutUnit*10, req, body, &resp)
 	return resp, err
 }
 
@@ -154,7 +153,7 @@ func (c *replicationClient) Commit(ctx context.Context, host, index, shard strin
 		return fmt.Errorf("create http request: %w", err)
 	}
 
-	return c.do(c.timeoutUnit*64, req, resp)
+	return c.do(c.timeoutUnit*64, req, nil, resp)
 }
 
 func (c *replicationClient) Abort(ctx context.Context, host, index, shard, requestID string) (
@@ -165,7 +164,7 @@ func (c *replicationClient) Abort(ctx context.Context, host, index, shard, reque
 		return resp, fmt.Errorf("create http request: %w", err)
 	}
 
-	err = c.do(c.timeoutUnit, req, &resp)
+	err = c.do(c.timeoutUnit, req, nil, &resp)
 	return resp, err
 }
 
@@ -191,16 +190,9 @@ func newHttpReplicaCMD(host, cmd, index, shard, requestId string, body io.Reader
 	return http.NewRequest(http.MethodPost, url.String(), body)
 }
 
-func (c *replicationClient) do(timeout time.Duration, req *http.Request, resp interface{}) (err error) {
+func (c *replicationClient) do(timeout time.Duration, req *http.Request, body []byte, resp interface{}) (err error) {
 	ctx, cancel := context.WithTimeout(req.Context(), timeout)
 	defer cancel()
-
-	// we have to save the req body contents (if present)
-	// prior to the first request. otherwise, the first
-	// request reads and closes the request body, and all
-	// future retries fail
-	body := readRequestBody(req)
-
 	try := func(ctx context.Context) (bool, error) {
 		req.Body = io.NopCloser(bytes.NewReader(body))
 		res, err := c.client.Do(req)
@@ -209,11 +201,9 @@ func (c *replicationClient) do(timeout time.Duration, req *http.Request, resp in
 		}
 		defer res.Body.Close()
 
-		if res.StatusCode == http.StatusServiceUnavailable {
-			return true, fmt.Errorf("host %q is unavailable", req.Host)
-		}
 		if code := res.StatusCode; code != http.StatusOK {
-			shouldRetry := code == http.StatusInternalServerError || code == http.StatusTooManyRequests
+			shouldRetry := code == http.StatusInternalServerError ||
+				code == http.StatusTooManyRequests || code == http.StatusServiceUnavailable
 			return shouldRetry, fmt.Errorf("status code: %v", code)
 		}
 		if err := json.NewDecoder(res.Body).Decode(resp); err != nil {
@@ -228,13 +218,4 @@ func (c *replicationClient) do(timeout time.Duration, req *http.Request, resp in
 // It implements truncated exponential back-off with introduced jitter.
 func backOff(d time.Duration) time.Duration {
 	return time.Duration(float64(d.Nanoseconds()*2) * (0.5 + rand.Float64()))
-}
-
-func readRequestBody(req *http.Request) []byte {
-	var body []byte
-	if req.Body != nil {
-		body, _ = io.ReadAll(req.Body)
-		req.Body.Close()
-	}
-	return body
 }

--- a/adapters/clients/replication.go
+++ b/adapters/clients/replication.go
@@ -194,7 +194,9 @@ func (c *replicationClient) do(timeout time.Duration, req *http.Request, body []
 	ctx, cancel := context.WithTimeout(req.Context(), timeout)
 	defer cancel()
 	try := func(ctx context.Context) (bool, error) {
-		req.Body = io.NopCloser(bytes.NewReader(body))
+		if body != nil {
+			req.Body = io.NopCloser(bytes.NewReader(body))
+		}
 		res, err := c.client.Do(req)
 		if err != nil {
 			return ctx.Err() == nil, fmt.Errorf("connect: %w", err)

--- a/adapters/repos/db/replication.go
+++ b/adapters/repos/db/replication.go
@@ -135,6 +135,12 @@ func (db *DB) AbortReplication(class,
 }
 
 func (db *DB) replicatedIndex(name string) (idx *Index, resp *replica.SimpleResponse) {
+	if !db.startupComplete {
+		return nil, &replica.SimpleResponse{Errors: []replica.Error{
+			*replica.NewError(replica.StatusNotReady, name),
+		}}
+	}
+
 	if idx = db.GetIndex(schema.ClassName(name)); idx == nil {
 		return nil, &replica.SimpleResponse{Errors: []replica.Error{
 			*replica.NewError(replica.StatusClassNotFound, name),

--- a/adapters/repos/db/replication.go
+++ b/adapters/repos/db/replication.go
@@ -135,7 +135,7 @@ func (db *DB) AbortReplication(class,
 }
 
 func (db *DB) replicatedIndex(name string) (idx *Index, resp *replica.SimpleResponse) {
-	if !db.startupComplete {
+	if !db.startupComplete.Load() {
 		return nil, &replica.SimpleResponse{Errors: []replica.Error{
 			*replica.NewError(replica.StatusNotReady, name),
 		}}

--- a/adapters/repos/db/repo.go
+++ b/adapters/repos/db/repo.go
@@ -14,6 +14,7 @@ package db
 import (
 	"context"
 	"sync"
+	"sync/atomic"
 
 	"github.com/pkg/errors"
 	"github.com/semi-technologies/weaviate/entities/schema"
@@ -36,7 +37,7 @@ type DB struct {
 	remoteNode      *sharding.RemoteNode
 	promMetrics     *monitoring.PrometheusMetrics
 	shutdown        chan struct{}
-	startupComplete bool
+	startupComplete atomic.Bool
 
 	// indexLock is an RWMutex which allows concurrent access to various indexes,
 	// but only one modifaction at a time. R/W can be a bit confusing here,
@@ -70,7 +71,7 @@ func (d *DB) WaitForStartup(ctx context.Context) error {
 		return err
 	}
 
-	d.startupComplete = true
+	d.startupComplete.Store(true)
 	d.scanResourceUsage()
 
 	return nil

--- a/adapters/repos/db/repo.go
+++ b/adapters/repos/db/repo.go
@@ -26,16 +26,17 @@ import (
 )
 
 type DB struct {
-	logger        logrus.FieldLogger
-	schemaGetter  schemaUC.SchemaGetter
-	config        Config
-	indices       map[string]*Index
-	remoteIndex   sharding.RemoteIndexClient
-	replicaClient replica.Client
-	nodeResolver  nodeResolver
-	remoteNode    *sharding.RemoteNode
-	promMetrics   *monitoring.PrometheusMetrics
-	shutdown      chan struct{}
+	logger          logrus.FieldLogger
+	schemaGetter    schemaUC.SchemaGetter
+	config          Config
+	indices         map[string]*Index
+	remoteIndex     sharding.RemoteIndexClient
+	replicaClient   replica.Client
+	nodeResolver    nodeResolver
+	remoteNode      *sharding.RemoteNode
+	promMetrics     *monitoring.PrometheusMetrics
+	shutdown        chan struct{}
+	startupComplete bool
 
 	// indexLock is an RWMutex which allows concurrent access to various indexes,
 	// but only one modifaction at a time. R/W can be a bit confusing here,
@@ -69,6 +70,7 @@ func (d *DB) WaitForStartup(ctx context.Context) error {
 		return err
 	}
 
+	d.startupComplete = true
 	d.scanResourceUsage()
 
 	return nil
@@ -125,19 +127,6 @@ func (d *DB) GetIndex(className schema.ClassName) *Index {
 
 // GetIndexForIncoming returns the index if it exists or nil if it doesn't
 func (d *DB) GetIndexForIncoming(className schema.ClassName) sharding.RemoteIndexIncomingRepo {
-	d.indexLock.RLock()
-	defer d.indexLock.RUnlock()
-
-	id := indexID(className)
-	index, ok := d.indices[id]
-	if !ok {
-		return nil
-	}
-
-	return index
-}
-
-func (d *DB) GetReplicatedIndex(className schema.ClassName) Replicator {
 	d.indexLock.RLock()
 	defer d.indexLock.RUnlock()
 

--- a/usecases/replica/transport.go
+++ b/usecases/replica/transport.go
@@ -35,6 +35,7 @@ const (
 	StatusShardNotFound
 	StatusNotFound
 	StatusAlreadyExisted
+	StatusNotReady
 	StatusConflict = iota + 300
 	StatusPreconditionFailed
 	StatusReadOnly
@@ -66,6 +67,10 @@ func (e *Error) Unwrap() error { return e.Err }
 
 func (e *Error) Error() string { return fmt.Sprintf("%s %q: %v", statusText(e.Code), e.Msg, e.Err) }
 
+func (e *Error) IsStatusCode(sc StatusCode) bool {
+	return e.Code == sc
+}
+
 // statusText returns a text for the status code. It returns the empty
 // string if the code is unknown.
 func statusText(code StatusCode) string {
@@ -84,6 +89,8 @@ func statusText(code StatusCode) string {
 		return "precondition failed"
 	case StatusAlreadyExisted:
 		return "already existed"
+	case StatusNotReady:
+		return "local index not ready"
 	case StatusReadOnly:
 		return "read only"
 	default:


### PR DESCRIPTION
### What's being changed:

- Fix bug causes clusterapi client retry requests from containing a `nil` body
- Retry if replication participant node is still initializing its indices 

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.
