### PR TITLE
Improve decoding values in LSM SetDecoder by not maintaining values original order

### DIFF
--- a/adapters/repos/db/delete_filter_integration_test.go
+++ b/adapters/repos/db/delete_filter_integration_test.go
@@ -132,7 +132,7 @@ func Test_FilterSearchesOnDeletedDocIDsWithLimits(t *testing.T) {
 
 		require.Len(t, res, 5)
 		actualIDs := extractIDs(res)
-		assert.Equal(t, expectedIDs, actualIDs)
+		assert.ElementsMatch(t, expectedIDs, actualIDs)
 	})
 }
 

--- a/adapters/repos/db/lsmkv/recover_from_wal_integration_test.go
+++ b/adapters/repos/db/lsmkv/recover_from_wal_integration_test.go
@@ -362,13 +362,13 @@ func TestSetStrategy_RecoverFromWAL(t *testing.T) {
 
 			res, err := b.SetList(key1)
 			require.Nil(t, err)
-			assert.Equal(t, orig1, res)
+			assertSameByteKeySet(t, orig1, res)
 			res, err = b.SetList(key2)
 			require.Nil(t, err)
-			assert.Equal(t, orig2, res)
+			assertSameByteKeySet(t, orig2, res)
 			res, err = b.SetList(key3)
 			require.Nil(t, err)
-			assert.Equal(t, orig3, res)
+			assertSameByteKeySet(t, orig3, res)
 		})
 
 		t.Run("delete individual keys", func(t *testing.T) {
@@ -406,13 +406,13 @@ func TestSetStrategy_RecoverFromWAL(t *testing.T) {
 
 			res, err := b.SetList(key1)
 			require.Nil(t, err)
-			assert.Equal(t, expected1, res)
+			assertSameByteKeySet(t, expected1, res)
 			res, err = b.SetList(key2)
 			require.Nil(t, err)
-			assert.Equal(t, expected2, res)
+			assertSameByteKeySet(t, expected2, res)
 			res, err = b.SetList(key3)
 			require.Nil(t, err)
-			assert.Equal(t, expected3, res)
+			assertSameByteKeySet(t, expected3, res)
 		})
 
 		t.Run("make sure the WAL is flushed", func(t *testing.T) {
@@ -461,13 +461,13 @@ func TestSetStrategy_RecoverFromWAL(t *testing.T) {
 
 			res, err := bRec.SetList(key1)
 			require.Nil(t, err)
-			assert.Equal(t, expected1, res)
+			assertSameByteKeySet(t, expected1, res)
 			res, err = bRec.SetList(key2)
 			require.Nil(t, err)
-			assert.Equal(t, expected2, res)
+			assertSameByteKeySet(t, expected2, res)
 			res, err = bRec.SetList(key3)
 			require.Nil(t, err)
-			assert.Equal(t, expected3, res)
+			assertSameByteKeySet(t, expected3, res)
 		})
 	})
 }
@@ -657,4 +657,29 @@ func TestMapStrategy_RecoverFromWAL(t *testing.T) {
 			assert.Equal(t, expectedRow2, res)
 		})
 	})
+}
+
+func assertSameByteKeySet(t *testing.T, xs, ys [][]byte) {
+	t.Helper()
+	if sameByteKeySet(xs, ys) {
+		return
+	}
+	assert.Equal(t, xs, ys)
+}
+
+func sameByteKeySet(xs, ys [][]byte) bool {
+	if len(xs) != len(ys) {
+		return false
+	}
+	m := make(map[string]struct{})
+	for _, x := range xs {
+		m[string(x)] = struct{}{}
+	}
+	if len(m) != len(xs) {
+		return false
+	}
+	for _, x := range ys {
+		delete(m, string(x))
+	}
+	return len(m) == 0
 }

--- a/adapters/repos/db/lsmkv/recover_from_wal_integration_test.go
+++ b/adapters/repos/db/lsmkv/recover_from_wal_integration_test.go
@@ -362,13 +362,13 @@ func TestSetStrategy_RecoverFromWAL(t *testing.T) {
 
 			res, err := b.SetList(key1)
 			require.Nil(t, err)
-			assertSameByteKeySet(t, orig1, res)
+			assert.ElementsMatch(t, orig1, res)
 			res, err = b.SetList(key2)
 			require.Nil(t, err)
-			assertSameByteKeySet(t, orig2, res)
+			assert.ElementsMatch(t, orig2, res)
 			res, err = b.SetList(key3)
 			require.Nil(t, err)
-			assertSameByteKeySet(t, orig3, res)
+			assert.ElementsMatch(t, orig3, res)
 		})
 
 		t.Run("delete individual keys", func(t *testing.T) {
@@ -406,13 +406,13 @@ func TestSetStrategy_RecoverFromWAL(t *testing.T) {
 
 			res, err := b.SetList(key1)
 			require.Nil(t, err)
-			assertSameByteKeySet(t, expected1, res)
+			assert.ElementsMatch(t, expected1, res)
 			res, err = b.SetList(key2)
 			require.Nil(t, err)
-			assertSameByteKeySet(t, expected2, res)
+			assert.ElementsMatch(t, expected2, res)
 			res, err = b.SetList(key3)
 			require.Nil(t, err)
-			assertSameByteKeySet(t, expected3, res)
+			assert.ElementsMatch(t, expected3, res)
 		})
 
 		t.Run("make sure the WAL is flushed", func(t *testing.T) {
@@ -461,13 +461,13 @@ func TestSetStrategy_RecoverFromWAL(t *testing.T) {
 
 			res, err := bRec.SetList(key1)
 			require.Nil(t, err)
-			assertSameByteKeySet(t, expected1, res)
+			assert.ElementsMatch(t, expected1, res)
 			res, err = bRec.SetList(key2)
 			require.Nil(t, err)
-			assertSameByteKeySet(t, expected2, res)
+			assert.ElementsMatch(t, expected2, res)
 			res, err = bRec.SetList(key3)
 			require.Nil(t, err)
-			assertSameByteKeySet(t, expected3, res)
+			assert.ElementsMatch(t, expected3, res)
 		})
 	})
 }
