### PR TITLE
Fix for nullstate/proplength for properties that are added later

### DIFF
--- a/adapters/repos/db/migrator.go
+++ b/adapters/repos/db/migrator.go
@@ -81,31 +81,9 @@ func (m *Migrator) AddClass(ctx context.Context, class *models.Class,
 		if prop.IndexInverted != nil && !*prop.IndexInverted {
 			continue
 		}
-
-		err := idx.addProperty(ctx, prop)
-		if err != nil {
-			return errors.Wrapf(err, "extend idx '%s' with property", idx.ID())
-		}
-
-		if class.InvertedIndexConfig.IndexNullState {
-			err = idx.addNullStateProperty(ctx, prop)
-			if err != nil {
-				return errors.Wrapf(err, "extend idx '%s' with nullstate properties", idx.ID())
-			}
-		}
-
-		if class.InvertedIndexConfig.IndexPropertyLength {
-			dt := schema.DataType(prop.DataType[0])
-			// some datatypes are not added to the inverted index, so we can skip them here
-			switch dt {
-			case schema.DataTypeGeoCoordinates, schema.DataTypePhoneNumber, schema.DataTypeBlob, schema.DataTypeInt,
-				schema.DataTypeNumber, schema.DataTypeBoolean, schema.DataTypeDate:
-			default:
-				err = idx.addPropertyLength(ctx, prop)
-				if err != nil {
-					return errors.Wrapf(err, "extend idx '%s' with property length", idx.ID())
-				}
-			}
+		errProps := m.addPropertiesAndNullAndLength(ctx, prop, idx)
+		if errProps != nil {
+			return errors.Wrapf(errProps, "add prop and null state and property length '%v'", prop)
 		}
 	}
 
@@ -120,6 +98,35 @@ func (m *Migrator) AddClass(ctx context.Context, class *models.Class,
 	idx.notifyReady()
 	m.db.indexLock.Unlock()
 
+	return nil
+}
+
+func (m *Migrator) addPropertiesAndNullAndLength(ctx context.Context, prop *models.Property, idx *Index) error {
+	err := idx.addProperty(ctx, prop)
+	if err != nil {
+		return errors.Wrapf(err, "extend idx '%s' with property", idx.ID())
+	}
+
+	if idx.invertedIndexConfig.IndexNullState {
+		err = idx.addNullStateProperty(ctx, prop)
+		if err != nil {
+			return errors.Wrapf(err, "extend idx '%s' with nullstate properties", idx.ID())
+		}
+	}
+
+	if idx.invertedIndexConfig.IndexPropertyLength {
+		dt := schema.DataType(prop.DataType[0])
+		// some datatypes are not added to the inverted index, so we can skip them here
+		switch dt {
+		case schema.DataTypeGeoCoordinates, schema.DataTypePhoneNumber, schema.DataTypeBlob, schema.DataTypeInt,
+			schema.DataTypeNumber, schema.DataTypeBoolean, schema.DataTypeDate:
+		default:
+			err = idx.addPropertyLength(ctx, prop)
+			if err != nil {
+				return errors.Wrapf(err, "extend idx '%s' with property length", idx.ID())
+			}
+		}
+	}
 	return nil
 }
 
@@ -146,7 +153,7 @@ func (m *Migrator) AddProperty(ctx context.Context, className string, prop *mode
 		return errors.Errorf("cannot add property to a non-existing index for %s", className)
 	}
 
-	return idx.addProperty(ctx, prop)
+	return m.addPropertiesAndNullAndLength(ctx, prop, idx)
 }
 
 // DropProperty is ignored, API compliant change


### PR DESCRIPTION
### What's being changed:

The buckets for nullState and property length were not added for class-properties that are added later (via `/schema/'Classname'/properties`)

- First commit adds [test that fails](https://github.com/semi-technologies/weaviate/actions/runs/3928342675/jobs/6715871163)
- Second commit adds fix

### Review checklist
- [x] All new code is covered by tests where it is reasonable.

