### PR TITLE
Query Duration Metrics

### DIFF
--- a/usecases/monitoring/prometheus.go
+++ b/usecases/monitoring/prometheus.go
@@ -75,18 +75,18 @@ func newPrometheusMetrics() *PrometheusMetrics {
 		BatchTime: promauto.NewHistogramVec(prometheus.HistogramOpts{
 			Name:    "batch_durations_ms",
 			Help:    "Duration in ms of a single batch",
-			Buckets: prometheus.ExponentialBuckets(10, 1.5, 12),
+			Buckets: prometheus.ExponentialBuckets(10, 1.8, 12),
 		}, []string{"operation", "class_name", "shard_name"}),
 		BatchDeleteTime: promauto.NewHistogramVec(prometheus.HistogramOpts{
 			Name:    "batch_delete_durations_ms",
 			Help:    "Duration in ms of a single delete batch",
-			Buckets: prometheus.ExponentialBuckets(10, 1.5, 12),
+			Buckets: prometheus.ExponentialBuckets(10, 1.8, 12),
 		}, []string{"operation", "class_name", "shard_name"}),
 
 		ObjectsTime: promauto.NewHistogramVec(prometheus.HistogramOpts{
 			Name:    "objects_durations_ms",
 			Help:    "Duration of an individual object operation. Also as part of batches.",
-			Buckets: prometheus.ExponentialBuckets(10, 1.5, 12),
+			Buckets: prometheus.ExponentialBuckets(1, 1.8, 12),
 		}, []string{"operation", "step", "class_name", "shard_name"}),
 		ObjectCount: promauto.NewGaugeVec(prometheus.GaugeOpts{
 			Name: "object_count",
@@ -121,7 +121,7 @@ func newPrometheusMetrics() *PrometheusMetrics {
 		LSMBloomFilters: promauto.NewHistogramVec(prometheus.HistogramOpts{
 			Name:    "lsm_bloom_filters_duration_ms",
 			Help:    "Duration of bloom filter operations",
-			Buckets: prometheus.ExponentialBuckets(1, 1.5, 12),
+			Buckets: prometheus.ExponentialBuckets(1, 1.8, 12),
 		}, []string{"operation", "strategy", "class_name", "shard_name"}),
 		LSMSegmentObjects: promauto.NewGaugeVec(prometheus.GaugeOpts{
 			Name: "lsm_segment_objects",
@@ -168,12 +168,12 @@ func newPrometheusMetrics() *PrometheusMetrics {
 		VectorIndexMaintenanceDurations: promauto.NewHistogramVec(prometheus.HistogramOpts{
 			Name:    "vector_index_maintenance_durations_ms",
 			Help:    "Duration of a sync or async vector index maintenance operation",
-			Buckets: prometheus.ExponentialBuckets(1, 1.5, 12),
+			Buckets: prometheus.ExponentialBuckets(1, 1.8, 12),
 		}, []string{"operation", "class_name", "shard_name"}),
 		VectorIndexDurations: promauto.NewHistogramVec(prometheus.HistogramOpts{
 			Name:    "vector_index_durations_ms",
 			Help:    "Duration of typical vector index operations (insert, delete)",
-			Buckets: prometheus.ExponentialBuckets(0.1, 1.5, 12),
+			Buckets: prometheus.ExponentialBuckets(0.1, 1.8, 12),
 		}, []string{"operation", "step", "class_name", "shard_name"}),
 		VectorDimensionsSum: promauto.NewGaugeVec(prometheus.GaugeOpts{
 			Name: "vector_dimensions_sum",
@@ -186,8 +186,8 @@ func newPrometheusMetrics() *PrometheusMetrics {
 		}, []string{"operation", "class_name", "shard_name"}),
 		StartupDurations: promauto.NewHistogramVec(prometheus.HistogramOpts{
 			Name:    "startup_durations_ms",
-			Help:    "Duration of inidividual startup operations in ms",
-			Buckets: prometheus.ExponentialBuckets(100, 1.5, 12),
+			Help:    "Duration of individual startup operations in ms",
+			Buckets: prometheus.ExponentialBuckets(100, 1.8, 12),
 		}, []string{"operation", "class_name", "shard_name"}),
 		StartupDiskIO: promauto.NewHistogramVec(prometheus.HistogramOpts{
 			Name:    "startup_diskio_throughput",
@@ -202,32 +202,32 @@ func newPrometheusMetrics() *PrometheusMetrics {
 		BackupRestoreDurations: promauto.NewHistogramVec(prometheus.HistogramOpts{
 			Name:    "backup_restore_ms",
 			Help:    "Duration of a backup restore",
-			Buckets: prometheus.ExponentialBuckets(1, 1.5, 12),
+			Buckets: prometheus.ExponentialBuckets(10, 1.8, 12),
 		}, []string{"backend_name", "class_name"}),
 		BackupRestoreClassDurations: promauto.NewHistogramVec(prometheus.HistogramOpts{
 			Name:    "backup_restore_class_ms",
 			Help:    "Duration restoring class",
-			Buckets: prometheus.ExponentialBuckets(1, 1.5, 12),
+			Buckets: prometheus.ExponentialBuckets(10, 1.8, 12),
 		}, []string{"class_name"}),
 		BackupRestoreBackupInitDurations: promauto.NewHistogramVec(prometheus.HistogramOpts{
 			Name:    "backup_restore_init_ms",
 			Help:    "startup phase of a backup restore",
-			Buckets: prometheus.ExponentialBuckets(1, 1.5, 12),
+			Buckets: prometheus.ExponentialBuckets(10, 1.8, 12),
 		}, []string{"backend_name", "class_name"}),
 		BackupRestoreFromStorageDurations: promauto.NewHistogramVec(prometheus.HistogramOpts{
 			Name:    "backup_restore_from_backend_ms",
 			Help:    "file transfer stage of a backup restore",
-			Buckets: prometheus.ExponentialBuckets(1, 1.5, 12),
+			Buckets: prometheus.ExponentialBuckets(10, 1.8, 12),
 		}, []string{"backend_name", "class_name"}),
 		BackupStoreDurations: promauto.NewHistogramVec(prometheus.HistogramOpts{
 			Name:    "backup_store_to_backend_ms",
 			Help:    "file transfer stage of a backup restore",
-			Buckets: prometheus.ExponentialBuckets(1, 1.5, 12),
+			Buckets: prometheus.ExponentialBuckets(10, 1.8, 12),
 		}, []string{"backend_name", "class_name"}),
 		BucketPauseDurations: promauto.NewHistogramVec(prometheus.HistogramOpts{
 			Name:    "bucket_pause_durations_ms",
 			Help:    "bucket pause durations",
-			Buckets: prometheus.ExponentialBuckets(1, 1.5, 12),
+			Buckets: prometheus.ExponentialBuckets(10, 1.8, 12),
 		}, []string{"bucket_dir"}),
 		BackupRestoreDataTransferred: promauto.NewCounterVec(prometheus.CounterOpts{
 			Name: "backup_restore_data_transferred",

--- a/usecases/monitoring/prometheus.go
+++ b/usecases/monitoring/prometheus.go
@@ -39,6 +39,7 @@ type PrometheusMetrics struct {
 	VectorIndexMaintenanceDurations    *prometheus.HistogramVec
 	ObjectCount                        *prometheus.GaugeVec
 	QueriesCount                       *prometheus.GaugeVec
+	QueriesDurations                   *prometheus.HistogramVec
 	QueryDimensions                    *prometheus.CounterVec
 	GoroutinesCount                    *prometheus.GaugeVec
 	BackupRestoreDurations             *prometheus.HistogramVec
@@ -95,6 +96,12 @@ func newPrometheusMetrics() *PrometheusMetrics {
 		QueriesCount: promauto.NewGaugeVec(prometheus.GaugeOpts{
 			Name: "concurrent_queries_count",
 			Help: "Number of concurrently running query operations",
+		}, []string{"class_name", "query_type"}),
+
+		QueriesDurations: promauto.NewHistogramVec(prometheus.HistogramOpts{
+			Name:    "queries_durations_ms",
+			Help:    "Duration of queries in milliseconds",
+			Buckets: []float64{1, 10, 25, 50, 75, 100, 250, 500, 1000, 2500, 5000, 10000},
 		}, []string{"class_name", "query_type"}),
 
 		GoroutinesCount: promauto.NewGaugeVec(prometheus.GaugeOpts{

--- a/usecases/monitoring/prometheus.go
+++ b/usecases/monitoring/prometheus.go
@@ -75,18 +75,18 @@ func newPrometheusMetrics() *PrometheusMetrics {
 		BatchTime: promauto.NewHistogramVec(prometheus.HistogramOpts{
 			Name:    "batch_durations_ms",
 			Help:    "Duration in ms of a single batch",
-			Buckets: prometheus.ExponentialBuckets(10, 1.25, 40),
+			Buckets: prometheus.ExponentialBuckets(10, 1.5, 12),
 		}, []string{"operation", "class_name", "shard_name"}),
 		BatchDeleteTime: promauto.NewHistogramVec(prometheus.HistogramOpts{
 			Name:    "batch_delete_durations_ms",
 			Help:    "Duration in ms of a single delete batch",
-			Buckets: prometheus.ExponentialBuckets(10, 1.25, 40),
+			Buckets: prometheus.ExponentialBuckets(10, 1.5, 12),
 		}, []string{"operation", "class_name", "shard_name"}),
 
 		ObjectsTime: promauto.NewHistogramVec(prometheus.HistogramOpts{
 			Name:    "objects_durations_ms",
 			Help:    "Duration of an individual object operation. Also as part of batches.",
-			Buckets: prometheus.ExponentialBuckets(10, 1.25, 25),
+			Buckets: prometheus.ExponentialBuckets(10, 1.5, 12),
 		}, []string{"operation", "step", "class_name", "shard_name"}),
 		ObjectCount: promauto.NewGaugeVec(prometheus.GaugeOpts{
 			Name: "object_count",
@@ -121,7 +121,7 @@ func newPrometheusMetrics() *PrometheusMetrics {
 		LSMBloomFilters: promauto.NewHistogramVec(prometheus.HistogramOpts{
 			Name:    "lsm_bloom_filters_duration_ms",
 			Help:    "Duration of bloom filter operations",
-			Buckets: prometheus.ExponentialBuckets(0.001, 1.25, 60),
+			Buckets: prometheus.ExponentialBuckets(1, 1.5, 12),
 		}, []string{"operation", "strategy", "class_name", "shard_name"}),
 		LSMSegmentObjects: promauto.NewGaugeVec(prometheus.GaugeOpts{
 			Name: "lsm_segment_objects",
@@ -168,12 +168,12 @@ func newPrometheusMetrics() *PrometheusMetrics {
 		VectorIndexMaintenanceDurations: promauto.NewHistogramVec(prometheus.HistogramOpts{
 			Name:    "vector_index_maintenance_durations_ms",
 			Help:    "Duration of a sync or async vector index maintenance operation",
-			Buckets: prometheus.ExponentialBuckets(1, 1.5, 30),
+			Buckets: prometheus.ExponentialBuckets(1, 1.5, 12),
 		}, []string{"operation", "class_name", "shard_name"}),
 		VectorIndexDurations: promauto.NewHistogramVec(prometheus.HistogramOpts{
 			Name:    "vector_index_durations_ms",
 			Help:    "Duration of typical vector index operations (insert, delete)",
-			Buckets: prometheus.ExponentialBuckets(0.1, 1.5, 30),
+			Buckets: prometheus.ExponentialBuckets(0.1, 1.5, 12),
 		}, []string{"operation", "step", "class_name", "shard_name"}),
 		VectorDimensionsSum: promauto.NewGaugeVec(prometheus.GaugeOpts{
 			Name: "vector_dimensions_sum",
@@ -187,12 +187,12 @@ func newPrometheusMetrics() *PrometheusMetrics {
 		StartupDurations: promauto.NewHistogramVec(prometheus.HistogramOpts{
 			Name:    "startup_durations_ms",
 			Help:    "Duration of inidividual startup operations in ms",
-			Buckets: prometheus.ExponentialBuckets(100, 1.25, 40),
+			Buckets: prometheus.ExponentialBuckets(100, 1.5, 12),
 		}, []string{"operation", "class_name", "shard_name"}),
 		StartupDiskIO: promauto.NewHistogramVec(prometheus.HistogramOpts{
 			Name:    "startup_diskio_throughput",
 			Help:    "Disk I/O throuhput in bytes per second",
-			Buckets: prometheus.ExponentialBuckets(1, 2, 40),
+			Buckets: prometheus.ExponentialBuckets(1, 2, 12),
 		}, []string{"operation", "class_name", "shard_name"}),
 		QueryDimensions: promauto.NewCounterVec(prometheus.CounterOpts{
 			Name: "query_dimensions_total",
@@ -202,32 +202,32 @@ func newPrometheusMetrics() *PrometheusMetrics {
 		BackupRestoreDurations: promauto.NewHistogramVec(prometheus.HistogramOpts{
 			Name:    "backup_restore_ms",
 			Help:    "Duration of a backup restore",
-			Buckets: prometheus.ExponentialBuckets(1, 1.5, 30),
+			Buckets: prometheus.ExponentialBuckets(1, 1.5, 12),
 		}, []string{"backend_name", "class_name"}),
 		BackupRestoreClassDurations: promauto.NewHistogramVec(prometheus.HistogramOpts{
 			Name:    "backup_restore_class_ms",
 			Help:    "Duration restoring class",
-			Buckets: prometheus.ExponentialBuckets(1, 1.5, 30),
+			Buckets: prometheus.ExponentialBuckets(1, 1.5, 12),
 		}, []string{"class_name"}),
 		BackupRestoreBackupInitDurations: promauto.NewHistogramVec(prometheus.HistogramOpts{
 			Name:    "backup_restore_init_ms",
 			Help:    "startup phase of a backup restore",
-			Buckets: prometheus.ExponentialBuckets(1, 1.5, 30),
+			Buckets: prometheus.ExponentialBuckets(1, 1.5, 12),
 		}, []string{"backend_name", "class_name"}),
 		BackupRestoreFromStorageDurations: promauto.NewHistogramVec(prometheus.HistogramOpts{
 			Name:    "backup_restore_from_backend_ms",
 			Help:    "file transfer stage of a backup restore",
-			Buckets: prometheus.ExponentialBuckets(1, 1.5, 30),
+			Buckets: prometheus.ExponentialBuckets(1, 1.5, 12),
 		}, []string{"backend_name", "class_name"}),
 		BackupStoreDurations: promauto.NewHistogramVec(prometheus.HistogramOpts{
 			Name:    "backup_store_to_backend_ms",
 			Help:    "file transfer stage of a backup restore",
-			Buckets: prometheus.ExponentialBuckets(1, 1.5, 30),
+			Buckets: prometheus.ExponentialBuckets(1, 1.5, 12),
 		}, []string{"backend_name", "class_name"}),
 		BucketPauseDurations: promauto.NewHistogramVec(prometheus.HistogramOpts{
 			Name:    "bucket_pause_durations_ms",
 			Help:    "bucket pause durations",
-			Buckets: prometheus.ExponentialBuckets(1, 1.5, 30),
+			Buckets: prometheus.ExponentialBuckets(1, 1.5, 12),
 		}, []string{"bucket_dir"}),
 		BackupRestoreDataTransferred: promauto.NewCounterVec(prometheus.CounterOpts{
 			Name: "backup_restore_data_transferred",

--- a/usecases/traverser/metrics.go
+++ b/usecases/traverser/metrics.go
@@ -12,13 +12,16 @@
 package traverser
 
 import (
+	"time"
+
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/semi-technologies/weaviate/usecases/monitoring"
 )
 
 type Metrics struct {
-	queriesCount *prometheus.GaugeVec
-	dimensions   *prometheus.CounterVec
+	queriesCount     *prometheus.GaugeVec
+	queriesDurations *prometheus.HistogramVec
+	dimensions       *prometheus.CounterVec
 }
 
 func NewMetrics(prom *monitoring.PrometheusMetrics) *Metrics {
@@ -27,8 +30,9 @@ func NewMetrics(prom *monitoring.PrometheusMetrics) *Metrics {
 	}
 
 	return &Metrics{
-		queriesCount: prom.QueriesCount,
-		dimensions:   prom.QueryDimensions,
+		queriesCount:     prom.QueriesCount,
+		queriesDurations: prom.QueriesDurations,
+		dimensions:       prom.QueryDimensions,
 	}
 }
 
@@ -63,6 +67,19 @@ func (m *Metrics) QueriesGetInc(className string) {
 		"class_name": className,
 		"query_type": "get_graphql",
 	}).Inc()
+}
+
+func (m *Metrics) QueriesObserveDuration(className string, startMs int64) {
+	if m == nil {
+		return
+	}
+
+	took := float64(time.Now().UnixMilli() - startMs)
+
+	m.queriesDurations.With(prometheus.Labels{
+		"class_name": className,
+		"query_type": "get_graphql",
+	}).Observe(float64(took))
 }
 
 func (m *Metrics) QueriesGetDec(className string) {

--- a/usecases/traverser/traverser_get.go
+++ b/usecases/traverser/traverser_get.go
@@ -14,6 +14,7 @@ package traverser
 import (
 	"context"
 	"fmt"
+	"time"
 
 	"github.com/semi-technologies/weaviate/entities/models"
 )
@@ -21,8 +22,10 @@ import (
 func (t *Traverser) GetClass(ctx context.Context, principal *models.Principal,
 	params GetParams,
 ) (interface{}, error) {
+	before := time.Now()
 	t.metrics.QueriesGetInc(params.ClassName)
 	defer t.metrics.QueriesGetDec(params.ClassName)
+	defer t.metrics.QueriesObserveDuration(params.ClassName, before.UnixMilli())
 
 	err := t.authorizer.Authorize(principal, "get", "traversal/*")
 	if err != nil {


### PR DESCRIPTION
### What's being changed:

- Addition of new histogram metric `queries_durations_ms`. This allows measurement of how long a GraphQL get query takes which is currently a gap in metrics.
- Histogram bucket sizes reduced over all metrics from 60/40 to 12 to reduce cardinality issues.
- For `queries_durations_ms` I created custom histogram buckets to answer things like "What are the proportion of queries under 50 ms" etc. I chose not to use the [summary type](https://prometheus.io/docs/practices/histograms/) as this would add more overhead to Weaviate.

### Review notes

Can we validate that the traverser is the right place to collect these metrics? Alternative would be to collect in the [middleware layer](https://github.com/semi-technologies/weaviate/blob/e8b5ccb7ee4b372b8b87f568c824fd65b8848b24/adapters/handlers/rest/middlewares.go#L122-L140) but unfortunately we don't have shard level information here (not sure if easy to add).

I can merge `QueriesGetDec` and `QueriesObserveDuration` if recommended.

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.