@@ -657,29 +657,4 @@ func TestMapStrategy_RecoverFromWAL(t *testing.T) {
 			assert.Equal(t, expectedRow2, res)
 		})
 	})
-}
-
-func assertSameByteKeySet(t *testing.T, xs, ys [][]byte) {
-	t.Helper()
-	if sameByteKeySet(xs, ys) {
-		return
-	}
-	assert.Equal(t, xs, ys)
-}
-
-func sameByteKeySet(xs, ys [][]byte) bool {
-	if len(xs) != len(ys) {
-		return false
-	}
-	m := make(map[string]struct{})
-	for _, x := range xs {
-		m[string(x)] = struct{}{}
-	}
-	if len(m) != len(xs) {
-		return false
-	}
-	for _, x := range ys {
-		delete(m, string(x))
-	}
-	return len(m) == 0
 }

--- a/adapters/repos/db/lsmkv/strategies_set_integration_test.go
+++ b/adapters/repos/db/lsmkv/strategies_set_integration_test.go
@@ -55,13 +55,13 @@ func TestSetCollectionStrategy_InsertAndSetAdd(t *testing.T) {
 
 			res, err := b.SetList(key1)
 			require.Nil(t, err)
-			assert.Equal(t, res, orig1)
+			assertSameByteKeySet(t, res, orig1)
 			res, err = b.SetList(key2)
 			require.Nil(t, err)
-			assert.Equal(t, res, orig2)
+			assertSameByteKeySet(t, res, orig2)
 			res, err = b.SetList(key3)
 			require.Nil(t, err)
-			assert.Equal(t, res, orig3)
+			assertSameByteKeySet(t, res, orig3)
 		})
 
 		t.Run("replace some, keep one", func(t *testing.T) {
@@ -78,13 +78,13 @@ func TestSetCollectionStrategy_InsertAndSetAdd(t *testing.T) {
 
 			res, err := b.SetList(key1)
 			require.Nil(t, err)
-			assert.Equal(t, orig1, res)
+			assertSameByteKeySet(t, orig1, res)
 			res, err = b.SetList(key2)
 			require.Nil(t, err)
-			assert.Equal(t, append(orig2, append2...), res)
+			assertSameByteKeySet(t, append(orig2, append2...), res)
 			res, err = b.SetList(key3)
 			require.Nil(t, err)
-			assert.Equal(t, append(orig3, append3...), res)
+			assertSameByteKeySet(t, append(orig3, append3...), res)
 		})
 	})
 
@@ -114,13 +114,13 @@ func TestSetCollectionStrategy_InsertAndSetAdd(t *testing.T) {
 
 			res, err := b.SetList(key1)
 			require.Nil(t, err)
-			assert.Equal(t, res, orig1)
+			assertSameByteKeySet(t, res, orig1)
 			res, err = b.SetList(key2)
 			require.Nil(t, err)
-			assert.Equal(t, res, orig2)
+			assertSameByteKeySet(t, res, orig2)
 			res, err = b.SetList(key3)
 			require.Nil(t, err)
-			assert.Equal(t, res, orig3)
+			assertSameByteKeySet(t, res, orig3)
 		})
 
 		t.Run("flush to disk", func(t *testing.T) {
@@ -141,13 +141,13 @@ func TestSetCollectionStrategy_InsertAndSetAdd(t *testing.T) {
 
 			res, err := b.SetList(key1)
 			require.Nil(t, err)
-			assert.Equal(t, orig1, res)
+			assertSameByteKeySet(t, orig1, res)
 			res, err = b.SetList(key2)
 			require.Nil(t, err)
-			assert.Equal(t, append(orig2, append2...), res)
+			assertSameByteKeySet(t, append(orig2, append2...), res)
 			res, err = b.SetList(key3)
 			require.Nil(t, err)
-			assert.Equal(t, append(orig3, append3...), res)
+			assertSameByteKeySet(t, append(orig3, append3...), res)
 		})
 	})
 
@@ -176,13 +176,13 @@ func TestSetCollectionStrategy_InsertAndSetAdd(t *testing.T) {
 
 			res, err := b.SetList(key1)
 			require.Nil(t, err)
-			assert.Equal(t, res, orig1)
+			assertSameByteKeySet(t, res, orig1)
 			res, err = b.SetList(key2)
 			require.Nil(t, err)
-			assert.Equal(t, res, orig2)
+			assertSameByteKeySet(t, res, orig2)
 			res, err = b.SetList(key3)
 			require.Nil(t, err)
-			assert.Equal(t, res, orig3)
+			assertSameByteKeySet(t, res, orig3)
 		})
 
 		t.Run("flush to disk", func(t *testing.T) {
@@ -206,13 +206,13 @@ func TestSetCollectionStrategy_InsertAndSetAdd(t *testing.T) {
 
 			res, err := b.SetList(key1)
 			require.Nil(t, err)
-			assert.Equal(t, orig1, res)
+			assertSameByteKeySet(t, orig1, res)
 			res, err = b.SetList(key2)
 			require.Nil(t, err)
-			assert.Equal(t, append(orig2, append2...), res)
+			assertSameByteKeySet(t, append(orig2, append2...), res)
 			res, err = b.SetList(key3)
 			require.Nil(t, err)
-			assert.Equal(t, append(orig3, append3...), res)
+			assertSameByteKeySet(t, append(orig3, append3...), res)
 		})
 	})
 
