### PR TITLE
Set default alpha correctly

### DIFF
--- a/adapters/handlers/graphql/local/get/class_builder_fields.go
+++ b/adapters/handlers/graphql/local/get/class_builder_fields.go
@@ -438,6 +438,14 @@ func (r *resolver) makeResolveGetClass(className string) graphql.FieldResolveFn 
 				args.Alpha = float64(config.DefaultAlpha)
 			}
 
+			if args.Alpha < 0.0 {
+				args.Alpha = 0.0
+			}
+
+			if args.Alpha > 1.0 {
+				args.Alpha = 1.0
+			}
+
 			query, ok := source["query"]
 			if ok {
 				args.Query = query.(string)

--- a/adapters/handlers/graphql/local/get/class_builder_fields.go
+++ b/adapters/handlers/graphql/local/get/class_builder_fields.go
@@ -435,7 +435,7 @@ func (r *resolver) makeResolveGetClass(className string) graphql.FieldResolveFn 
 			if ok {
 				args.Alpha = alpha.(float64)
 			} else {
-				args.Alpha = float64(config.DefaultAlpha)
+				args.Alpha = config.DefaultAlpha
 			}
 
 			if args.Alpha < 0.0 {

--- a/adapters/handlers/graphql/local/get/class_builder_fields.go
+++ b/adapters/handlers/graphql/local/get/class_builder_fields.go
@@ -26,6 +26,7 @@ import (
 	"github.com/semi-technologies/weaviate/entities/schema"
 	"github.com/semi-technologies/weaviate/entities/search"
 	"github.com/semi-technologies/weaviate/entities/searchparams"
+	"github.com/semi-technologies/weaviate/usecases/config"
 	"github.com/semi-technologies/weaviate/usecases/traverser"
 	"github.com/tailor-inc/graphql"
 	"github.com/tailor-inc/graphql/language/ast"
@@ -433,6 +434,8 @@ func (r *resolver) makeResolveGetClass(className string) graphql.FieldResolveFn 
 			alpha, ok := source["alpha"]
 			if ok {
 				args.Alpha = alpha.(float64)
+			} else {
+				args.Alpha = float64(config.DefaultAlpha)
 			}
 
 			query, ok := source["query"]

--- a/usecases/config/config_handler.go
+++ b/usecases/config/config_handler.go
@@ -48,7 +48,7 @@ const (
 	DefaultBM25b  = float32(0.75)
 
 	// These hybrid tuning params can be overwritten on a per-class basis
-	DefaultAlpha = float32(0.75)
+	DefaultAlpha = float64(0.75)
 )
 
 const (


### PR DESCRIPTION
### What's being changed:

This correctly sets alpha to the default value of 0.75 if it isn't present in the query.  It also checks for alpha being out of bounds.

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.
