### PR TITLE
Improve selection of replicas and return more descriptive selection errors

### DIFF
--- a/usecases/replica/finder_test.go
+++ b/usecases/replica/finder_test.go
@@ -32,7 +32,7 @@ func TestFinderReplicaNotFound(t *testing.T) {
 		f       = factory.newFinder()
 	)
 	_, err := f.FindOne(ctx, "ONE", "S", "id", nil, additional.Properties{})
-	assert.ErrorIs(t, err, errReplicaNotFound)
+	assert.ErrorIs(t, err, errNoReplicaFound)
 }
 
 func TestFinderNodeObject(t *testing.T) {

--- a/usecases/replica/replicator.go
+++ b/usecases/replica/replicator.go
@@ -198,30 +198,6 @@ func (r *Replicator) AddReferences(ctx context.Context, shard string,
 	return errorsFromSimpleResponses(len(refs), coord.responses, err)
 }
 
-// rFinder is just a place holder to find replicas of specific hard
-// TODO: the mapping between a shard and its replicas need to be implemented
-type rFinder struct {
-	schema   shardingState
-	resolver nodeResolver
-	class    string
-}
-
-func (r *rFinder) FindReplicas(shardName string) []string {
-	shard, ok := r.schema.ShardingState(r.class).Physical[shardName]
-	if !ok {
-		return nil
-	}
-	replicas := make([]string, 0, len(shard.BelongsToNodes))
-	for _, node := range shard.BelongsToNodes {
-		host, ok := r.resolver.NodeHostname(node)
-		if !ok || host == "" {
-			return nil
-		}
-		replicas = append(replicas, host)
-	}
-	return replicas
-}
-
 func errorsFromSimpleResponses(batchSize int, rs []SimpleResponse, defaultErr error) []error {
 	errs := make([]error, batchSize)
 	n := 0

--- a/usecases/replica/replicator_test.go
+++ b/usecases/replica/replicator_test.go
@@ -32,7 +32,7 @@ func TestReplicatorReplicaNotFound(t *testing.T) {
 	f := newFakeFactory("C1", "S", []string{})
 	rep := f.newReplicator()
 	err := rep.PutObject(context.Background(), "S", nil)
-	assert.ErrorIs(t, err, errReplicaNotFound)
+	assert.ErrorIs(t, err, errNoReplicaFound)
 }
 
 func TestReplicatorPutObject(t *testing.T) {

--- a/usecases/replica/resolver.go
+++ b/usecases/replica/resolver.go
@@ -1,0 +1,101 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2022 SeMI Technologies B.V. All rights reserved.
+//
+//  CONTACT: hello@semi.technology
+//
+
+//	_       _
+//
+// __      _____  __ ___   ___  __ _| |_ ___
+//
+//	\ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//	 \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//	  \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//	 Copyright © 2016 - 2022 SeMI Technologies B.V. All rights reserved.
+//
+//	 CONTACT: hello@semi.technology
+package replica
+
+import (
+	"fmt"
+
+	"github.com/pkg/errors"
+)
+
+type ConsistencyLevel string
+
+const (
+	One    ConsistencyLevel = "ONE"
+	Quorum ConsistencyLevel = "QUORUM"
+	All    ConsistencyLevel = "ALL"
+)
+
+func cLevel(l ConsistencyLevel, n int) int {
+	switch l {
+	case All:
+		return n
+	case Quorum:
+		return n/2 + 1
+	default:
+		return 1
+	}
+}
+
+var (
+	errNoReplicaFound = errors.New("no replica found")
+	errUnresolvedName = errors.New("unresolved node name")
+)
+
+// resolver finds replicas and resolves theirs names
+type resolver struct {
+	schema shardingState
+	nodeResolver
+	class string
+}
+
+// State returns replicas state
+func (r *resolver) State(shardName string) (res rState, err error) {
+	shard, ok := r.schema.ShardingState(r.class).Physical[shardName]
+	if !ok {
+		return res, fmt.Errorf("sharding state not found")
+	}
+	if len(shard.BelongsToNodes) == 0 {
+		return res, errNoReplicaFound
+	}
+	res.Hosts = make([]string, 0, len(shard.BelongsToNodes))
+	for _, node := range shard.BelongsToNodes {
+		host, ok := r.NodeHostname(node)
+		if ok && host != "" {
+			res.Hosts = append(res.Hosts, host)
+		} else {
+			res.nodes = append(res.nodes, node)
+		}
+	}
+	return res, nil
+}
+
+// rState replicas state
+type rState struct {
+	Hosts []string // successfully resolved names
+	nodes []string // names which could not be resolved
+}
+
+// Len returns the number of replica
+func (r rState) Len() int {
+	return len(r.Hosts) + len(r.nodes)
+}
+
+// ConsistencyLevel returns consistency level when it is satisfied
+func (r rState) ConsistencyLevel(l ConsistencyLevel) (int, error) {
+	level := cLevel(l, r.Len())
+	if n := len(r.Hosts); level > n {
+		return 0, fmt.Errorf("consistency level (%d) > available replicas(%d): %w :%v", level, n, errUnresolvedName, r.nodes)
+	}
+	return level, nil
+}

--- a/usecases/replica/resolver.go
+++ b/usecases/replica/resolver.go
@@ -9,17 +9,6 @@
 //  CONTACT: hello@semi.technology
 //
 
-//	_       _
-//
-// __      _____  __ ___   ___  __ _| |_ ___
-//
-//	\ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
-//	 \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
-//	  \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
-//
-//	 Copyright © 2016 - 2022 SeMI Technologies B.V. All rights reserved.
-//
-//	 CONTACT: hello@semi.technology
 package replica
 
 import (

--- a/usecases/replica/resolver_test.go
+++ b/usecases/replica/resolver_test.go
@@ -1,0 +1,69 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2022 SeMI Technologies B.V. All rights reserved.
+//
+//  CONTACT: hello@semi.technology
+//
+
+package replica
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestResolver(t *testing.T) {
+	ss := map[string][]string{
+		"S0": {},
+		"S1": {"A", "B", "C"},
+		"S2": {"D", "E"},
+		"S3": {"A", "B", "C", "D", "E"},
+		"S4": {"D", "E", "F"},
+		"S5": {"A", "B", "C", "D", "E", "F"},
+	}
+
+	r := resolver{
+		schema:       newFakeShardingState(ss),
+		nodeResolver: newFakeNodeResolver([]string{"A", "B", "C"}),
+	}
+	t.Run("ShardingState", func(t *testing.T) {
+		_, err := r.State("Sx")
+		assert.NotNil(t, err)
+		assert.Contains(t, err.Error(), "sharding state")
+	})
+	t.Run("ALL", func(t *testing.T) {
+		got, err := r.State("S1")
+		assert.Nil(t, err)
+		want := rState{ss["S1"], nil}
+		assert.Equal(t, want, got)
+	})
+	t.Run("Quorum", func(t *testing.T) {
+		got, err := r.State("S3")
+		assert.Nil(t, err)
+		want := rState{ss["S1"], ss["S2"]}
+		assert.Equal(t, want, got)
+		_, err = got.ConsistencyLevel(All)
+		assert.ErrorIs(t, err, errUnresolvedName)
+		_, err = got.ConsistencyLevel(Quorum)
+		assert.Nil(t, err)
+		_, err = got.ConsistencyLevel(One)
+		assert.Nil(t, err)
+	})
+	t.Run("NoQuorum", func(t *testing.T) {
+		got, err := r.State("S5")
+		assert.Nil(t, err)
+		want := rState{ss["S1"], ss["S4"]}
+		assert.Equal(t, want, got)
+		_, err = got.ConsistencyLevel(All)
+		assert.ErrorIs(t, err, errUnresolvedName)
+		_, err = got.ConsistencyLevel(Quorum)
+		assert.ErrorIs(t, err, errUnresolvedName)
+		_, err = got.ConsistencyLevel(One)
+		assert.Nil(t, err)
+	})
+}


### PR DESCRIPTION


### What's being changed:
Improve replica selection using a new class Resolver
Depending on the consistency level we can tolerate unresolved names
Make error returned during replicas selection more descriptive

### Review checklist

- [x] Documentation has been updated, if necessary. Link to changed documentation:
- [x] Chaos pipeline run or not necessary. Link to pipeline:https://github.com/semi-technologies/weaviate-chaos-engineering/pull/34
- [x] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.