@@ -242,13 +242,13 @@ func TestSetCollectionStrategy_InsertAndSetAdd(t *testing.T) {
 
 			res, err := b.SetList(key1)
 			require.Nil(t, err)
-			assert.Equal(t, res, orig1)
+			assertSameByteKeySet(t, res, orig1)
 			res, err = b.SetList(key2)
 			require.Nil(t, err)
-			assert.Equal(t, res, orig2)
+			assertSameByteKeySet(t, res, orig2)
 			res, err = b.SetList(key3)
 			require.Nil(t, err)
-			assert.Equal(t, res, orig3)
+			assertSameByteKeySet(t, res, orig3)
 		})
 
 		t.Run("replace some, keep one", func(t *testing.T) {
@@ -265,13 +265,13 @@ func TestSetCollectionStrategy_InsertAndSetAdd(t *testing.T) {
 
 			res, err := b.SetList(key1)
 			require.Nil(t, err)
-			assert.Equal(t, orig1, res)
+			assertSameByteKeySet(t, orig1, res)
 			res, err = b.SetList(key2)
 			require.Nil(t, err)
-			assert.Equal(t, append(orig2, append2...), res)
+			assertSameByteKeySet(t, append(orig2, append2...), res)
 			res, err = b.SetList(key3)
 			require.Nil(t, err)
-			assert.Equal(t, append(orig3, append3...), res)
+			assertSameByteKeySet(t, append(orig3, append3...), res)
 		})
 
 		t.Run("orderly shutdown", func(t *testing.T) {
@@ -291,13 +291,13 @@ func TestSetCollectionStrategy_InsertAndSetAdd(t *testing.T) {
 
 			res, err := b2.SetList(key1)
 			require.Nil(t, err)
-			assert.Equal(t, orig1, res)
+			assertSameByteKeySet(t, orig1, res)
 			res, err = b2.SetList(key2)
 			require.Nil(t, err)
-			assert.Equal(t, append(orig2, append2...), res)
+			assertSameByteKeySet(t, append(orig2, append2...), res)
 			res, err = b2.SetList(key3)
 			require.Nil(t, err)
-			assert.Equal(t, append(orig3, append3...), res)
+			assertSameByteKeySet(t, append(orig3, append3...), res)
 		})
 	})
 }
@@ -332,13 +332,13 @@ func TestSetCollectionStrategy_InsertAndDelete(t *testing.T) {
 
 			res, err := b.SetList(key1)
 			require.Nil(t, err)
-			assert.Equal(t, orig1, res)
+			assertSameByteKeySet(t, orig1, res)
 			res, err = b.SetList(key2)
 			require.Nil(t, err)
-			assert.Equal(t, orig2, res)
+			assertSameByteKeySet(t, orig2, res)
 			res, err = b.SetList(key3)
 			require.Nil(t, err)
-			assert.Equal(t, orig3, res)
+			assertSameByteKeySet(t, orig3, res)
 		})
 
 		t.Run("delete individual keys", func(t *testing.T) {
@@ -358,13 +358,13 @@ func TestSetCollectionStrategy_InsertAndDelete(t *testing.T) {
 
 			res, err := b.SetList(key1)
 			require.Nil(t, err)
-			assert.Equal(t, expected1, res)
+			assertSameByteKeySet(t, expected1, res)
 			res, err = b.SetList(key2)
 			require.Nil(t, err)
-			assert.Equal(t, expected2, res)
+			assertSameByteKeySet(t, expected2, res)
 			res, err = b.SetList(key3)
 			require.Nil(t, err)
-			assert.Equal(t, expected3, res)
+			assertSameByteKeySet(t, expected3, res)
 		})
 
 		t.Run("re-add keys which were previously deleted and new ones", func(t *testing.T) {
@@ -392,13 +392,13 @@ func TestSetCollectionStrategy_InsertAndDelete(t *testing.T) {
 
 			res, err := b.SetList(key1)
 			require.Nil(t, err)
-			assert.Equal(t, expected1, res)
+			assertSameByteKeySet(t, expected1, res)
 			res, err = b.SetList(key2)
 			require.Nil(t, err)
-			assert.Equal(t, expected2, res)
+			assertSameByteKeySet(t, expected2, res)
 			res, err = b.SetList(key3)
 			require.Nil(t, err)
-			assert.Equal(t, expected3, res)
+			assertSameByteKeySet(t, expected3, res)
 		})
 	})
 
