### PR TITLE
GH-2488 - Add support for new davinci model version

### DIFF
--- a/modules/qna-openai/config/class_settings.go
+++ b/modules/qna-openai/config/class_settings.go
@@ -42,8 +42,16 @@ var maxTokensForModel = map[string]float64{
 	"text-babbage-001": 2048,
 	"text-curie-001":   2048,
 	"text-davinci-002": 4000,
+	"text-davinci-003": 4000,
 }
-var availableOpenAIModels = []string{"text-ada-001", "text-babbage-001", "text-curie-001", "text-davinci-002"}
+
+var availableOpenAIModels = []string{
+	"text-ada-001",
+	"text-babbage-001",
+	"text-curie-001",
+	"text-davinci-002",
+	"text-davinci-003",
+}
 
 type classSettings struct {
 	cfg moduletools.ClassConfig

--- a/modules/text2vec-openai/vectorizer/class_settings.go
+++ b/modules/text2vec-openai/vectorizer/class_settings.go
@@ -151,11 +151,20 @@ func (ic *classSettings) validateModelVersion(version, model, docType string) er
 		return nil
 	}
 
-	if version != "002" {
+	if version == "002" {
+		// only ada/davinci 002
+		if model != "ada" && model != "davinci" {
+			return fmt.Errorf("unsupported version %s", version)
+		}
+	}
+
+	if version == "003" && model != "davinci" {
+		// only davinci 003
 		return fmt.Errorf("unsupported version %s", version)
 	}
 
-	if model != "ada" {
+	if version != "002" && version != "003" {
+		// all other fallback
 		return fmt.Errorf("model %s is only available in version 001", model)
 	}
 

--- a/modules/text2vec-openai/vectorizer/objects_test.go
+++ b/modules/text2vec-openai/vectorizer/objects_test.go
@@ -388,16 +388,23 @@ func TestValidateModelVersion(t *testing.T) {
 
 		// 002 models
 		{"ada", "text", "002", true},
+		{"davinci", "text", "002", true},
 		{"ada", "code", "002", false},
 		{"babbage", "text", "002", false},
 		{"babbage", "code", "002", false},
 		{"curie", "text", "002", false},
 		{"curie", "code", "002", false},
-		{"davinci", "text", "002", false},
 		{"davinci", "code", "002", false},
 
 		// 003
+		{"davinci", "text", "003", true},
 		{"ada", "text", "003", false},
+		{"babbage", "text", "003", false},
+
+		// 004
+		{"davinci", "text", "004", false},
+		{"ada", "text", "004", false},
+		{"babbage", "text", "004", false},
 	}
 
 	for _, test := range tests {


### PR DESCRIPTION
### What's being changed:

Adds support for version 002 and 003 to the OpenAI text2vec and support for 003 to OpenAI QA

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.
