### PR TITLE
Extend GetObject with retries when consistency level is specified

### DIFF
--- a/adapters/clients/client.go
+++ b/adapters/clients/client.go
@@ -31,22 +31,10 @@ type retryer struct {
 
 func newRetryer() *retryer {
 	return &retryer{
-		minBackOff:  time.Millisecond * 200,
+		minBackOff:  time.Millisecond * 250,
 		maxBackOff:  time.Second * 30,
 		timeoutUnit: time.Second, // used by unit tests
 	}
-}
-
-// WithMin set minimum delay
-func (r *retryer) WithMin(d time.Duration) *retryer {
-	r.minBackOff = d
-	return r
-}
-
-// WithMax sets maximum delay
-func (r *retryer) WithMax(d time.Duration) *retryer {
-	r.maxBackOff = d
-	return r
 }
 
 func (r *retryer) retry(ctx context.Context, n int, work func(context.Context) (bool, error)) error {

--- a/adapters/clients/remote_index.go
+++ b/adapters/clients/remote_index.go
@@ -629,8 +629,7 @@ func (c *RemoteIndex) GetShardStatus(ctx context.Context,
 
 		if code := res.StatusCode; code != http.StatusOK {
 			body, _ := io.ReadAll(res.Body)
-			shouldRetry := (code == http.StatusInternalServerError || code == http.StatusTooManyRequests)
-			return shouldRetry, fmt.Errorf("status code: %v body: (%s)", code, body)
+			return shouldRetry(code), fmt.Errorf("status code: %v body: (%s)", code, body)
 		}
 		resBytes, err := io.ReadAll(res.Body)
 		if err != nil {
@@ -648,7 +647,7 @@ func (c *RemoteIndex) GetShardStatus(ctx context.Context,
 		}
 		return false, nil
 	}
-	return status, c.retry(ctx, 5, try)
+	return status, c.retry(ctx, 9, try)
 }
 
 func (c *RemoteIndex) UpdateShardStatus(ctx context.Context, hostName, indexName, shardName,
@@ -678,14 +677,13 @@ func (c *RemoteIndex) UpdateShardStatus(ctx context.Context, hostName, indexName
 
 		if code := res.StatusCode; code != http.StatusOK {
 			body, _ := io.ReadAll(res.Body)
-			shouldRetry := (code == http.StatusInternalServerError || code == http.StatusTooManyRequests)
-			return shouldRetry, fmt.Errorf("status code: %v body: (%s)", code, body)
+			return shouldRetry(code), fmt.Errorf("status code: %v body: (%s)", code, body)
 		}
 
 		return false, nil
 	}
 
-	return c.retry(ctx, 7, try)
+	return c.retry(ctx, 9, try)
 }
 
 func (c *RemoteIndex) PutFile(ctx context.Context, hostName, indexName,
@@ -710,7 +708,7 @@ func (c *RemoteIndex) PutFile(ctx context.Context, hostName, indexName,
 		defer res.Body.Close()
 
 		if code := res.StatusCode; code != http.StatusNoContent {
-			shouldRetry := (code == http.StatusInternalServerError || code == http.StatusTooManyRequests)
+			shouldRetry := shouldRetry(code)
 			if shouldRetry {
 				_, err := payload.Seek(0, 0)
 				shouldRetry = (err == nil)
@@ -721,7 +719,7 @@ func (c *RemoteIndex) PutFile(ctx context.Context, hostName, indexName,
 		return false, nil
 	}
 
-	return c.retry(ctx, 7, try)
+	return c.retry(ctx, 9, try)
 }
 
 func (c *RemoteIndex) CreateShard(ctx context.Context,
@@ -744,14 +742,13 @@ func (c *RemoteIndex) CreateShard(ctx context.Context,
 		defer res.Body.Close()
 
 		if code := res.StatusCode; code != http.StatusCreated {
-			shouldRetry := (code == http.StatusInternalServerError || code == http.StatusTooManyRequests)
 			body, _ := io.ReadAll(res.Body)
-			return shouldRetry, fmt.Errorf("status code: %v body: (%s)", code, body)
+			return shouldRetry(code), fmt.Errorf("status code: %v body: (%s)", code, body)
 		}
 		return false, nil
 	}
 
-	return c.retry(ctx, 7, try)
+	return c.retry(ctx, 9, try)
 }
 
 func (c *RemoteIndex) ReInitShard(ctx context.Context,
@@ -774,15 +771,14 @@ func (c *RemoteIndex) ReInitShard(ctx context.Context,
 		defer res.Body.Close()
 
 		if code := res.StatusCode; code != http.StatusNoContent {
-			shouldRetry := (code == http.StatusInternalServerError || code == http.StatusTooManyRequests)
 			body, _ := io.ReadAll(res.Body)
-			return shouldRetry, fmt.Errorf("status code: %v body: (%s)", code, body)
+			return shouldRetry(code), fmt.Errorf("status code: %v body: (%s)", code, body)
 
 		}
 		return false, nil
 	}
 
-	return c.retry(ctx, 7, try)
+	return c.retry(ctx, 9, try)
 }
 
 func (c *RemoteIndex) IncreaseReplicationFactor(ctx context.Context,
@@ -811,10 +807,78 @@ func (c *RemoteIndex) IncreaseReplicationFactor(ctx context.Context,
 
 		if code := res.StatusCode; code != http.StatusNoContent {
 			body, _ := io.ReadAll(res.Body)
-			shouldRetry := (code == http.StatusInternalServerError || code == http.StatusTooManyRequests)
-			return shouldRetry, fmt.Errorf("status code: %v body: (%s)", code, body)
+			return shouldRetry(code), fmt.Errorf("status code: %v body: (%s)", code, body)
 		}
 		return false, nil
 	}
-	return c.retry(ctx, 7, try)
+	return c.retry(ctx, 9, try)
+}
+
+// FindObject extends GetObject with retries
+// It exists to not alter the behavior of GetObject when replication is not enabled
+func (c *RemoteIndex) FindObject(ctx context.Context, hostName, indexName,
+	shardName string, id strfmt.UUID, selectProps search.SelectProperties,
+	additional additional.Properties,
+) (*storobj.Object, error) {
+	selectPropsBytes, err := json.Marshal(selectProps)
+	if err != nil {
+		return nil, fmt.Errorf("marshal selectProps props: %w", err)
+	}
+
+	additionalBytes, err := json.Marshal(additional)
+	if err != nil {
+		return nil, fmt.Errorf("marshal additional props: %w", err)
+	}
+
+	url := url.URL{
+		Scheme: "http",
+		Host:   hostName,
+		Path:   fmt.Sprintf("/indices/%s/shards/%s/objects/%s", indexName, shardName, id),
+	}
+	q := url.Query()
+	q.Set("additional", base64.StdEncoding.EncodeToString(additionalBytes))
+	q.Set("selectProperties", base64.StdEncoding.EncodeToString(selectPropsBytes))
+	url.RawQuery = q.Encode()
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url.String(), nil)
+	if err != nil {
+		return nil, fmt.Errorf("create http request: %w", err)
+	}
+
+	var obj *storobj.Object
+	try := func(ctx context.Context) (bool, error) {
+		res, err := c.client.Do(req)
+		if err != nil {
+			return ctx.Err() == nil, fmt.Errorf("connect: %w", err)
+		}
+
+		defer res.Body.Close()
+		if res.StatusCode == http.StatusNotFound {
+			// this is a legitimate case - the requested ID doesn't exist, don't try
+			// to unmarshal anything
+			return false, nil
+		}
+		if code := res.StatusCode; code != http.StatusOK {
+			body, _ := io.ReadAll(res.Body)
+			return shouldRetry(code), fmt.Errorf("status code: %v body: (%s)", code, body)
+
+		}
+
+		ct, ok := clusterapi.IndicesPayloads.SingleObject.CheckContentTypeHeader(res)
+		if !ok {
+			return false, fmt.Errorf("unknown content type %s", ct)
+		}
+
+		objBytes, err := io.ReadAll(res.Body)
+		if err != nil {
+			return false, fmt.Errorf("read body: %w", err)
+		}
+
+		obj, err = clusterapi.IndicesPayloads.SingleObject.Unmarshal(objBytes)
+		if err != nil {
+			return false, fmt.Errorf("unmarshal body: %w", err)
+		}
+		return false, nil
+	}
+	return obj, c.retry(ctx, 9, try)
 }

--- a/adapters/clients/remote_index_test.go
+++ b/adapters/clients/remote_index_test.go
@@ -33,8 +33,72 @@ import (
 	"time"
 
 	"github.com/semi-technologies/weaviate/adapters/handlers/rest/clusterapi"
+	"github.com/semi-technologies/weaviate/entities/additional"
+	"github.com/semi-technologies/weaviate/entities/search"
+	"github.com/semi-technologies/weaviate/entities/storobj"
 	"github.com/stretchr/testify/assert"
 )
+
+func TestRemoteIndexGetObject(t *testing.T) {
+	t.Parallel()
+	var (
+		ctx  = context.Background()
+		uuid = UUID1
+		path = fmt.Sprintf("/indices/C1/shards/S1/objects/%s", uuid)
+		obj  = &storobj.Object{MarshallerVersion: 1, Object: anyObject(UUID1)}
+		fs   = newFakeRemoteIndexServer(t, http.MethodGet, path)
+	)
+	ts := fs.server(t)
+	defer ts.Close()
+	client := newRemoteIndex(ts.Client())
+	t.Run("ConnectionError", func(t *testing.T) {
+		_, err := client.FindObject(ctx, "", "C1", "S1", uuid, search.SelectProperties{}, additional.Properties{})
+		assert.NotNil(t, err)
+		assert.Contains(t, err.Error(), "connect")
+	})
+	n := 0
+	fs.doAfter = func(w http.ResponseWriter, r *http.Request) {
+		if n == 0 {
+			w.WriteHeader(http.StatusNotFound)
+		} else if n == 1 {
+			w.WriteHeader(http.StatusInternalServerError)
+		} else if n == 2 {
+			w.WriteHeader(http.StatusTooManyRequests)
+		} else if n == 3 {
+			w.WriteHeader(http.StatusServiceUnavailable)
+		} else if n == 4 {
+			w.Header().Set("content-type", "any")
+		} else if n == 5 {
+			w.Header().Set("content-type", clusterapi.IndicesPayloads.SingleObject.MIME())
+			w.Write([]byte("hello"))
+		} else {
+			w.Header().Set("content-type", clusterapi.IndicesPayloads.SingleObject.MIME())
+			bytes, _ := clusterapi.IndicesPayloads.SingleObject.Marshal(obj)
+			w.Write(bytes)
+		}
+		n++
+	}
+	t.Run("NotFound", func(t *testing.T) {
+		obj, err := client.FindObject(ctx, fs.host, "C1", "S1", uuid, search.SelectProperties{}, additional.Properties{})
+		assert.Nil(t, err)
+		assert.Nil(t, obj)
+	})
+	t.Run("ContentType", func(t *testing.T) {
+		_, err := client.FindObject(ctx, fs.host, "C1", "S1", uuid, search.SelectProperties{}, additional.Properties{})
+		assert.NotNil(t, err)
+	})
+
+	t.Run("body", func(t *testing.T) {
+		_, err := client.FindObject(ctx, fs.host, "C1", "S1", uuid, search.SelectProperties{}, additional.Properties{})
+		assert.NotNil(t, err)
+	})
+	t.Run("Success", func(t *testing.T) {
+		obj, err := client.FindObject(ctx, fs.host, "C1", "S1", uuid, search.SelectProperties{}, additional.Properties{})
+		assert.Nil(t, err)
+		assert.NotNil(t, obj)
+		assert.Equal(t, uuid, obj.ID())
+	})
+}
 
 func TestRemoteIndexIncreaseRF(t *testing.T) {
 	t.Parallel()

--- a/adapters/handlers/rest/clusterapi/serve.go
+++ b/adapters/handlers/rest/clusterapi/serve.go
@@ -27,7 +27,7 @@ func Serve(appState *state.State) {
 		Debugf("serving cluster api on port %d", port)
 
 	schema := NewSchema(appState.SchemaManager.TxManager())
-	indices := NewIndices(appState.RemoteIndexIncoming)
+	indices := NewIndices(appState.RemoteIndexIncoming, appState.DB)
 	replicatedIndices := NewReplicatedIndices(appState.RemoteReplicaIncoming, appState.ScaleOutManager)
 	classifications := NewClassifications(appState.ClassificationRepo.TxManager())
 	nodes := NewNodes(appState.RemoteNodeIncoming)

--- a/adapters/handlers/rest/configure_api.go
+++ b/adapters/handlers/rest/configure_api.go
@@ -179,6 +179,7 @@ func configureAPI(api *operations.WeaviateAPI) http.Handler {
 		ReindexVectorDimensionsAtStartup: appState.ServerConfig.Config.ReindexVectorDimensionsAtStartup,
 		ResourceUsage:                    appState.ServerConfig.Config.ResourceUsage,
 	}, remoteIndexClient, appState.Cluster, remoteNodesClient, replicationClient, appState.Metrics) // TODO client
+	appState.DB = repo
 	vectorMigrator = db.NewMigrator(repo, appState.Logger)
 	vectorRepo = repo
 	migrator = vectorMigrator

--- a/adapters/handlers/rest/state/state.go
+++ b/adapters/handlers/rest/state/state.go
@@ -14,6 +14,7 @@ package state
 import (
 	"github.com/semi-technologies/weaviate/adapters/handlers/graphql"
 	"github.com/semi-technologies/weaviate/adapters/repos/classifications"
+	"github.com/semi-technologies/weaviate/adapters/repos/db"
 	"github.com/semi-technologies/weaviate/usecases/auth/authentication/anonymous"
 	"github.com/semi-technologies/weaviate/usecases/auth/authentication/oidc"
 	"github.com/semi-technologies/weaviate/usecases/auth/authorization"
@@ -52,6 +53,7 @@ type State struct {
 	ClassificationRepo *classifications.DistributedRepo
 	Metrics            *monitoring.PrometheusMetrics
 	BackupManager      *backup.Manager
+	DB                 *db.DB
 }
 
 // GetGraphQL is the safe way to retrieve GraphQL from the state as it can be

--- a/adapters/repos/db/clusterintegrationtest/fakes_for_test.go
+++ b/adapters/repos/db/clusterintegrationtest/fakes_for_test.go
@@ -96,7 +96,7 @@ func (n *node) init(dirName string, shardStateRaw []byte,
 
 	n.migrator = db.NewMigrator(n.repo, logger)
 
-	indices := clusterapi.NewIndices(sharding.NewRemoteIndexIncoming(n.repo))
+	indices := clusterapi.NewIndices(sharding.NewRemoteIndexIncoming(n.repo), n.repo)
 	mux := http.NewServeMux()
 	mux.Handle("/indices/", indices.Indices())
 

--- a/adapters/repos/db/fakes_for_test.go
+++ b/adapters/repos/db/fakes_for_test.go
@@ -138,6 +138,13 @@ func (f *fakeRemoteClient) GetObject(ctx context.Context, hostName, indexName,
 	return nil, nil
 }
 
+func (f *fakeRemoteClient) FindObject(ctx context.Context, hostName, indexName,
+	shardName string, id strfmt.UUID, props search.SelectProperties,
+	additional additional.Properties,
+) (*storobj.Object, error) {
+	return nil, nil
+}
+
 func (f *fakeRemoteClient) Exists(ctx context.Context, hostName, indexName,
 	shardName string, id strfmt.UUID,
 ) (bool, error) {

--- a/adapters/repos/db/replication.go
+++ b/adapters/repos/db/replication.go
@@ -135,7 +135,7 @@ func (db *DB) AbortReplication(class,
 }
 
 func (db *DB) replicatedIndex(name string) (idx *Index, resp *replica.SimpleResponse) {
-	if !db.startupComplete.Load() {
+	if !db.StartupComplete() {
 		return nil, &replica.SimpleResponse{Errors: []replica.Error{
 			*replica.NewError(replica.StatusNotReady, name),
 		}}

--- a/adapters/repos/db/repo.go
+++ b/adapters/repos/db/repo.go
@@ -77,6 +77,8 @@ func (d *DB) WaitForStartup(ctx context.Context) error {
 	return nil
 }
 
+func (d *DB) StartupComplete() bool { return d.startupComplete.Load() }
+
 func New(logger logrus.FieldLogger, config Config,
 	remoteIndex sharding.RemoteIndexClient, nodeResolver nodeResolver,
 	remoteNodesClient sharding.RemoteNodeClient, replicaClient replica.Client,

--- a/usecases/classification/integrationtest/fakes_for_integration_test.go
+++ b/usecases/classification/integrationtest/fakes_for_integration_test.go
@@ -350,6 +350,13 @@ func (f *fakeRemoteClient) GetObject(ctx context.Context, hostName, indexName,
 	return nil, nil
 }
 
+func (f *fakeRemoteClient) FindObject(ctx context.Context, hostName, indexName,
+	shardName string, id strfmt.UUID, props search.SelectProperties,
+	additional additional.Properties,
+) (*storobj.Object, error) {
+	return nil, nil
+}
+
 func (f *fakeRemoteClient) Exists(ctx context.Context, hostName, indexName,
 	shardName string, id strfmt.UUID,
 ) (bool, error) {

--- a/usecases/replica/coordinator.go
+++ b/usecases/replica/coordinator.go
@@ -114,14 +114,15 @@ func (c *coordinator[T]) commitAll(ctx context.Context, replicas []string, op co
 // Replicate writes on all replicas of specific shard
 func (c *coordinator[T]) Replicate(ctx context.Context, ask readyOp, com commitOp[T]) error {
 	c.nodes = c.FindReplicas(c.shard)
+	const msg = "replication with consistency level 'ALL'"
 	if len(c.nodes) == 0 {
-		return fmt.Errorf("%w : class %q shard %q", errReplicaNotFound, c.class, c.shard)
+		return fmt.Errorf("%s: %w : class %q shard %q", msg, errReplicaNotFound, c.class, c.shard)
 	}
 	if err := c.broadcast(ctx, c.nodes, ask); err != nil {
-		return fmt.Errorf("broadcast: %w", err)
+		return fmt.Errorf("%s: broadcast: %w", msg, err)
 	}
 	if err := c.commitAll(context.Background(), c.nodes, com); err != nil {
-		return fmt.Errorf("commit: %w", err)
+		return fmt.Errorf("%s commit: %w", msg, err)
 	}
 	return nil
 }

--- a/usecases/replica/finder.go
+++ b/usecases/replica/finder.go
@@ -84,7 +84,7 @@ func (f *Finder) FindOne(ctx context.Context, level ConsistencyLevel, shard stri
 		for i, host := range replicas {
 			i, host := i, host
 			g.Go(func() error {
-				o, err := f.GetObject(ctx, host, f.class, shard, id, props, additional)
+				o, err := f.FindObject(ctx, host, f.class, shard, id, props, additional)
 				responses <- tuple{o, i, err}
 				return nil
 			})
@@ -105,7 +105,7 @@ func (f *Finder) NodeObject(ctx context.Context, nodeName, shard string,
 	if !ok || host == "" {
 		return nil, fmt.Errorf("cannot resolve node name: %s", nodeName)
 	}
-	return f.RClient.GetObject(ctx, host, f.class, shard, id, props, additional)
+	return f.RClient.FindObject(ctx, host, f.class, shard, id, props, additional)
 }
 
 func readObject(responses <-chan tuple, cl int, replicas []string) (*storobj.Object, error) {

--- a/usecases/replica/finder_test.go
+++ b/usecases/replica/finder_test.go
@@ -58,7 +58,7 @@ func TestFinderNodeObject(t *testing.T) {
 		f := newFakeFactory("C1", shard, nodes)
 		finder := f.newFinder()
 		for _, n := range nodes {
-			f.Client.On("GetObject", anyVal, n, cls, shard, id, proj, adds).Return(obj, nil)
+			f.Client.On("FindObject", anyVal, n, cls, shard, id, proj, adds).Return(obj, nil)
 		}
 		got, err := finder.NodeObject(ctx, nodes[0], shard, id, proj, adds)
 		assert.Nil(t, err)
@@ -91,7 +91,7 @@ func TestFinderFindOne(t *testing.T) {
 		f := newFakeFactory("C1", shard, nodes)
 		finder := f.newFinder()
 		for _, n := range nodes {
-			f.Client.On("GetObject", anyVal, n, cls, shard, id, proj, adds).Return(obj, nil)
+			f.Client.On("FindObject", anyVal, n, cls, shard, id, proj, adds).Return(obj, nil)
 		}
 		got, err := finder.FindOne(ctx, All, shard, id, proj, adds)
 		assert.Nil(t, err)
@@ -101,9 +101,9 @@ func TestFinderFindOne(t *testing.T) {
 		f := newFakeFactory("C1", shard, nodes)
 		finder := f.newFinder()
 		for _, n := range nodes[:len(nodes)-1] {
-			f.Client.On("GetObject", anyVal, n, cls, shard, id, proj, adds).Return(obj, nil)
+			f.Client.On("FindObject", anyVal, n, cls, shard, id, proj, adds).Return(obj, nil)
 		}
-		f.Client.On("GetObject", anyVal, nodes[len(nodes)-1], cls, shard, id, proj, adds).Return(object(id, 1), nil)
+		f.Client.On("FindObject", anyVal, nodes[len(nodes)-1], cls, shard, id, proj, adds).Return(object(id, 1), nil)
 		got, err := finder.FindOne(ctx, All, shard, id, proj, adds)
 		assert.NotNil(t, err)
 		assert.Nil(t, got)
@@ -113,9 +113,9 @@ func TestFinderFindOne(t *testing.T) {
 		f := newFakeFactory("C1", shard, nodes)
 		finder := f.newFinder()
 		for _, n := range nodes[1:] {
-			f.Client.On("GetObject", anyVal, n, cls, shard, id, proj, adds).Return(obj, nil)
+			f.Client.On("FindObject", anyVal, n, cls, shard, id, proj, adds).Return(obj, nil)
 		}
-		f.Client.On("GetObject", anyVal, nodes[0], cls, shard, id, proj, adds).Return(object(id, 1), nil)
+		f.Client.On("FindObject", anyVal, nodes[0], cls, shard, id, proj, adds).Return(object(id, 1), nil)
 		got, err := finder.FindOne(ctx, All, shard, id, proj, adds)
 		assert.NotNil(t, err)
 		assert.Nil(t, got)
@@ -126,9 +126,9 @@ func TestFinderFindOne(t *testing.T) {
 		finder := f.newFinder()
 		obj := object(id, 5)
 		for _, n := range nodes[1:] {
-			f.Client.On("GetObject", anyVal, n, cls, shard, id, proj, adds).Return(obj, nil)
+			f.Client.On("FindObject", anyVal, n, cls, shard, id, proj, adds).Return(obj, nil)
 		}
-		f.Client.On("GetObject", anyVal, nodes[0], cls, shard, id, proj, adds).Return(object(id, 1), nil)
+		f.Client.On("FindObject", anyVal, nodes[0], cls, shard, id, proj, adds).Return(object(id, 1), nil)
 		got, err := finder.FindOne(ctx, Quorum, shard, id, proj, adds)
 		assert.Nil(t, err)
 		assert.Equal(t, obj, got)
@@ -138,9 +138,9 @@ func TestFinderFindOne(t *testing.T) {
 		finder := f.newFinder()
 		for i, n := range nodes {
 			obj := object(id, int64(i+1))
-			f.Client.On("GetObject", anyVal, n, cls, shard, id, proj, adds).Return(obj, nil)
+			f.Client.On("FindObject", anyVal, n, cls, shard, id, proj, adds).Return(obj, nil)
 		}
-		f.Client.On("GetObject", anyVal, nodes[0], cls, shard, id, proj, adds).Return(object(id, 1), nil)
+		f.Client.On("FindObject", anyVal, nodes[0], cls, shard, id, proj, adds).Return(object(id, 1), nil)
 		got, err := finder.FindOne(ctx, Quorum, shard, id, proj, adds)
 		assert.Nil(t, got)
 		assert.Contains(t, err.Error(), "A: 1, B: 2, C: 3")
@@ -149,10 +149,10 @@ func TestFinderFindOne(t *testing.T) {
 		f := newFakeFactory("C1", shard, nodes)
 		finder := f.newFinder()
 		obj := object(id, 1)
-		f.Client.On("GetObject", anyVal, nodes[0], cls, shard, id, proj, adds).Return(obj, nil)
+		f.Client.On("FindObject", anyVal, nodes[0], cls, shard, id, proj, adds).Return(obj, nil)
 		for i, n := range nodes {
 			obj := object(id, int64(i+1))
-			f.Client.On("GetObject", anyVal, n, cls, shard, id, proj, adds).Return(obj, nil).After(time.Second)
+			f.Client.On("FindObject", anyVal, n, cls, shard, id, proj, adds).Return(obj, nil).After(time.Second)
 		}
 		got, err := finder.FindOne(ctx, One, shard, id, proj, adds)
 		assert.Nil(t, err)
@@ -164,9 +164,9 @@ func TestFinderFindOne(t *testing.T) {
 		finder := f.newFinder()
 		obj := object(id, 5)
 		for _, n := range nodes[:len(nodes)-1] {
-			f.Client.On("GetObject", anyVal, n, cls, shard, id, proj, adds).Return(obj, errAny).After(time.Second)
+			f.Client.On("FindObject", anyVal, n, cls, shard, id, proj, adds).Return(obj, errAny).After(time.Second)
 		}
-		f.Client.On("GetObject", anyVal, nodes[len(nodes)-1], cls, shard, id, proj, adds).Return(obj, nil)
+		f.Client.On("FindObject", anyVal, nodes[len(nodes)-1], cls, shard, id, proj, adds).Return(obj, nil)
 		got, err := finder.FindOne(ctx, One, shard, id, proj, adds)
 		assert.Nil(t, err)
 		assert.Equal(t, obj, got)
@@ -177,7 +177,7 @@ func TestFinderFindOne(t *testing.T) {
 		finder := f.newFinder()
 		var obj *storobj.Object
 		for _, n := range nodes {
-			f.Client.On("GetObject", anyVal, n, cls, shard, id, proj, adds).Return(obj, nil)
+			f.Client.On("FindObject", anyVal, n, cls, shard, id, proj, adds).Return(obj, nil)
 		}
 		got, err := finder.FindOne(ctx, One, shard, id, proj, adds)
 		assert.Nil(t, err)
@@ -188,7 +188,7 @@ func TestFinderFindOne(t *testing.T) {
 		finder := f.newFinder()
 		obj := object(id, 5)
 		for _, n := range nodes {
-			f.Client.On("GetObject", anyVal, n, cls, shard, id, proj, adds).Return(obj, errAny)
+			f.Client.On("FindObject", anyVal, n, cls, shard, id, proj, adds).Return(obj, errAny)
 		}
 		got, err := finder.FindOne(ctx, One, shard, id, proj, adds)
 		assert.NotNil(t, err)

--- a/usecases/replica/mocks_test.go
+++ b/usecases/replica/mocks_test.go
@@ -27,7 +27,7 @@ type fakeRClient struct {
 	mock.Mock
 }
 
-func (f *fakeRClient) GetObject(ctx context.Context, host, index, shard string,
+func (f *fakeRClient) FindObject(ctx context.Context, host, index, shard string,
 	id strfmt.UUID, props search.SelectProperties,
 	additional additional.Properties,
 ) (*storobj.Object, error) {
@@ -91,7 +91,7 @@ func (f *fakeClient) Abort(ctx context.Context, host, index, shard, requestID st
 	return args.Get(0).(SimpleResponse), args.Error(1)
 }
 
-func (f *fakeClient) GetObject(ctx context.Context, host, index, shard string,
+func (f *fakeClient) FindObject(ctx context.Context, host, index, shard string,
 	id strfmt.UUID, props search.SelectProperties,
 	additional additional.Properties,
 ) (*storobj.Object, error) {

--- a/usecases/replica/transport.go
+++ b/usecases/replica/transport.go
@@ -157,7 +157,7 @@ type Client interface {
 
 // RClient is the client used to read from remote replicas
 type RClient interface {
-	GetObject(ctx context.Context, host, index, shard string,
+	FindObject(ctx context.Context, host, index, shard string,
 		id strfmt.UUID, props search.SelectProperties,
 		additional additional.Properties) (*storobj.Object, error)
 }

--- a/usecases/sharding/remote_index.go
+++ b/usecases/sharding/remote_index.go
@@ -87,6 +87,12 @@ type RemoteIndexClient interface {
 
 	PutFile(ctx context.Context, hostName, indexName, shardName, fileName string,
 		payload io.ReadSeekCloser) error
+
+	// FindObject extends GetObject with retries
+	// It exists to not alter the behavior of GetObject when replication is not enabled
+	FindObject(ctx context.Context, hostname, indexName, shardName string,
+		id strfmt.UUID, props search.SelectProperties,
+		additional additional.Properties) (*storobj.Object, error)
 }
 
 func (ri *RemoteIndex) PutObject(ctx context.Context, shardName string,


### PR DESCRIPTION


### What's being changed:
Extend GetObject with retries when consistency level is specified
Add more context to replication erros
Increase replication timeouts to 90 sec to count for node restart

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [x] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.