@@ -428,13 +428,13 @@ func TestSetCollectionStrategy_InsertAndDelete(t *testing.T) {
 
 			res, err := b.SetList(key1)
 			require.Nil(t, err)
-			assert.Equal(t, res, orig1)
+			assertSameByteKeySet(t, res, orig1)
 			res, err = b.SetList(key2)
 			require.Nil(t, err)
-			assert.Equal(t, res, orig2)
+			assertSameByteKeySet(t, res, orig2)
 			res, err = b.SetList(key3)
 			require.Nil(t, err)
-			assert.Equal(t, res, orig3)
+			assertSameByteKeySet(t, res, orig3)
 		})
 
 		t.Run("flush to disk", func(t *testing.T) {
@@ -458,13 +458,13 @@ func TestSetCollectionStrategy_InsertAndDelete(t *testing.T) {
 
 			res, err := b.SetList(key1)
 			require.Nil(t, err)
-			assert.Equal(t, expected1, res)
+			assertSameByteKeySet(t, expected1, res)
 			res, err = b.SetList(key2)
 			require.Nil(t, err)
-			assert.Equal(t, expected2, res)
+			assertSameByteKeySet(t, expected2, res)
 			res, err = b.SetList(key3)
 			require.Nil(t, err)
-			assert.Equal(t, expected3, res)
+			assertSameByteKeySet(t, expected3, res)
 		})
 
 		t.Run("re-add keys which were previously deleted and new ones", func(t *testing.T) {
@@ -492,13 +492,13 @@ func TestSetCollectionStrategy_InsertAndDelete(t *testing.T) {
 
 			res, err := b.SetList(key1)
 			require.Nil(t, err)
-			assert.Equal(t, expected1, res)
+			assertSameByteKeySet(t, expected1, res)
 			res, err = b.SetList(key2)
 			require.Nil(t, err)
-			assert.Equal(t, expected2, res)
+			assertSameByteKeySet(t, expected2, res)
 			res, err = b.SetList(key3)
 			require.Nil(t, err)
-			assert.Equal(t, expected3, res)
+			assertSameByteKeySet(t, expected3, res)
 		})
 	})
 
@@ -528,13 +528,13 @@ func TestSetCollectionStrategy_InsertAndDelete(t *testing.T) {
 
 			res, err := b.SetList(key1)
 			require.Nil(t, err)
-			assert.Equal(t, res, orig1)
+			assertSameByteKeySet(t, res, orig1)
 			res, err = b.SetList(key2)
 			require.Nil(t, err)
-			assert.Equal(t, res, orig2)
+			assertSameByteKeySet(t, res, orig2)
 			res, err = b.SetList(key3)
 			require.Nil(t, err)
-			assert.Equal(t, res, orig3)
+			assertSameByteKeySet(t, res, orig3)
 		})
 
 		t.Run("flush to disk", func(t *testing.T) {
@@ -562,13 +562,13 @@ func TestSetCollectionStrategy_InsertAndDelete(t *testing.T) {
 
 			res, err := b.SetList(key1)
 			require.Nil(t, err)
-			assert.Equal(t, expected1, res)
+			assertSameByteKeySet(t, expected1, res)
 			res, err = b.SetList(key2)
 			require.Nil(t, err)
-			assert.Equal(t, expected2, res)
+			assertSameByteKeySet(t, expected2, res)
 			res, err = b.SetList(key3)
 			require.Nil(t, err)
-			assert.Equal(t, expected3, res)
+			assertSameByteKeySet(t, expected3, res)
 		})
 
 		t.Run("re-add keys which were previously deleted and new ones", func(t *testing.T) {
@@ -600,13 +600,13 @@ func TestSetCollectionStrategy_InsertAndDelete(t *testing.T) {
 
 			res, err := b.SetList(key1)
 			require.Nil(t, err)
-			assert.Equal(t, expected1, res)
+			assertSameByteKeySet(t, expected1, res)
 			res, err = b.SetList(key2)
 			require.Nil(t, err)
-			assert.Equal(t, expected2, res)
+			assertSameByteKeySet(t, expected2, res)
 			res, err = b.SetList(key3)
 			require.Nil(t, err)
-			assert.Equal(t, expected3, res)
+			assertSameByteKeySet(t, expected3, res)
 		})
 	})
 
@@ -637,13 +637,13 @@ func TestSetCollectionStrategy_InsertAndDelete(t *testing.T) {
 
 				res, err := b.SetList(key1)
 				require.Nil(t, err)
-				assert.Equal(t, res, orig1)
+				assertSameByteKeySet(t, res, orig1)
 				res, err = b.SetList(key2)
 				require.Nil(t, err)
-				assert.Equal(t, res, orig2)
+				assertSameByteKeySet(t, res, orig2)
 				res, err = b.SetList(key3)
 				require.Nil(t, err)
-				assert.Equal(t, res, orig3)
+				assertSameByteKeySet(t, res, orig3)
 			})
 
 			t.Run("delete individual keys", func(t *testing.T) {
@@ -670,13 +670,13 @@ func TestSetCollectionStrategy_InsertAndDelete(t *testing.T) {
 
 				res, err := b2.SetList(key1)
 				require.Nil(t, err)
-				assert.Equal(t, expected1, res)
+				assertSameByteKeySet(t, expected1, res)
 				res, err = b2.SetList(key2)
 				require.Nil(t, err)
-				assert.Equal(t, expected2, res)
+				assertSameByteKeySet(t, expected2, res)
 				res, err = b2.SetList(key3)
 				require.Nil(t, err)
-				assert.Equal(t, expected3, res)
+				assertSameByteKeySet(t, expected3, res)
 			})
 		})
 }
@@ -744,7 +744,10 @@ func TestSetCollectionStrategy_Cursors(t *testing.T) {
 			}
 
 			assert.Equal(t, expectedKeys, retrievedKeys)
