### PR TITLE
Don't attempt to query the inverted index on properties that aren't indexed

### DIFF
--- a/adapters/repos/db/bm25f_test.go
+++ b/adapters/repos/db/bm25f_test.go
@@ -46,6 +46,7 @@ func BM25FinvertedConfig(k1, b float32) *models.InvertedIndexConfig {
 		IndexPropertyLength: true,
 	}
 }
+
 func truePointer() *bool {
 	t := true
 	return &t
@@ -57,24 +58,24 @@ func SetupClass(t require.TestingT, repo *DB, schemaGetter *fakeSchemaGetter, lo
 		VectorIndexConfig:   enthnsw.NewDefaultUserConfig(),
 		InvertedIndexConfig: BM25FinvertedConfig(k1, b),
 		Class:               "MyClass",
-		
+
 		Properties: []*models.Property{
 			{
-				Name:         "title",
-				DataType:     []string{string(schema.DataTypeText)},
-				Tokenization: "word",
+				Name:          "title",
+				DataType:      []string{string(schema.DataTypeText)},
+				Tokenization:  "word",
 				IndexInverted: truePointer(),
 			},
 			{
-				Name:         "description",
-				DataType:     []string{string(schema.DataTypeText)},
-				Tokenization: "word",
+				Name:          "description",
+				DataType:      []string{string(schema.DataTypeText)},
+				Tokenization:  "word",
 				IndexInverted: truePointer(),
 			},
 			{
-				Name:         "stringField",
-				DataType:     []string{string(schema.DataTypeString)},
-				Tokenization: "field",
+				Name:          "stringField",
+				DataType:      []string{string(schema.DataTypeString)},
+				Tokenization:  "field",
 				IndexInverted: truePointer(),
 			},
 		},

--- a/adapters/repos/db/bm25f_test.go
+++ b/adapters/repos/db/bm25f_test.go
@@ -46,6 +46,10 @@ func BM25FinvertedConfig(k1, b float32) *models.InvertedIndexConfig {
 		IndexPropertyLength: true,
 	}
 }
+func truePointer() *bool {
+	t := true
+	return &t
+}
 
 func SetupClass(t require.TestingT, repo *DB, schemaGetter *fakeSchemaGetter, logger logrus.FieldLogger, k1, b float32,
 ) {
@@ -53,21 +57,25 @@ func SetupClass(t require.TestingT, repo *DB, schemaGetter *fakeSchemaGetter, lo
 		VectorIndexConfig:   enthnsw.NewDefaultUserConfig(),
 		InvertedIndexConfig: BM25FinvertedConfig(k1, b),
 		Class:               "MyClass",
+		
 		Properties: []*models.Property{
 			{
 				Name:         "title",
 				DataType:     []string{string(schema.DataTypeText)},
 				Tokenization: "word",
+				IndexInverted: truePointer(),
 			},
 			{
 				Name:         "description",
 				DataType:     []string{string(schema.DataTypeText)},
 				Tokenization: "word",
+				IndexInverted: truePointer(),
 			},
 			{
 				Name:         "stringField",
 				DataType:     []string{string(schema.DataTypeString)},
 				Tokenization: "field",
+				IndexInverted: truePointer(),
 			},
 		},
 	}

--- a/adapters/repos/db/clusterintegrationtest/helpers_for_test.go
+++ b/adapters/repos/db/clusterintegrationtest/helpers_for_test.go
@@ -118,6 +118,11 @@ func multiShardState(nodeCount int) *sharding.State {
 	return s
 }
 
+func truePointer() *bool {
+	b := true
+	return &b
+}
+
 func class() *models.Class {
 	cfg := enthnsw.NewDefaultUserConfig()
 	cfg.EF = 500
@@ -130,10 +135,12 @@ func class() *models.Class {
 				Name:         "description",
 				DataType:     []string{string(schema.DataTypeText)},
 				Tokenization: "word",
+				IndexInverted: truePointer(),
 			},
 			{
 				Name:     "other_property",
 				DataType: []string{string(schema.DataTypeText)},
+				IndexInverted: truePointer(),
 			},
 			{
 				Name:     "date_property",

--- a/adapters/repos/db/clusterintegrationtest/helpers_for_test.go
+++ b/adapters/repos/db/clusterintegrationtest/helpers_for_test.go
@@ -132,14 +132,14 @@ func class() *models.Class {
 		InvertedIndexConfig: invertedConfig(),
 		Properties: []*models.Property{
 			{
-				Name:         "description",
-				DataType:     []string{string(schema.DataTypeText)},
-				Tokenization: "word",
+				Name:          "description",
+				DataType:      []string{string(schema.DataTypeText)},
+				Tokenization:  "word",
 				IndexInverted: truePointer(),
 			},
 			{
-				Name:     "other_property",
-				DataType: []string{string(schema.DataTypeText)},
+				Name:          "other_property",
+				DataType:      []string{string(schema.DataTypeText)},
 				IndexInverted: truePointer(),
 			},
 			{

--- a/adapters/repos/db/inverted/bm25_searcher.go
+++ b/adapters/repos/db/inverted/bm25_searcher.go
@@ -90,15 +90,32 @@ func (b *BM25Searcher) Object(ctx context.Context, limit int,
 	terms := strings.Split(keywordRanking.Query, " ")
 
 	idLists := make([]docPointersWithScore, len(terms))
-
+	c, err := schema.GetClassByName(b.schema.Objects, string(className))
+	if err != nil {
+		return nil, []float32{}, errors.Wrap(err,
+			"get class by name")
+	}
 	for i, term := range terms {
-		ids, err := b.retrieveScoreAndSortForSingleTerm(ctx,
-			keywordRanking.Properties[0], term)
-		if err != nil {
-			return nil, nil, err
-		}
+		property := keywordRanking.Properties[0]
+		p, err := schema.GetPropertyByName(c, property)
 
-		idLists[i] = ids
+		if err != nil {
+			return nil, []float32{}, errors.Wrap(err,
+				"read property from class")
+		}
+		indexed := p.IndexInverted
+
+		if indexed !=nil &&  *indexed {
+			ids, err := b.retrieveScoreAndSortForSingleTerm(ctx,
+				property, term)
+			if err != nil {
+				return nil, nil, err
+			}
+
+			idLists[i] = ids
+		} else {
+			idLists[i] = docPointersWithScore{}
+		}
 	}
 
 	before := time.Now()
@@ -308,19 +325,24 @@ func (b *BM25Searcher) retrieveForSingleTermMultipleProps(ctx context.Context, c
 				"get class by name")
 		}
 		p, err := schema.GetPropertyByName(c, property)
+
 		if err != nil {
 			return docPointersWithScore{}, errors.Wrap(err,
 				"read property from class")
 		}
+		indexed := p.IndexInverted
 
-		if p.Tokenization == "word" {
-			ids, err = b.getIdsWithFrequenciesForTerm(ctx, property, searchTerm)
-		} else {
-			ids, err = b.getIdsWithFrequenciesForTerm(ctx, property, query)
-		}
-		if err != nil {
-			return docPointersWithScore{}, errors.Wrap(err,
-				"read doc ids and their frequencies from inverted index")
+		//Properties don't have to be indexed, if they are not, they will error on search
+		if indexed != nil && *indexed {
+			if p.Tokenization == "word" {
+				ids, err = b.getIdsWithFrequenciesForTerm(ctx, property, searchTerm)
+			} else {
+				ids, err = b.getIdsWithFrequenciesForTerm(ctx, property, query)
+			}
+			if err != nil {
+				return docPointersWithScore{}, errors.Wrap(err,
+					"read doc ids and their frequencies from inverted index")
+			}
 		}
 
 		for i := range ids.docIDs {

--- a/adapters/repos/db/inverted/bm25_searcher.go
+++ b/adapters/repos/db/inverted/bm25_searcher.go
@@ -98,14 +98,13 @@ func (b *BM25Searcher) Object(ctx context.Context, limit int,
 	for i, term := range terms {
 		property := keywordRanking.Properties[0]
 		p, err := schema.GetPropertyByName(c, property)
-
 		if err != nil {
 			return nil, []float32{}, errors.Wrap(err,
 				"read property from class")
 		}
 		indexed := p.IndexInverted
 
-		if indexed !=nil &&  *indexed {
+		if indexed != nil && *indexed {
 			ids, err := b.retrieveScoreAndSortForSingleTerm(ctx,
 				property, term)
 			if err != nil {
@@ -325,14 +324,13 @@ func (b *BM25Searcher) retrieveForSingleTermMultipleProps(ctx context.Context, c
 				"get class by name")
 		}
 		p, err := schema.GetPropertyByName(c, property)
-
 		if err != nil {
 			return docPointersWithScore{}, errors.Wrap(err,
 				"read property from class")
 		}
 		indexed := p.IndexInverted
 
-		//Properties don't have to be indexed, if they are not, they will error on search
+		// Properties don't have to be indexed, if they are not, they will error on search
 		if indexed != nil && *indexed {
 			if p.Tokenization == "word" {
 				ids, err = b.getIdsWithFrequenciesForTerm(ctx, property, searchTerm)

--- a/adapters/repos/db/multi_shard_integration_test.go
+++ b/adapters/repos/db/multi_shard_integration_test.go
@@ -172,10 +172,12 @@ func Test_MultiShardJourneys_BM25_Search(t *testing.T) {
 					Name:         "contents",
 					DataType:     []string{string(schema.DataTypeText)},
 					Tokenization: "word",
+					IndexInverted: truePointer(),
 				},
 				{
 					Name:     "stringProp",
 					DataType: []string{string(schema.DataTypeString)},
+					IndexInverted: truePointer(),
 				},
 				{
 					Name:     "textArrayProp",
@@ -865,6 +867,7 @@ func testClassesForImporting() []*models.Class {
 				{
 					Name:     "stringProp",
 					DataType: []string{string(schema.DataTypeString)},
+					IndexInverted: truePointer(),
 				},
 				{
 					Name:     "textArrayProp",

--- a/adapters/repos/db/multi_shard_integration_test.go
+++ b/adapters/repos/db/multi_shard_integration_test.go
@@ -169,14 +169,14 @@ func Test_MultiShardJourneys_BM25_Search(t *testing.T) {
 			},
 			Properties: []*models.Property{
 				{
-					Name:         "contents",
-					DataType:     []string{string(schema.DataTypeText)},
-					Tokenization: "word",
+					Name:          "contents",
+					DataType:      []string{string(schema.DataTypeText)},
+					Tokenization:  "word",
 					IndexInverted: truePointer(),
 				},
 				{
-					Name:     "stringProp",
-					DataType: []string{string(schema.DataTypeString)},
+					Name:          "stringProp",
+					DataType:      []string{string(schema.DataTypeString)},
 					IndexInverted: truePointer(),
 				},
 				{
@@ -865,8 +865,8 @@ func testClassesForImporting() []*models.Class {
 					DataType: []string{string(schema.DataTypeInt)},
 				},
 				{
-					Name:     "stringProp",
-					DataType: []string{string(schema.DataTypeString)},
+					Name:          "stringProp",
+					DataType:      []string{string(schema.DataTypeString)},
 					IndexInverted: truePointer(),
 				},
 				{


### PR DESCRIPTION
Weaviate currently allows inverted index searches on all text and string properties, however properties can have the index turned off.  This patch checks that an index exists before attempting to query it.

### What's being changed:


### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.
