### PR TITLE
Add support for new OpenAI Davinci model version

### DIFF
--- a/adapters/repos/db/helper_for_test.go
+++ b/adapters/repos/db/helper_for_test.go
@@ -204,9 +204,10 @@ func testShard(t *testing.T, ctx context.Context, className string, indexOpts ..
 	tmpDir := t.TempDir()
 
 	shardState := singleShardState()
+	class := models.Class{Class: className}
 	sch := schema.Schema{
 		Objects: &models.Schema{
-			Classes: []*models.Class{{Class: className}},
+			Classes: []*models.Class{&class},
 		},
 	}
 	schemaGetter := &fakeSchemaGetter{shardState: shardState, schema: sch}
@@ -226,7 +227,7 @@ func testShard(t *testing.T, ctx context.Context, className string, indexOpts ..
 
 	shardName := shardState.AllPhysicalShards()[0]
 
-	shd, err := NewShard(ctx, nil, shardName, idx)
+	shd, err := NewShard(ctx, nil, shardName, idx, &class)
 	if err != nil {
 		panic(err)
 	}

--- a/adapters/repos/db/index.go
+++ b/adapters/repos/db/index.go
@@ -85,7 +85,7 @@ func NewIndex(ctx context.Context, config IndexConfig,
 	cs inverted.ClassSearcher, logger logrus.FieldLogger,
 	nodeResolver nodeResolver, remoteClient sharding.RemoteIndexClient,
 	replicaClient replica.Client,
-	promMetrics *monitoring.PrometheusMetrics,
+	promMetrics *monitoring.PrometheusMetrics, class *models.Class,
 ) (*Index, error) {
 	sd, err := stopwords.NewDetectorFromConfig(invertedIndexConfig.Stopwords)
 	if err != nil {
@@ -121,7 +121,7 @@ func NewIndex(ctx context.Context, config IndexConfig,
 			continue
 		}
 
-		shard, err := NewShard(ctx, promMetrics, shardName, index)
+		shard, err := NewShard(ctx, promMetrics, shardName, index, class)
 		if err != nil {
 			return nil, errors.Wrapf(err, "init shard %s of index %s", shardName, index.ID())
 		}

--- a/adapters/repos/db/init.go
+++ b/adapters/repos/db/init.go
@@ -71,7 +71,7 @@ func (d *DB) init(ctx context.Context) error {
 				inverted.ConfigFromModel(invertedConfig),
 				class.VectorIndexConfig.(schema.VectorIndexConfig),
 				d.schemaGetter, d, d.logger, d.nodeResolver, d.remoteIndex,
-				d.replicaClient, d.promMetrics)
+				d.replicaClient, d.promMetrics, class)
 			if err != nil {
 				return errors.Wrap(err, "create index")
 			}

--- a/adapters/repos/db/replication.go
+++ b/adapters/repos/db/replication.go
@@ -250,7 +250,7 @@ func (i *Index) IncomingCreateShard(ctx context.Context,
 	}
 
 	// TODO: metrics
-	s, err := NewShard(ctx, nil, shardName, i)
+	s, err := NewShard(ctx, nil, shardName, i, nil)
 	if err != nil {
 		return err
 	}
@@ -307,7 +307,7 @@ func (s *Shard) reinit(ctx context.Context) error {
 		defer s.vectorIndex.PostStartup()
 	}
 
-	if err := s.initNonVector(ctx); err != nil {
+	if err := s.initNonVector(ctx, nil); err != nil {
 		return fmt.Errorf("init non-vector: %w", err)
 	}
 

--- a/adapters/repos/db/search.go
+++ b/adapters/repos/db/search.go
@@ -281,9 +281,11 @@ func (d *DB) objectSearch(ctx context.Context, offset, limit int,
 func (d *DB) validateSort(sort []filters.Sort) error {
 	if len(sort) > 0 {
 		var errorMsgs []string
+		// needs to happen before the index lock as they might deadlock each other
+		schema := d.schemaGetter.GetSchemaSkipAuth()
 		d.indexLock.RLock()
 		for _, index := range d.indices {
-			err := filters.ValidateSort(d.schemaGetter.GetSchemaSkipAuth(),
+			err := filters.ValidateSort(schema,
 				index.Config.ClassName, sort)
 			if err != nil {
 				errorMsg := errors.Wrapf(err, "search index %s", index.ID()).Error()

--- a/adapters/repos/db/shard_init_properties.go
+++ b/adapters/repos/db/shard_init_properties.go
@@ -21,16 +21,14 @@ import (
 	"golang.org/x/sync/errgroup"
 )
 
-func (s *Shard) initProperties() error {
+func (s *Shard) initProperties(class *models.Class) error {
 	s.propertyIndices = propertyspecific.Indices{}
-	sch := s.index.getSchema.GetSchemaSkipAuth()
-	c := sch.FindClassByName(s.index.Config.ClassName)
-	if c == nil {
+	if class == nil {
 		return nil
 	}
 
 	eg := &errgroup.Group{}
-	for _, prop := range c.Properties {
+	for _, prop := range class.Properties {
 		if prop.IndexInverted != nil && !*prop.IndexInverted {
 			continue
 		}

--- a/entities/deepcopy/models_deepcopy.go
+++ b/entities/deepcopy/models_deepcopy.go
@@ -1,0 +1,96 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2022 SeMI Technologies B.V. All rights reserved.
+//
+//  CONTACT: hello@semi.technology
+//
+
+package deepcopy
+
+import "github.com/semi-technologies/weaviate/entities/models"
+
+func Schema(s *models.Schema) *models.Schema {
+	classes := make([]*models.Class, len(s.Classes))
+	for i, class := range s.Classes {
+		classes[i] = Class(class)
+	}
+
+	return &models.Schema{Name: s.Name, Maintainer: s.Maintainer, Classes: classes}
+}
+
+func Class(c *models.Class) *models.Class {
+	if c == nil {
+		return nil
+	}
+
+	var properties []*models.Property = nil
+	if c.Properties != nil {
+		properties = make([]*models.Property, len(c.Properties))
+		for i, prop := range c.Properties {
+			properties[i] = Prop(prop)
+		}
+	}
+	var replicationConf *models.ReplicationConfig = nil
+	if c.ReplicationConfig != nil {
+		replicationConf = &models.ReplicationConfig{Factor: c.ReplicationConfig.Factor}
+	}
+
+	return &models.Class{
+		Class:               c.Class,
+		Description:         c.Description,
+		ModuleConfig:        c.ModuleConfig,
+		ShardingConfig:      c.ShardingConfig,
+		VectorIndexConfig:   c.VectorIndexConfig,
+		VectorIndexType:     c.VectorIndexType,
+		ReplicationConfig:   replicationConf,
+		Vectorizer:          c.Vectorizer,
+		InvertedIndexConfig: InvertedIndexConfig(c.InvertedIndexConfig),
+		Properties:          properties,
+	}
+}
+
+func Prop(p *models.Property) *models.Property {
+	var indexInverted *bool = nil
+	if p.IndexInverted != nil {
+		b := *(p.IndexInverted)
+		indexInverted = &b
+	}
+
+	return &models.Property{
+		DataType:      p.DataType,
+		Description:   p.Description,
+		ModuleConfig:  p.ModuleConfig,
+		Name:          p.Name,
+		Tokenization:  p.Tokenization,
+		IndexInverted: indexInverted,
+	}
+}
+
+func InvertedIndexConfig(i *models.InvertedIndexConfig) *models.InvertedIndexConfig {
+	if i == nil {
+		return nil
+	}
+
+	var bm25 *models.BM25Config = nil
+	if i.Bm25 != nil {
+		bm25 = &models.BM25Config{B: i.Bm25.B, K1: i.Bm25.K1}
+	}
+
+	var stopwords *models.StopwordConfig = nil
+	if i.Stopwords != nil {
+		stopwords = &models.StopwordConfig{Additions: i.Stopwords.Additions, Preset: i.Stopwords.Preset, Removals: i.Stopwords.Removals}
+	}
+
+	return &models.InvertedIndexConfig{
+		Bm25:                   bm25,
+		CleanupIntervalSeconds: i.CleanupIntervalSeconds,
+		IndexNullState:         i.IndexNullState,
+		IndexPropertyLength:    i.IndexPropertyLength,
+		IndexTimestamps:        i.IndexTimestamps,
+		Stopwords:              stopwords,
+	}
+}

--- a/entities/schema/backward_compat.go
+++ b/entities/schema/backward_compat.go
@@ -19,16 +19,6 @@ import (
 	"github.com/semi-technologies/weaviate/entities/models"
 )
 
-type schemaProperties struct {
-	Schema *models.Schema
-}
-
-// WeaviateSchema represents the used schema's
-type WeaviateSchema struct {
-	ActionSchema schemaProperties
-	ThingSchema  schemaProperties
-}
-
 // GetClassByName returns the class by its name
 func GetClassByName(s *models.Schema, className string) (*models.Class, error) {
 	if s == nil {

--- a/modules/qna-openai/config/class_settings.go
+++ b/modules/qna-openai/config/class_settings.go
@@ -42,8 +42,16 @@ var maxTokensForModel = map[string]float64{
 	"text-babbage-001": 2048,
 	"text-curie-001":   2048,
 	"text-davinci-002": 4000,
+	"text-davinci-003": 4000,
 }
-var availableOpenAIModels = []string{"text-ada-001", "text-babbage-001", "text-curie-001", "text-davinci-002"}
+
+var availableOpenAIModels = []string{
+	"text-ada-001",
+	"text-babbage-001",
+	"text-curie-001",
+	"text-davinci-002",
+	"text-davinci-003",
+}
 
 type classSettings struct {
 	cfg moduletools.ClassConfig

--- a/modules/text2vec-openai/vectorizer/class_settings.go
+++ b/modules/text2vec-openai/vectorizer/class_settings.go
@@ -151,11 +151,20 @@ func (ic *classSettings) validateModelVersion(version, model, docType string) er
 		return nil
 	}
 
-	if version != "002" {
+	if version == "002" {
+		// only ada/davinci 002
+		if model != "ada" && model != "davinci" {
+			return fmt.Errorf("unsupported version %s", version)
+		}
+	}
+
+	if version == "003" && model != "davinci" {
+		// only davinci 003
 		return fmt.Errorf("unsupported version %s", version)
 	}
 
-	if model != "ada" {
+	if version != "002" && version != "003" {
+		// all other fallback
 		return fmt.Errorf("model %s is only available in version 001", model)
 	}
 

--- a/modules/text2vec-openai/vectorizer/objects_test.go
+++ b/modules/text2vec-openai/vectorizer/objects_test.go
@@ -388,16 +388,23 @@ func TestValidateModelVersion(t *testing.T) {
 
 		// 002 models
 		{"ada", "text", "002", true},
+		{"davinci", "text", "002", true},
 		{"ada", "code", "002", false},
 		{"babbage", "text", "002", false},
 		{"babbage", "code", "002", false},
 		{"curie", "text", "002", false},
 		{"curie", "code", "002", false},
-		{"davinci", "text", "002", false},
 		{"davinci", "code", "002", false},
 
 		// 003
+		{"davinci", "text", "003", true},
 		{"ada", "text", "003", false},
+		{"babbage", "text", "003", false},
+
+		// 004
+		{"davinci", "text", "004", false},
+		{"ada", "text", "004", false},
+		{"babbage", "text", "004", false},
 	}
 
 	for _, test := range tests {

--- a/usecases/objects/batch_add.go
+++ b/usecases/objects/batch_add.go
@@ -125,10 +125,6 @@ func (b *BatchManager) validateObject(ctx context.Context, principal *models.Pri
 		id = concept.ID
 	}
 
-	// Validate schema given in body with the weaviate schema
-	s, err := b.schemaManager.GetSchema(principal)
-	ec.Add(err)
-
 	// Create Action object
 	object := &models.Object{}
 	object.LastUpdateTimeUnix = 0
@@ -152,12 +148,19 @@ func (b *BatchManager) validateObject(ctx context.Context, principal *models.Pri
 	if _, ok := fieldsToKeep["lastUpdateTimeUnix"]; ok {
 		object.LastUpdateTimeUnix = now
 	}
-
-	err = validation.New(s, b.vectorRepo.Exists, b.config).Object(ctx, object)
+	class, err := b.schemaManager.GetClass(ctx, principal, object.Class)
 	ec.Add(err)
+	if class == nil {
+		ec.Add(fmt.Errorf("class '%s' not present in schema", object.Class))
+	} else {
+		// not possible without the class being present
+		err = validation.New(b.vectorRepo.Exists, b.config).Object(ctx, object, class)
+		ec.Add(err)
 
-	err = b.modulesProvider.UpdateVector(ctx, object, nil, b.findObject, b.logger)
-	ec.Add(err)
+		err = b.modulesProvider.UpdateVector(ctx, object, class, nil, b.findObject, b.logger)
+		ec.Add(err)
+
+	}
 
 	*resultsC <- BatchObject{
 		UUID:          id,

--- a/usecases/objects/fakes_for_test.go
+++ b/usecases/objects/fakes_for_test.go
@@ -66,6 +66,18 @@ func (f *fakeSchemaManager) GetSchema(principal *models.Principal) (schema.Schem
 	return f.GetSchemaResponse, f.GetschemaErr
 }
 
+func (f *fakeSchemaManager) GetClass(ctx context.Context, principal *models.Principal,
+	name string,
+) (*models.Class, error) {
+	classes := f.GetSchemaResponse.Objects.Classes
+	for _, class := range classes {
+		if class.Class == name {
+			return class, f.GetschemaErr
+		}
+	}
+	return nil, f.GetschemaErr
+}
+
 func (f *fakeSchemaManager) AddClass(ctx context.Context, principal *models.Principal,
 	class *models.Class,
 ) error {
@@ -300,7 +312,7 @@ func (p *fakeModulesProvider) UsingRef2Vec(moduleName string) bool {
 	return args.Bool(0)
 }
 
-func (p *fakeModulesProvider) UpdateVector(ctx context.Context, object *models.Object,
+func (p *fakeModulesProvider) UpdateVector(ctx context.Context, object *models.Object, class *models.Class,
 	objectDiff *moduletools.ObjectDiff, findObjFn modulecapabilities.FindObjectFn, logger logrus.FieldLogger,
 ) error {
 	args := p.Called(object, findObjFn)

--- a/usecases/objects/manager.go
+++ b/usecases/objects/manager.go
@@ -112,7 +112,7 @@ type ModulesProvider interface {
 	ListObjectsAdditionalExtend(ctx context.Context, in search.Results,
 		moduleParams map[string]interface{}) (search.Results, error)
 	UsingRef2Vec(className string) bool
-	UpdateVector(ctx context.Context, object *models.Object, objectDiff *moduletools.ObjectDiff,
+	UpdateVector(ctx context.Context, object *models.Object, class *models.Class, objectDiff *moduletools.ObjectDiff,
 		repo modulecapabilities.FindObjectFn, logger logrus.FieldLogger) error
 	VectorizerName(className string) (string, error)
 }

--- a/usecases/objects/merge.go
+++ b/usecases/objects/merge.go
@@ -146,8 +146,11 @@ func (m *Manager) mergeObjectSchemaAndVectorize(ctx context.Context, className s
 	// Note: vector could be a nil vector in case a vectorizer is configured,
 	// then the vectorizer will set it
 	obj := &models.Object{Class: className, Properties: merged, Vector: vector}
-
-	if err := m.modulesProvider.UpdateVector(ctx, obj, objDiff, m.findObject, m.logger); err != nil {
+	class, err := m.schemaManager.GetClass(ctx, principal, className)
+	if err != nil {
+		return nil, err
+	}
+	if err := m.modulesProvider.UpdateVector(ctx, obj, class, objDiff, m.findObject, m.logger); err != nil {
 		return nil, err
 	}
 

--- a/usecases/objects/references_add.go
+++ b/usecases/objects/references_add.go
@@ -19,7 +19,6 @@ import (
 	"github.com/go-openapi/strfmt"
 	"github.com/semi-technologies/weaviate/entities/additional"
 	"github.com/semi-technologies/weaviate/entities/models"
-	"github.com/semi-technologies/weaviate/entities/schema"
 	"github.com/semi-technologies/weaviate/usecases/objects/validation"
 )
 
@@ -57,7 +56,7 @@ func (m *Manager) AddObjectReference(
 	}
 	defer unlock()
 
-	validator := validation.New(schema.Schema{}, m.vectorRepo.Exists, m.config)
+	validator := validation.New(m.vectorRepo.Exists, m.config)
 	if err := input.validate(ctx, principal, validator, m.schemaManager); err != nil {
 		return &Error{"validate inputs", StatusBadRequest, err}
 	}
@@ -76,7 +75,7 @@ func (m *Manager) AddObjectReference(
 		return &Error{"add reference to repo", StatusInternalServerError, err}
 	}
 
-	if err := m.updateRefVector(ctx, input.Class, input.ID); err != nil {
+	if err := m.updateRefVector(ctx, principal, input.Class, input.ID); err != nil {
 		return &Error{"update ref vector", StatusInternalServerError, err}
 	}
 

--- a/usecases/objects/references_delete.go
+++ b/usecases/objects/references_delete.go
@@ -85,7 +85,7 @@ func (m *Manager) DeleteObjectReference(
 		return &Error{"repo.putobject", StatusInternalServerError, err}
 	}
 
-	if err := m.updateRefVector(ctx, input.Class, input.ID); err != nil {
+	if err := m.updateRefVector(ctx, principal, input.Class, input.ID); err != nil {
 		return &Error{"update ref vector", StatusInternalServerError, err}
 	}
 

--- a/usecases/objects/references_update.go
+++ b/usecases/objects/references_update.go
@@ -70,7 +70,7 @@ func (m *Manager) UpdateObjectReferences(
 	}
 	defer unlock()
 
-	validator := validation.New(schema.Schema{}, m.vectorRepo.Exists, m.config)
+	validator := validation.New(m.vectorRepo.Exists, m.config)
 	if err := input.validate(ctx, principal, validator, m.schemaManager); err != nil {
 		return &Error{"bad inputs", StatusBadRequest, err}
 	}

--- a/usecases/objects/validation/model_validation.go
+++ b/usecases/objects/validation/model_validation.go
@@ -17,7 +17,6 @@ import (
 
 	"github.com/go-openapi/strfmt"
 	"github.com/semi-technologies/weaviate/entities/models"
-	"github.com/semi-technologies/weaviate/entities/schema"
 	"github.com/semi-technologies/weaviate/entities/schema/crossref"
 	"github.com/semi-technologies/weaviate/usecases/config"
 )
@@ -60,27 +59,25 @@ const (
 )
 
 type Validator struct {
-	schema schema.Schema
 	exists exists
 	config *config.WeaviateConfig
 }
 
-func New(schema schema.Schema, exists exists,
+func New(exists exists,
 	config *config.WeaviateConfig,
 ) *Validator {
 	return &Validator{
-		schema: schema,
 		exists: exists,
 		config: config,
 	}
 }
 
-func (v *Validator) Object(ctx context.Context, object *models.Object) error {
+func (v *Validator) Object(ctx context.Context, object *models.Object, class *models.Class) error {
 	if err := validateClass(object.Class); err != nil {
 		return err
 	}
 
-	return v.properties(ctx, object)
+	return v.properties(ctx, object, class)
 }
 
 func validateClass(class string) error {

--- a/usecases/objects/validation/phone_numbers_test.go
+++ b/usecases/objects/validation/phone_numbers_test.go
@@ -159,7 +159,7 @@ func TestPropertyOfTypePhoneNumberValidation(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			config := &config.WeaviateConfig{}
-			validator := New(testSchema(), fakeExists, config)
+			validator := New(fakeExists, config)
 
 			obj := &models.Object{
 				Class: "Person",
@@ -167,7 +167,8 @@ func TestPropertyOfTypePhoneNumberValidation(t *testing.T) {
 					"phone": test.phone,
 				},
 			}
-			err := validator.properties(context.Background(), obj)
+			schema := testSchema()
+			err := validator.properties(context.Background(), obj, schema.Objects.Classes[0])
 			assert.Equal(t, test.expectedErr, err)
 			if err != nil {
 				return

--- a/usecases/objects/validation/properties_validation.go
+++ b/usecases/objects/validation/properties_validation.go
@@ -39,15 +39,10 @@ const (
 	ErrorMissingSingleRefType string = "class '%s' with property '%s' requires exactly 3 arguments: 'beacon', 'locationUrl' and 'type'. 'type' is missing, check your input schema"
 )
 
-func (v *Validator) properties(ctx context.Context, object interface{}) error {
+func (v *Validator) properties(ctx context.Context, object interface{}, class *models.Class) error {
 	className := object.(*models.Object).Class
 	isp := object.(*models.Object).Properties
 	vectorWeights := object.(*models.Object).VectorWeights
-
-	class := v.schema.GetClass(schema.ClassName(className))
-	if class == nil {
-		return fmt.Errorf("class '%s' not present in schema", className)
-	}
 
 	if vectorWeights != nil {
 		res, err := v.validateVectorWeights(vectorWeights)

--- a/usecases/objects/validation/properties_validation_test.go
+++ b/usecases/objects/validation/properties_validation_test.go
@@ -127,7 +127,6 @@ func TestValidator_extractAndValidateProperty(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			v := &Validator{
-				schema: tt.fields.schema,
 				exists: tt.fields.exists,
 				config: tt.fields.config,
 			}

--- a/usecases/objects/vector.go
+++ b/usecases/objects/vector.go
@@ -15,12 +15,14 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/semi-technologies/weaviate/entities/models"
+
 	"github.com/go-openapi/strfmt"
 	"github.com/semi-technologies/weaviate/entities/additional"
 	"github.com/semi-technologies/weaviate/entities/search"
 )
 
-func (m *Manager) updateRefVector(ctx context.Context,
+func (m *Manager) updateRefVector(ctx context.Context, principal *models.Principal,
 	className string, id strfmt.UUID,
 ) error {
 	if m.modulesProvider.UsingRef2Vec(className) {
@@ -33,8 +35,12 @@ func (m *Manager) updateRefVector(ctx context.Context,
 
 		obj := parent.Object()
 
+		class, err := m.schemaManager.GetClass(ctx, principal, className)
+		if err != nil {
+			return err
+		}
 		if err := m.modulesProvider.UpdateVector(
-			ctx, obj, nil, m.findObject, m.logger); err != nil {
+			ctx, obj, class, nil, m.findObject, m.logger); err != nil {
 			return fmt.Errorf("calculate ref vector for '%s/%s': %w",
 				className, id, err)
 		}

--- a/usecases/schema/add_property.go
+++ b/usecases/schema/add_property.go
@@ -14,9 +14,10 @@ package schema
 import (
 	"context"
 
+	"github.com/semi-technologies/weaviate/entities/schema"
+
 	"github.com/pkg/errors"
 	"github.com/semi-technologies/weaviate/entities/models"
-	"github.com/semi-technologies/weaviate/entities/schema"
 )
 
 // AddClassProperty to an existing Class
@@ -37,12 +38,10 @@ func (m *Manager) addClassProperty(ctx context.Context,
 	m.Lock()
 	defer m.Unlock()
 
-	semanticSchema := m.state.SchemaFor()
-	class, err := schema.GetClassByName(semanticSchema, className)
+	class, err := schema.GetClassByName(m.state.ObjectSchema, className)
 	if err != nil {
 		return err
 	}
-
 	prop.Name = lowerCaseFirstLetter(prop.Name)
 
 	m.setNewPropDefaults(class, prop)
@@ -79,8 +78,7 @@ func (m *Manager) setNewPropDefaults(class *models.Class, prop *models.Property)
 func (m *Manager) addClassPropertyApplyChanges(ctx context.Context,
 	className string, prop *models.Property,
 ) error {
-	semanticSchema := m.state.SchemaFor()
-	class, err := schema.GetClassByName(semanticSchema, className)
+	class, err := schema.GetClassByName(m.state.ObjectSchema, className)
 	if err != nil {
 		return err
 	}
@@ -88,7 +86,7 @@ func (m *Manager) addClassPropertyApplyChanges(ctx context.Context,
 	class.Properties = append(class.Properties, prop)
 	err = m.saveSchema(ctx)
 	if err != nil {
-		return nil
+		return err
 	}
 
 	return m.migrator.AddProperty(ctx, className, prop)

--- a/usecases/schema/authorization_test.go
+++ b/usecases/schema/authorization_test.go
@@ -106,9 +106,9 @@ func Test_Schema_Authorization(t *testing.T) {
 
 		for _, method := range allExportedMethods(&Manager{}) {
 			switch method {
-			case "TriggerSchemaUpdateCallbacks", "RegisterSchemaUpdateCallback",
-				"UpdateMeta", "GetSchemaSkipAuth", "IndexedInverted", "Lock", "Unlock",
-				"TryLock", // introduced by sync.Mutex in go 1.18
+			case "RegisterSchemaUpdateCallback",
+				"UpdateMeta", "GetSchemaSkipAuth", "IndexedInverted", "RLock", "RUnlock", "Lock", "Unlock",
+				"TryLock", "RLocker", "TryRLock", // introduced by sync.Mutex in go 1.18
 				"Nodes", "NodeName", "ClusterHealthScore",
 				"ShardingState", "TxManager", "RestoreClass":
 				// don't require auth on methods which are exported because other

--- a/usecases/schema/delete.go
+++ b/usecases/schema/delete.go
@@ -50,7 +50,7 @@ func (m *Manager) deleteClass(ctx context.Context, className string) error {
 }
 
 func (m *Manager) deleteClassApplyChanges(ctx context.Context, className string) error {
-	semanticSchema := m.state.SchemaFor()
+	semanticSchema := m.state.ObjectSchema
 	classIdx := -1
 	for idx, class := range semanticSchema.Classes {
 		if class.Class == className {

--- a/usecases/schema/get.go
+++ b/usecases/schema/get.go
@@ -41,6 +41,12 @@ func (m *Manager) GetSchemaSkipAuth() schema.Schema {
 	}
 }
 
+func (m *Manager) getSchema() schema.Schema {
+	return schema.Schema{
+		Objects: m.state.ObjectSchema,
+	}
+}
+
 func (m *Manager) IndexedInverted(className, propertyName string) bool {
 	class := m.getClassByName(className)
 	if class == nil {
@@ -67,7 +73,6 @@ func (m *Manager) GetClass(ctx context.Context, principal *models.Principal,
 	if err != nil {
 		return nil, err
 	}
-
 	return m.getClassByName(name), nil
 }
 
@@ -80,7 +85,10 @@ func (m *Manager) getClassByName(name string) *models.Class {
 }
 
 func (m *Manager) ShardingState(className string) *sharding.State {
-	return m.state.ShardingState[className]
+	m.shardingStateLock.RLock()
+	copiedState := m.state.ShardingState[className].DeepCopy()
+	m.shardingStateLock.RUnlock()
+	return &copiedState
 }
 
 func (m *Manager) Nodes() []string {

--- a/usecases/schema/meta.go
+++ b/usecases/schema/meta.go
@@ -21,9 +21,8 @@ import (
 func (m *Manager) UpdateMeta(ctx context.Context,
 	atContext strfmt.URI, maintainer strfmt.Email, name string,
 ) error {
-	semanticSchema := m.state.SchemaFor()
-	semanticSchema.Maintainer = maintainer
-	semanticSchema.Name = name
+	m.state.ObjectSchema.Maintainer = maintainer
+	m.state.ObjectSchema.Name = name
 
 	return m.saveSchema(ctx)
 }

--- a/usecases/schema/update.go
+++ b/usecases/schema/update.go
@@ -130,8 +130,9 @@ func (m *Manager) updateClassApplyChanges(ctx context.Context, className string,
 		// the sharding state caches the node name, we must therefore set this
 		// explicitly now.
 		updatedShardingState.SetLocalName(m.clusterState.LocalName())
+		m.shardingStateLock.Lock()
 		m.state.ShardingState[className] = updatedShardingState
-
+		m.shardingStateLock.Unlock()
 	}
 
 	return m.saveSchema(ctx)
@@ -232,10 +233,8 @@ func (m *Manager) updateClass(ctx context.Context, className string,
 		newName = &n
 	}
 
-	semanticSchema := m.state.SchemaFor()
-
 	var err error
-	class, err = schema.GetClassByName(semanticSchema, className)
+	class, err = schema.GetClassByName(m.state.ObjectSchema, className)
 	if err != nil {
 		return err
 	}

--- a/usecases/schema/validation.go
+++ b/usecases/schema/validation.go
@@ -22,7 +22,7 @@ import (
 )
 
 func (m *Manager) validateClassNameUniqueness(className string) error {
-	for _, otherClass := range m.state.SchemaFor().Classes {
+	for _, otherClass := range m.state.ObjectSchema.Classes {
 		if className == otherClass.Class {
 			return fmt.Errorf("Name '%s' already used as a name for an Object class", className)
 		}


### PR DESCRIPTION
Adds support for new davinci model version for both OpenAI transformer as the QA module. Leaving in support for both 002 and 003. (002 support was not added to vectorizer yet)

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.