-			assert.Equal(t, expectedValues, retrievedValues)
+			assert.Equal(t, len(expectedValues), len(retrievedValues))
+			for i, v := range retrievedValues {
+				assertSameByteKeySet(t, expectedValues[i], v)
+			}
 		})
 
 		t.Run("start from the beginning", func(t *testing.T) {
@@ -771,7 +774,10 @@ func TestSetCollectionStrategy_Cursors(t *testing.T) {
 			}
 
 			assert.Equal(t, expectedKeys, retrievedKeys)
-			assert.Equal(t, expectedValues, retrievedValues)
+			assert.Equal(t, len(expectedValues), len(retrievedValues))
+			for i, v := range retrievedValues {
+				assertSameByteKeySet(t, expectedValues[i], v)
+			}
 		})
 
 		t.Run("extend an existing key", func(t *testing.T) {
@@ -806,7 +812,10 @@ func TestSetCollectionStrategy_Cursors(t *testing.T) {
 			}
 
 			assert.Equal(t, expectedKeys, retrievedKeys)
-			assert.Equal(t, expectedValues, retrievedValues)
+			assert.Equal(t, len(expectedValues), len(retrievedValues))
+			for i, v := range retrievedValues {
+				assertSameByteKeySet(t, expectedValues[i], v)
+			}
 		})
 	})
 
@@ -948,7 +957,10 @@ func TestSetCollectionStrategy_Cursors(t *testing.T) {
 			}
 
 			assert.Equal(t, expectedKeys, retrievedKeys)
-			assert.Equal(t, expectedValues, retrievedValues)
+			assert.Equal(t, len(expectedValues), len(retrievedValues))
+			for i, v := range retrievedValues {
+				assertSameByteKeySet(t, expectedValues[i], v)
+			}
 		})
 
 		t.Run("start from the beginning", func(t *testing.T) {
@@ -975,7 +987,10 @@ func TestSetCollectionStrategy_Cursors(t *testing.T) {
 			}
 
 			assert.Equal(t, expectedKeys, retrievedKeys)
-			assert.Equal(t, expectedValues, retrievedValues)
+			assert.Equal(t, len(expectedValues), len(retrievedValues))
+			for i, v := range retrievedValues {
+				assertSameByteKeySet(t, expectedValues[i], v)
+			}
 		})
 
 		t.Run("delete & extend an existing key", func(t *testing.T) {
@@ -1018,7 +1033,10 @@ func TestSetCollectionStrategy_Cursors(t *testing.T) {
 			}
 
 			assert.Equal(t, expectedKeys, retrievedKeys)
-			assert.Equal(t, expectedValues, retrievedValues)
+			assert.Equal(t, len(expectedValues), len(retrievedValues))
+			for i, v := range retrievedValues {
+				assertSameByteKeySet(t, expectedValues[i], v)
+			}
 		})
 
 		t.Run("flush to disk", func(t *testing.T) {
@@ -1054,7 +1072,10 @@ func TestSetCollectionStrategy_Cursors(t *testing.T) {
 			}
 
 			assert.Equal(t, expectedKeys, retrievedKeys)
-			assert.Equal(t, expectedValues, retrievedValues)
+			assert.Equal(t, len(expectedValues), len(retrievedValues))
+			for i, v := range retrievedValues {
+				assertSameByteKeySet(t, expectedValues[i], v)
+			}
 		})
 	})
 }

--- a/adapters/repos/db/lsmkv/strategies_set_integration_test.go
+++ b/adapters/repos/db/lsmkv/strategies_set_integration_test.go
@@ -55,13 +55,13 @@ func TestSetCollectionStrategy_InsertAndSetAdd(t *testing.T) {
 
 			res, err := b.SetList(key1)
 			require.Nil(t, err)
-			assertSameByteKeySet(t, res, orig1)
+			assert.ElementsMatch(t, res, orig1)
 			res, err = b.SetList(key2)
 			require.Nil(t, err)
-			assertSameByteKeySet(t, res, orig2)
+			assert.ElementsMatch(t, res, orig2)
 			res, err = b.SetList(key3)
 			require.Nil(t, err)
-			assertSameByteKeySet(t, res, orig3)
+			assert.ElementsMatch(t, res, orig3)
 		})
 
 		t.Run("replace some, keep one", func(t *testing.T) {
@@ -78,13 +78,13 @@ func TestSetCollectionStrategy_InsertAndSetAdd(t *testing.T) {
 
 			res, err := b.SetList(key1)
 			require.Nil(t, err)
-			assertSameByteKeySet(t, orig1, res)
+			assert.ElementsMatch(t, orig1, res)
 			res, err = b.SetList(key2)
 			require.Nil(t, err)
-			assertSameByteKeySet(t, append(orig2, append2...), res)
+			assert.ElementsMatch(t, append(orig2, append2...), res)
 			res, err = b.SetList(key3)
 			require.Nil(t, err)
-			assertSameByteKeySet(t, append(orig3, append3...), res)
+			assert.ElementsMatch(t, append(orig3, append3...), res)
 		})
 	})
 
@@ -114,13 +114,13 @@ func TestSetCollectionStrategy_InsertAndSetAdd(t *testing.T) {
 
 			res, err := b.SetList(key1)
 			require.Nil(t, err)
-			assertSameByteKeySet(t, res, orig1)
+			assert.ElementsMatch(t, res, orig1)
 			res, err = b.SetList(key2)
 			require.Nil(t, err)
-			assertSameByteKeySet(t, res, orig2)
+			assert.ElementsMatch(t, res, orig2)
 			res, err = b.SetList(key3)
 			require.Nil(t, err)
-			assertSameByteKeySet(t, res, orig3)
+			assert.ElementsMatch(t, res, orig3)
 		})
 
 		t.Run("flush to disk", func(t *testing.T) {
@@ -141,13 +141,13 @@ func TestSetCollectionStrategy_InsertAndSetAdd(t *testing.T) {
 
 			res, err := b.SetList(key1)
 			require.Nil(t, err)
-			assertSameByteKeySet(t, orig1, res)
+			assert.ElementsMatch(t, orig1, res)
 			res, err = b.SetList(key2)
 			require.Nil(t, err)
-			assertSameByteKeySet(t, append(orig2, append2...), res)
+			assert.ElementsMatch(t, append(orig2, append2...), res)
 			res, err = b.SetList(key3)
 			require.Nil(t, err)
-			assertSameByteKeySet(t, append(orig3, append3...), res)
+			assert.ElementsMatch(t, append(orig3, append3...), res)
 		})
 	})
 
