### PR TITLE
Fix bug in sorting via REST

### DIFF
--- a/adapters/handlers/rest/handlers_objects.go
+++ b/adapters/handlers/rest/handlers_objects.go
@@ -224,15 +224,15 @@ func (h *objectHandlers) query(params objects.ObjectsListParams,
 		switch rerr.Code {
 		case uco.StatusForbidden:
 			return objects.NewObjectsListForbidden().
-				WithPayload(errPayloadFromSingleErr(err))
+				WithPayload(errPayloadFromSingleErr(rerr))
 		case uco.StatusNotFound:
 			return objects.NewObjectsListNotFound()
 		case uco.StatusBadRequest:
 			return objects.NewObjectsListUnprocessableEntity().
-				WithPayload(errPayloadFromSingleErr(err))
+				WithPayload(errPayloadFromSingleErr(rerr))
 		default:
 			return objects.NewObjectsListInternalServerError().
-				WithPayload(errPayloadFromSingleErr(err))
+				WithPayload(errPayloadFromSingleErr(rerr))
 		}
 	}
 

--- a/adapters/repos/db/search.go
+++ b/adapters/repos/db/search.go
@@ -223,8 +223,12 @@ func (d *DB) Query(ctx context.Context, q *objects.QueryInput) (search.Results, 
 	if totalLimit == 0 {
 		return nil, nil
 	}
-	if err := d.validateSort(q.Sort); err != nil {
-		return nil, &objects.Error{Msg: "sorting", Code: objects.StatusBadRequest, Err: err}
+	if len(q.Sort) > 0 {
+		scheme := d.schemaGetter.GetSchemaSkipAuth()
+		if err := filters.ValidateSort(scheme, schema.ClassName(q.Class), q.Sort); err != nil {
+			return nil, &objects.Error{Msg: "sorting", Code: objects.StatusBadRequest, Err: err}
+		}
+
 	}
 	idx := d.GetIndex(schema.ClassName(q.Class))
 	if idx == nil {

--- a/test/acceptance/actions/object_test.go
+++ b/test/acceptance/actions/object_test.go
@@ -28,19 +28,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func Test_ObjectHTTP(t *testing.T) {
-	t.Run("GET", findObject)
-	t.Run("HEAD", headObject)
-	t.Run("PUT", putObject)
-	t.Run("PATCH", patchObject)
-	t.Run("DELETE", deleteObject)
-	t.Run("PostReference", postReference)
-	t.Run("PutReferences", putReferences)
-	t.Run("DeleteReference", deleteReference)
-	t.Run("Query", query)
-}
-
-func findObject(t *testing.T) {
+func TestFindObject(t *testing.T) {
 	t.Parallel()
 	var (
 		cls           = "TestObjectHTTPGet"
@@ -97,7 +85,7 @@ func findObject(t *testing.T) {
 	helper.AssertRequestFail(t, resp, err, nil)
 }
 
-func headObject(t *testing.T) {
+func TestHeadObject(t *testing.T) {
 	t.Parallel()
 	cls := "TestObjectHTTPHead"
 	// test setup
@@ -129,7 +117,7 @@ func headObject(t *testing.T) {
 	helper.AssertRequestFail(t, resp, err, nil)
 }
 
-func putObject(t *testing.T) {
+func TestPutObject(t *testing.T) {
 	t.Parallel()
 	var (
 		cls        = "TestObjectHTTPUpdate"
@@ -208,7 +196,7 @@ func putObject(t *testing.T) {
 	assert.Equal(t, expected, actual)
 }
 
-func patchObject(t *testing.T) {
+func TestPatchObject(t *testing.T) {
 	t.Parallel()
 	var (
 		cls        = "TestObjectHTTPPatch"
@@ -307,7 +295,7 @@ func patchObject(t *testing.T) {
 	}
 }
 
-func deleteObject(t *testing.T) {
+func TestDeleteObject(t *testing.T) {
 	t.Parallel()
 	var (
 		id     = strfmt.UUID("21111111-1111-1111-1111-111111111111")
@@ -410,7 +398,7 @@ func deleteObject(t *testing.T) {
 	}
 }
 
-func postReference(t *testing.T) {
+func TestPostReference(t *testing.T) {
 	t.Parallel()
 	var (
 		cls        = "TestObjectHTTPAddReference"
@@ -480,7 +468,7 @@ func postReference(t *testing.T) {
 	}
 }
 
-func putReferences(t *testing.T) {
+func TestPutReferences(t *testing.T) {
 	t.Parallel()
 	var (
 		cls           = "TestObjectHTTPUpdateReferences"
@@ -595,7 +583,7 @@ func putReferences(t *testing.T) {
 	}
 }
 
-func deleteReference(t *testing.T) {
+func TestDeleteReference(t *testing.T) {
 	t.Parallel()
 	var (
 		cls           = "TestObjectHTTPDeleteReference"
@@ -717,7 +705,7 @@ func deleteReference(t *testing.T) {
 	}
 }
 
-func query(t *testing.T) {
+func TestQuery(t *testing.T) {
 	t.Parallel()
 	var (
 		cls          = "TestObjectHTTPQuery"

--- a/test/acceptance/objects/setup_test.go
+++ b/test/acceptance/objects/setup_test.go
@@ -14,10 +14,49 @@ package test
 import (
 	"testing"
 
+	"github.com/semi-technologies/weaviate/client/objects"
+	"github.com/stretchr/testify/require"
+
 	"github.com/semi-technologies/weaviate/client/schema"
 	"github.com/semi-technologies/weaviate/entities/models"
 	"github.com/semi-technologies/weaviate/test/helper"
 )
+
+// Tests that sort parameters are validated with the correct class
+func TestSort(t *testing.T) {
+	createObjectClass(t, &models.Class{
+		Class: "ClassToSort",
+		Properties: []*models.Property{
+			{
+				Name:     "name",
+				DataType: []string{"string"},
+			},
+		},
+	})
+	defer deleteObjectClass(t, "ClassToSort")
+
+	createObjectClass(t, &models.Class{
+		Class: "OtherClass",
+		Properties: []*models.Property{
+			{
+				Name:     "ref",
+				DataType: []string{"ClassToSort"},
+			},
+		},
+	})
+	defer deleteObjectClass(t, "OtherClass")
+
+	listParams := objects.NewObjectsListParams()
+	nameClass := "ClassToSort"
+	nameProp := "name"
+	limit := int64(5)
+	listParams.Class = &nameClass
+	listParams.Sort = &nameProp
+	listParams.Limit = &limit
+
+	_, err := helper.Client(t).Objects.ObjectsList(listParams, nil)
+	require.Nil(t, err, "should not error")
+}
 
 func Test_Objects(t *testing.T) {
 	createObjectClass(t, &models.Class{


### PR DESCRIPTION
### What's being changed:

Found when trying to add sorting via REST-GET in the python client.

The validation tried to validate the sorting name with all existing classes where the property might not exist.

### Review checklist
- [x] All new code is covered by tests where it is reasonable.

