### PR TITLE
Support new text-embedding-ada-002 model in text2vec-openai module 

### DIFF
--- a/modules/text2vec-openai/clients/vectorizer.go
+++ b/modules/text2vec-openai/clients/vectorizer.go
@@ -157,7 +157,9 @@ func (v *vectorizer) getApiKey(ctx context.Context) (string, error) {
 
 func (v *vectorizer) getModelString(docType, model, action string) string {
 	modelBaseString := "%s-search-%s-%s-001"
-	if action == "document" {
+	if model == "ada2" {
+		return "text-embedding-ada-002"
+	} else if action == "document" {
 		if docType == "code" {
 			return fmt.Sprintf(modelBaseString, docType, model, "code")
 		}

--- a/modules/text2vec-openai/clients/vectorizer.go
+++ b/modules/text2vec-openai/clients/vectorizer.go
@@ -70,13 +70,13 @@ func New(apiKey string, logger logrus.FieldLogger) *vectorizer {
 func (v *vectorizer) Vectorize(ctx context.Context, input string,
 	config ent.VectorizationConfig,
 ) (*ent.VectorizationResult, error) {
-	return v.vectorize(ctx, input, v.getModelString(config.Type, config.Model, "document"))
+	return v.vectorize(ctx, input, v.getModelString(config.Type, config.Model, "document", config.ModelVersion))
 }
 
 func (v *vectorizer) VectorizeQuery(ctx context.Context, input string,
 	config ent.VectorizationConfig,
 ) (*ent.VectorizationResult, error) {
-	return v.vectorize(ctx, input, v.getModelString(config.Type, config.Model, "query"))
+	return v.vectorize(ctx, input, v.getModelString(config.Type, config.Model, "query", config.ModelVersion))
 }
 
 func (v *vectorizer) vectorize(ctx context.Context, input string,
@@ -155,11 +155,17 @@ func (v *vectorizer) getApiKey(ctx context.Context) (string, error) {
 		"nor in environment variable under OPENAI_APIKEY")
 }
 
-func (v *vectorizer) getModelString(docType, model, action string) string {
+func (v *vectorizer) getModelString(docType, model, action, version string) string {
+	if version == "002" {
+		return v.getModel002String(model)
+	}
+
+	return v.getModel001String(docType, model, action)
+}
+
+func (v *vectorizer) getModel001String(docType, model, action string) string {
 	modelBaseString := "%s-search-%s-%s-001"
-	if model == "ada2" {
-		return "text-embedding-ada-002"
-	} else if action == "document" {
+	if action == "document" {
 		if docType == "code" {
 			return fmt.Sprintf(modelBaseString, docType, model, "code")
 		}
@@ -171,4 +177,9 @@ func (v *vectorizer) getModelString(docType, model, action string) string {
 		}
 		return fmt.Sprintf(modelBaseString, docType, model, "query")
 	}
+}
+
+func (v *vectorizer) getModel002String(model string) string {
+	modelBaseString := "text-embedding-%s-002"
+	return fmt.Sprintf(modelBaseString, model)
 }

--- a/modules/text2vec-openai/clients/vectorizer_test.go
+++ b/modules/text2vec-openai/clients/vectorizer_test.go
@@ -201,6 +201,7 @@ func Test_getModelString(t *testing.T) {
 		type args struct {
 			docType string
 			model   string
+			version string
 		}
 		tests := []struct {
 			name string
@@ -216,10 +217,11 @@ func Test_getModelString(t *testing.T) {
 				want: "text-search-ada-doc-001",
 			},
 			{
-				name: "Document type: text model: ada2 vectorizationType: document",
+				name: "Document type: text model: ada-002 vectorizationType: document",
 				args: args{
 					docType: "text",
-					model:   "ada2",
+					model:   "ada",
+					version: "002",
 				},
 				want: "text-embedding-ada-002",
 			},
@@ -256,14 +258,6 @@ func Test_getModelString(t *testing.T) {
 				want: "code-search-ada-code-001",
 			},
 			{
-				name: "Document type: code model: ada2 vectorizationType: code",
-				args: args{
-					docType: "code",
-					model:   "ada2",
-				},
-				want: "text-embedding-ada-002",
-			},
-			{
 				name: "Document type: code model: babbage vectorizationType: code",
 				args: args{
 					docType: "code",
@@ -275,7 +269,7 @@ func Test_getModelString(t *testing.T) {
 		for _, tt := range tests {
 			t.Run(tt.name, func(t *testing.T) {
 				v := New("apiKey", nullLogger())
-				if got := v.getModelString(tt.args.docType, tt.args.model, "document"); got != tt.want {
+				if got := v.getModelString(tt.args.docType, tt.args.model, "document", tt.args.version); got != tt.want {
 					t.Errorf("vectorizer.getModelString() = %v, want %v", got, tt.want)
 				}
 			})
@@ -286,6 +280,7 @@ func Test_getModelString(t *testing.T) {
 		type args struct {
 			docType string
 			model   string
+			version string
 		}
 		tests := []struct {
 			name string
@@ -299,14 +294,6 @@ func Test_getModelString(t *testing.T) {
 					model:   "ada",
 				},
 				want: "text-search-ada-query-001",
-			},
-			{
-				name: "Document type: text model: ada2 vectorizationType: query",
-				args: args{
-					docType: "text",
-					model:   "ada2",
-				},
-				want: "text-embedding-ada-002",
 			},
 			{
 				name: "Document type: text model: babbage vectorizationType: query",
@@ -341,14 +328,6 @@ func Test_getModelString(t *testing.T) {
 				want: "code-search-ada-text-001",
 			},
 			{
-				name: "Document type: code model: ada2 vectorizationType: text",
-				args: args{
-					docType: "code",
-					model:   "ada2",
-				},
-				want: "text-embedding-ada-002",
-			},
-			{
 				name: "Document type: code model: babbage vectorizationType: text",
 				args: args{
 					docType: "code",
@@ -360,7 +339,7 @@ func Test_getModelString(t *testing.T) {
 		for _, tt := range tests {
 			t.Run(tt.name, func(t *testing.T) {
 				v := New("apiKey", nullLogger())
-				if got := v.getModelString(tt.args.docType, tt.args.model, "query"); got != tt.want {
+				if got := v.getModelString(tt.args.docType, tt.args.model, "query", tt.args.version); got != tt.want {
 					t.Errorf("vectorizer.getModelString() = %v, want %v", got, tt.want)
 				}
 			})

--- a/modules/text2vec-openai/clients/vectorizer_test.go
+++ b/modules/text2vec-openai/clients/vectorizer_test.go
@@ -216,6 +216,14 @@ func Test_getModelString(t *testing.T) {
 				want: "text-search-ada-doc-001",
 			},
 			{
+				name: "Document type: text model: ada2 vectorizationType: document",
+				args: args{
+					docType: "text",
+					model:   "ada2",
+				},
+				want: "text-embedding-ada-002",
+			},
+			{
 				name: "Document type: text model: babbage vectorizationType: document",
 				args: args{
 					docType: "text",
@@ -246,6 +254,14 @@ func Test_getModelString(t *testing.T) {
 					model:   "ada",
 				},
 				want: "code-search-ada-code-001",
+			},
+			{
+				name: "Document type: code model: ada2 vectorizationType: code",
+				args: args{
+					docType: "code",
+					model:   "ada2",
+				},
+				want: "text-embedding-ada-002",
 			},
 			{
 				name: "Document type: code model: babbage vectorizationType: code",
@@ -285,6 +301,14 @@ func Test_getModelString(t *testing.T) {
 				want: "text-search-ada-query-001",
 			},
 			{
+				name: "Document type: text model: ada2 vectorizationType: query",
+				args: args{
+					docType: "text",
+					model:   "ada2",
+				},
+				want: "text-embedding-ada-002",
+			},
+			{
 				name: "Document type: text model: babbage vectorizationType: query",
 				args: args{
 					docType: "text",
@@ -308,7 +332,6 @@ func Test_getModelString(t *testing.T) {
 				},
 				want: "text-search-davinci-query-001",
 			},
-
 			{
 				name: "Document type: code model: ada vectorizationType: text",
 				args: args{
@@ -316,6 +339,14 @@ func Test_getModelString(t *testing.T) {
 					model:   "ada",
 				},
 				want: "code-search-ada-text-001",
+			},
+			{
+				name: "Document type: code model: ada2 vectorizationType: text",
+				args: args{
+					docType: "code",
+					model:   "ada2",
+				},
+				want: "text-embedding-ada-002",
 			},
 			{
 				name: "Document type: code model: babbage vectorizationType: text",

--- a/modules/text2vec-openai/config.go
+++ b/modules/text2vec-openai/config.go
@@ -26,6 +26,8 @@ func (m *OpenAIModule) ClassConfigDefaults() map[string]interface{} {
 		"vectorizeClassName": vectorizer.DefaultVectorizeClassName,
 		"type":               vectorizer.DefaultOpenAIDocumentType,
 		"model":              vectorizer.DefaultOpenAIModel,
+		"modelVersion": vectorizer.PickDefaultModelVersion(vectorizer.DefaultOpenAIModel,
+			vectorizer.DefaultOpenAIDocumentType),
 	}
 }
 

--- a/modules/text2vec-openai/ent/vectorization_config.go
+++ b/modules/text2vec-openai/ent/vectorization_config.go
@@ -12,5 +12,5 @@
 package ent
 
 type VectorizationConfig struct {
-	Type, Model string
+	Type, Model, ModelVersion string
 }

--- a/modules/text2vec-openai/vectorizer/fakes_for_test.go
+++ b/modules/text2vec-openai/vectorizer/fakes_for_test.go
@@ -52,6 +52,7 @@ type fakeSettings struct {
 	excludedProperty   string
 	openAIType         string
 	openAIModel        string
+	openAIModelVersion string
 }
 
 func (f *fakeSettings) PropertyIndexed(propName string) bool {
@@ -72,4 +73,8 @@ func (f *fakeSettings) Type() string {
 
 func (f *fakeSettings) Model() string {
 	return f.openAIModel
+}
+
+func (f *fakeSettings) ModelVersion() string {
+	return f.openAIModelVersion
 }

--- a/modules/text2vec-openai/vectorizer/objects.go
+++ b/modules/text2vec-openai/vectorizer/objects.go
@@ -47,6 +47,7 @@ type ClassSettings interface {
 	VectorizeClassName() bool
 	Model() string
 	Type() string
+	ModelVersion() string
 }
 
 func sortStringKeys(schema_map map[string]interface{}) []string {
@@ -132,8 +133,9 @@ func (v *Vectorizer) object(ctx context.Context, className string,
 
 	text := strings.Join(corpi, " ")
 	res, err := v.client.Vectorize(ctx, text, ent.VectorizationConfig{
-		Type:  icheck.Type(),
-		Model: icheck.Model(),
+		Type:         icheck.Type(),
+		Model:        icheck.Model(),
+		ModelVersion: icheck.ModelVersion(),
 	})
 	if err != nil {
 		return nil, err

--- a/modules/text2vec-openai/vectorizer/objects_test.go
+++ b/modules/text2vec-openai/vectorizer/objects_test.go
@@ -13,6 +13,7 @@ package vectorizer
 
 import (
 	"context"
+	"fmt"
 	"strings"
 	"testing"
 
@@ -36,6 +37,7 @@ func TestVectorizingObjects(t *testing.T) {
 		excludedClass       string // to simulate a schema where class names aren't vectorized
 		openAIType          string
 		openAIModel         string
+		openAIModelVersion  string
 	}
 
 	tests := []testCase{
@@ -187,6 +189,7 @@ func TestVectorizingObjects(t *testing.T) {
 				vectorizeClassName: test.excludedClass != "Car",
 				openAIType:         test.openAIType,
 				openAIModel:        test.openAIModel,
+				openAIModelVersion: test.openAIModelVersion,
 			}
 			err := v.Object(context.Background(), test.input, nil, ic)
 
@@ -362,4 +365,48 @@ func TestVectorizingObjectWithDiff(t *testing.T) {
 
 func newObjectDiffWithVector() *moduletools.ObjectDiff {
 	return moduletools.NewObjectDiff([]float32{0, 0, 0, 0})
+}
+
+func TestValidateModelVersion(t *testing.T) {
+	type test struct {
+		model    string
+		docType  string
+		version  string
+		possible bool
+	}
+
+	tests := []test{
+		// 001 models
+		{"ada", "text", "001", true},
+		{"ada", "code", "001", true},
+		{"babbage", "text", "001", true},
+		{"babbage", "code", "001", true},
+		{"curie", "text", "001", true},
+		{"curie", "code", "001", true},
+		{"davinci", "text", "001", true},
+		{"davinci", "code", "001", true},
+
+		// 002 models
+		{"ada", "text", "002", true},
+		{"ada", "code", "002", false},
+		{"babbage", "text", "002", false},
+		{"babbage", "code", "002", false},
+		{"curie", "text", "002", false},
+		{"curie", "code", "002", false},
+		{"davinci", "text", "002", false},
+		{"davinci", "code", "002", false},
+	}
+
+	for _, test := range tests {
+		name := fmt.Sprintf("model=%s docType=%s version=%s", test.model, test.docType, test.version)
+		t.Run(name, func(t *testing.T) {
+			err := (&classSettings{}).validateModelVersion(test.version, test.model, test.docType)
+			if test.possible {
+				assert.Nil(t, err, "this combination should be possible")
+			} else {
+				assert.NotNil(t, err, "this combination should not be possible")
+			}
+		})
+
+	}
 }

--- a/modules/text2vec-openai/vectorizer/objects_test.go
+++ b/modules/text2vec-openai/vectorizer/objects_test.go
@@ -395,6 +395,9 @@ func TestValidateModelVersion(t *testing.T) {
 		{"curie", "code", "002", false},
 		{"davinci", "text", "002", false},
 		{"davinci", "code", "002", false},
+
+		// 003
+		{"ada", "text", "003", false},
 	}
 
 	for _, test := range tests {
@@ -407,6 +410,22 @@ func TestValidateModelVersion(t *testing.T) {
 				assert.NotNil(t, err, "this combination should not be possible")
 			}
 		})
-
 	}
+}
+
+func TestPickDefaultModelVersion(t *testing.T) {
+	t.Run("ada with text", func(t *testing.T) {
+		version := PickDefaultModelVersion("ada", "text")
+		assert.Equal(t, "002", version)
+	})
+
+	t.Run("ada with code", func(t *testing.T) {
+		version := PickDefaultModelVersion("ada", "code")
+		assert.Equal(t, "001", version)
+	})
+
+	t.Run("with curie", func(t *testing.T) {
+		version := PickDefaultModelVersion("curie", "text")
+		assert.Equal(t, "001", version)
+	})
 }


### PR DESCRIPTION
### What's being changed:

- add new config field `"version"` which accepts either `"001"` or `"002"`
- if no config is provided the default is `model=ada, modelVersion=002, type=text`
- there is new validation that makes sure that invalid combinations such as `model=ada, modelVersion=002, type=code` or `model=curie, modelVersion=002, type=text` are not allowed
- there is new logic that builds the right model script based on the version number. This was required because `002` no longer uses separate models for query and document, but just a single model

### Review checklist

- [x] Documentation has been updated, if necessary. Link to changed documentation: @bobvanluijt is in the process of doing that and releasing it when ready
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [x] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.