@@ -176,13 +176,13 @@ func TestSetCollectionStrategy_InsertAndSetAdd(t *testing.T) {
 
 			res, err := b.SetList(key1)
 			require.Nil(t, err)
-			assertSameByteKeySet(t, res, orig1)
+			assert.ElementsMatch(t, res, orig1)
 			res, err = b.SetList(key2)
 			require.Nil(t, err)
-			assertSameByteKeySet(t, res, orig2)
+			assert.ElementsMatch(t, res, orig2)
 			res, err = b.SetList(key3)
 			require.Nil(t, err)
-			assertSameByteKeySet(t, res, orig3)
+			assert.ElementsMatch(t, res, orig3)
 		})
 
 		t.Run("flush to disk", func(t *testing.T) {
@@ -206,13 +206,13 @@ func TestSetCollectionStrategy_InsertAndSetAdd(t *testing.T) {
 
 			res, err := b.SetList(key1)
 			require.Nil(t, err)
-			assertSameByteKeySet(t, orig1, res)
+			assert.ElementsMatch(t, orig1, res)
 			res, err = b.SetList(key2)
 			require.Nil(t, err)
-			assertSameByteKeySet(t, append(orig2, append2...), res)
+			assert.ElementsMatch(t, append(orig2, append2...), res)
 			res, err = b.SetList(key3)
 			require.Nil(t, err)
-			assertSameByteKeySet(t, append(orig3, append3...), res)
+			assert.ElementsMatch(t, append(orig3, append3...), res)
 		})
 	})
 
@@ -242,13 +242,13 @@ func TestSetCollectionStrategy_InsertAndSetAdd(t *testing.T) {
 
 			res, err := b.SetList(key1)
 			require.Nil(t, err)
-			assertSameByteKeySet(t, res, orig1)
+			assert.ElementsMatch(t, res, orig1)
 			res, err = b.SetList(key2)
 			require.Nil(t, err)
-			assertSameByteKeySet(t, res, orig2)
+			assert.ElementsMatch(t, res, orig2)
 			res, err = b.SetList(key3)
 			require.Nil(t, err)
-			assertSameByteKeySet(t, res, orig3)
+			assert.ElementsMatch(t, res, orig3)
 		})
 
 		t.Run("replace some, keep one", func(t *testing.T) {
@@ -265,13 +265,13 @@ func TestSetCollectionStrategy_InsertAndSetAdd(t *testing.T) {
 
 			res, err := b.SetList(key1)
 			require.Nil(t, err)
-			assertSameByteKeySet(t, orig1, res)
+			assert.ElementsMatch(t, orig1, res)
 			res, err = b.SetList(key2)
 			require.Nil(t, err)
-			assertSameByteKeySet(t, append(orig2, append2...), res)
+			assert.ElementsMatch(t, append(orig2, append2...), res)
 			res, err = b.SetList(key3)
 			require.Nil(t, err)
-			assertSameByteKeySet(t, append(orig3, append3...), res)
+			assert.ElementsMatch(t, append(orig3, append3...), res)
 		})
 
 		t.Run("orderly shutdown", func(t *testing.T) {
@@ -291,13 +291,13 @@ func TestSetCollectionStrategy_InsertAndSetAdd(t *testing.T) {
 
 			res, err := b2.SetList(key1)
 			require.Nil(t, err)
-			assertSameByteKeySet(t, orig1, res)
+			assert.ElementsMatch(t, orig1, res)
 			res, err = b2.SetList(key2)
 			require.Nil(t, err)
-			assertSameByteKeySet(t, append(orig2, append2...), res)
+			assert.ElementsMatch(t, append(orig2, append2...), res)
 			res, err = b2.SetList(key3)
 			require.Nil(t, err)
-			assertSameByteKeySet(t, append(orig3, append3...), res)
+			assert.ElementsMatch(t, append(orig3, append3...), res)
 		})
 	})
 }
@@ -332,13 +332,13 @@ func TestSetCollectionStrategy_InsertAndDelete(t *testing.T) {
 
 			res, err := b.SetList(key1)
 			require.Nil(t, err)
-			assertSameByteKeySet(t, orig1, res)
+			assert.ElementsMatch(t, orig1, res)
 			res, err = b.SetList(key2)
 			require.Nil(t, err)
-			assertSameByteKeySet(t, orig2, res)
+			assert.ElementsMatch(t, orig2, res)
 			res, err = b.SetList(key3)
 			require.Nil(t, err)
-			assertSameByteKeySet(t, orig3, res)
+			assert.ElementsMatch(t, orig3, res)
 		})
 
 		t.Run("delete individual keys", func(t *testing.T) {
@@ -358,13 +358,13 @@ func TestSetCollectionStrategy_InsertAndDelete(t *testing.T) {
 
 			res, err := b.SetList(key1)
 			require.Nil(t, err)
-			assertSameByteKeySet(t, expected1, res)
+			assert.ElementsMatch(t, expected1, res)
 			res, err = b.SetList(key2)
 			require.Nil(t, err)
-			assertSameByteKeySet(t, expected2, res)
+			assert.ElementsMatch(t, expected2, res)
 			res, err = b.SetList(key3)
 			require.Nil(t, err)
-			assertSameByteKeySet(t, expected3, res)
+			assert.ElementsMatch(t, expected3, res)
 		})
 
 		t.Run("re-add keys which were previously deleted and new ones", func(t *testing.T) {
@@ -392,13 +392,13 @@ func TestSetCollectionStrategy_InsertAndDelete(t *testing.T) {
 
 			res, err := b.SetList(key1)
 			require.Nil(t, err)
-			assertSameByteKeySet(t, expected1, res)
+			assert.ElementsMatch(t, expected1, res)
 			res, err = b.SetList(key2)
 			require.Nil(t, err)
-			assertSameByteKeySet(t, expected2, res)
+			assert.ElementsMatch(t, expected2, res)
 			res, err = b.SetList(key3)
 			require.Nil(t, err)
-			assertSameByteKeySet(t, expected3, res)
+			assert.ElementsMatch(t, expected3, res)
 		})
 	})
 
@@ -428,13 +428,13 @@ func TestSetCollectionStrategy_InsertAndDelete(t *testing.T) {
 
 			res, err := b.SetList(key1)
 			require.Nil(t, err)
-			assertSameByteKeySet(t, res, orig1)
+			assert.ElementsMatch(t, res, orig1)
 			res, err = b.SetList(key2)
 			require.Nil(t, err)
-			assertSameByteKeySet(t, res, orig2)
+			assert.ElementsMatch(t, res, orig2)
 			res, err = b.SetList(key3)
 			require.Nil(t, err)
-			assertSameByteKeySet(t, res, orig3)
+			assert.ElementsMatch(t, res, orig3)
 		})
 
 		t.Run("flush to disk", func(t *testing.T) {
@@ -458,13 +458,13 @@ func TestSetCollectionStrategy_InsertAndDelete(t *testing.T) {
 
 			res, err := b.SetList(key1)
 			require.Nil(t, err)
-			assertSameByteKeySet(t, expected1, res)
+			assert.ElementsMatch(t, expected1, res)
 			res, err = b.SetList(key2)
 			require.Nil(t, err)
-			assertSameByteKeySet(t, expected2, res)
+			assert.ElementsMatch(t, expected2, res)
 			res, err = b.SetList(key3)
 			require.Nil(t, err)
-			assertSameByteKeySet(t, expected3, res)
+			assert.ElementsMatch(t, expected3, res)
 		})
 
 		t.Run("re-add keys which were previously deleted and new ones", func(t *testing.T) {
@@ -492,13 +492,13 @@ func TestSetCollectionStrategy_InsertAndDelete(t *testing.T) {
 
 			res, err := b.SetList(key1)
 			require.Nil(t, err)
-			assertSameByteKeySet(t, expected1, res)
+			assert.ElementsMatch(t, expected1, res)
 			res, err = b.SetList(key2)
 			require.Nil(t, err)
-			assertSameByteKeySet(t, expected2, res)
+			assert.ElementsMatch(t, expected2, res)
 			res, err = b.SetList(key3)
 			require.Nil(t, err)
-			assertSameByteKeySet(t, expected3, res)
+			assert.ElementsMatch(t, expected3, res)
 		})
 	})
 
@@ -528,13 +528,13 @@ func TestSetCollectionStrategy_InsertAndDelete(t *testing.T) {
 
 			res, err := b.SetList(key1)
 			require.Nil(t, err)
-			assertSameByteKeySet(t, res, orig1)
+			assert.ElementsMatch(t, res, orig1)
 			res, err = b.SetList(key2)
 			require.Nil(t, err)
-			assertSameByteKeySet(t, res, orig2)
+			assert.ElementsMatch(t, res, orig2)
 			res, err = b.SetList(key3)
 			require.Nil(t, err)
-			assertSameByteKeySet(t, res, orig3)
+			assert.ElementsMatch(t, res, orig3)
 		})
 
 		t.Run("flush to disk", func(t *testing.T) {
@@ -562,13 +562,13 @@ func TestSetCollectionStrategy_InsertAndDelete(t *testing.T) {
 
 			res, err := b.SetList(key1)
 			require.Nil(t, err)
-			assertSameByteKeySet(t, expected1, res)
+			assert.ElementsMatch(t, expected1, res)
 			res, err = b.SetList(key2)
 			require.Nil(t, err)
-			assertSameByteKeySet(t, expected2, res)
+			assert.ElementsMatch(t, expected2, res)
 			res, err = b.SetList(key3)
 			require.Nil(t, err)
-			assertSameByteKeySet(t, expected3, res)
+			assert.ElementsMatch(t, expected3, res)
 		})
 
 		t.Run("re-add keys which were previously deleted and new ones", func(t *testing.T) {
@@ -600,13 +600,13 @@ func TestSetCollectionStrategy_InsertAndDelete(t *testing.T) {
 
 			res, err := b.SetList(key1)
 			require.Nil(t, err)
-			assertSameByteKeySet(t, expected1, res)
+			assert.ElementsMatch(t, expected1, res)
 			res, err = b.SetList(key2)
 			require.Nil(t, err)
-			assertSameByteKeySet(t, expected2, res)
+			assert.ElementsMatch(t, expected2, res)
 			res, err = b.SetList(key3)
 			require.Nil(t, err)
-			assertSameByteKeySet(t, expected3, res)
+			assert.ElementsMatch(t, expected3, res)
 		})
 	})
 
@@ -637,13 +637,13 @@ func TestSetCollectionStrategy_InsertAndDelete(t *testing.T) {
 
 				res, err := b.SetList(key1)
 				require.Nil(t, err)
-				assertSameByteKeySet(t, res, orig1)
+				assert.ElementsMatch(t, res, orig1)
 				res, err = b.SetList(key2)
 				require.Nil(t, err)
-				assertSameByteKeySet(t, res, orig2)
+				assert.ElementsMatch(t, res, orig2)
 				res, err = b.SetList(key3)
 				require.Nil(t, err)
-				assertSameByteKeySet(t, res, orig3)
+				assert.ElementsMatch(t, res, orig3)
 			})
 
 			t.Run("delete individual keys", func(t *testing.T) {
@@ -670,13 +670,13 @@ func TestSetCollectionStrategy_InsertAndDelete(t *testing.T) {
 
 				res, err := b2.SetList(key1)
 				require.Nil(t, err)
-				assertSameByteKeySet(t, expected1, res)
+				assert.ElementsMatch(t, expected1, res)
 				res, err = b2.SetList(key2)
 				require.Nil(t, err)
-				assertSameByteKeySet(t, expected2, res)
+				assert.ElementsMatch(t, expected2, res)
 				res, err = b2.SetList(key3)
 				require.Nil(t, err)
-				assertSameByteKeySet(t, expected3, res)
+				assert.ElementsMatch(t, expected3, res)
 			})
 		})
 }
@@ -746,7 +746,7 @@ func TestSetCollectionStrategy_Cursors(t *testing.T) {
 			assert.Equal(t, expectedKeys, retrievedKeys)
 			assert.Equal(t, len(expectedValues), len(retrievedValues))
 			for i, v := range retrievedValues {
-				assertSameByteKeySet(t, expectedValues[i], v)
+				assert.ElementsMatch(t, expectedValues[i], v)
 			}
 		})
 
@@ -776,7 +776,7 @@ func TestSetCollectionStrategy_Cursors(t *testing.T) {
 			assert.Equal(t, expectedKeys, retrievedKeys)
 			assert.Equal(t, len(expectedValues), len(retrievedValues))
 			for i, v := range retrievedValues {
-				assertSameByteKeySet(t, expectedValues[i], v)
+				assert.ElementsMatch(t, expectedValues[i], v)
 			}
 		})
 
@@ -814,7 +814,7 @@ func TestSetCollectionStrategy_Cursors(t *testing.T) {
 			assert.Equal(t, expectedKeys, retrievedKeys)
 			assert.Equal(t, len(expectedValues), len(retrievedValues))
 			for i, v := range retrievedValues {
-				assertSameByteKeySet(t, expectedValues[i], v)
+				assert.ElementsMatch(t, expectedValues[i], v)
 			}
 		})
 	})
@@ -959,7 +959,7 @@ func TestSetCollectionStrategy_Cursors(t *testing.T) {
 			assert.Equal(t, expectedKeys, retrievedKeys)
 			assert.Equal(t, len(expectedValues), len(retrievedValues))
 			for i, v := range retrievedValues {
-				assertSameByteKeySet(t, expectedValues[i], v)
+				assert.ElementsMatch(t, expectedValues[i], v)
 			}
 		})
 
@@ -989,7 +989,7 @@ func TestSetCollectionStrategy_Cursors(t *testing.T) {
 			assert.Equal(t, expectedKeys, retrievedKeys)
 			assert.Equal(t, len(expectedValues), len(retrievedValues))
 			for i, v := range retrievedValues {
-				assertSameByteKeySet(t, expectedValues[i], v)
+				assert.ElementsMatch(t, expectedValues[i], v)
 			}
 		})
 
@@ -1035,7 +1035,7 @@ func TestSetCollectionStrategy_Cursors(t *testing.T) {
 			assert.Equal(t, expectedKeys, retrievedKeys)
 			assert.Equal(t, len(expectedValues), len(retrievedValues))
 			for i, v := range retrievedValues {
-				assertSameByteKeySet(t, expectedValues[i], v)
+				assert.ElementsMatch(t, expectedValues[i], v)
 			}
 		})
 
@@ -1074,7 +1074,7 @@ func TestSetCollectionStrategy_Cursors(t *testing.T) {
 			assert.Equal(t, expectedKeys, retrievedKeys)
 			assert.Equal(t, len(expectedValues), len(retrievedValues))
 			for i, v := range retrievedValues {
-				assertSameByteKeySet(t, expectedValues[i], v)
+				assert.ElementsMatch(t, expectedValues[i], v)
 			}
 		})
 	})

--- a/adapters/repos/db/lsmkv/strategies_set_test.go
+++ b/adapters/repos/db/lsmkv/strategies_set_test.go
@@ -174,7 +174,11 @@ func TestSetDecoder(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			assert.Equal(t, test.out, newSetDecoder().Do(test.in))
+			xs := newSetDecoder().Do(test.in)
+			if len(xs) == 2 && string(xs[0]) == "bar" {
+				xs[0], xs[1] = xs[1], xs[0]
+			}
+			assert.Equal(t, test.out, xs)
 		})
 	}
 }


### PR DESCRIPTION
Access to the map has been reduced to a minimum

### What's being changed:


### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.
